### PR TITLE
Enable preliminary Windows support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,58 @@
+#---------------------------------#
+#      general configuration      #
+#---------------------------------#
+
+# version format
+version: 0.0.{build}-{branch}
+
+#---------------------------------#
+#    environment configuration    #
+#---------------------------------#
+
+# Build worker image (VM template)
+image: Visual Studio 2015
+
+# scripts that are called at very beginning, before repo cloning
+init:
+  # configure node-gyp environment https://github.com/nodejs/node-gyp#installation
+  - npm config set msvs_version 2015
+  - 'echo System architecture: %PLATFORM%'
+
+# environment variables
+environment:
+  nodejs_version: "6.2.2"
+
+# this is how to allow failing jobs in the matrix
+matrix:
+  fast_finish: true                     # set this flag to immediately finish build once one of the jobs fails.
+
+# build cache to preserve files/folders between builds
+cache:
+  - node_modules                        # local npm modules
+
+# scripts that run after cloning repository
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - npm -g install npm@next             # install latest npm for node-gyp build issue https://github.com/nodejs/node-gyp/issues/972
+
+#---------------------------------#
+#       build configuration       #
+#---------------------------------#
+
+platform:
+  - x64
+
+# scripts to run before build
+before_build:
+  - sh scripts/install.sh
+  - npm run lint
+
+# scripts to run *after* solution is built and *before* automatic packaging occurs (web apps, NuGet packages, Azure Cloud Services)
+before_package:
+
+# scripts to run after build
+after_build:
+
+# to run your custom scripts instead of automatic MSBuild
+build_script:
+  - echo build native module completed   # avoid to trigger msbuild

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "repository": "zeit/hyperterm",
   "description": "HTML/JS/CSS Terminal",
   "dependencies": {
-    "child_pty": "3.0.1",
     "convert-css-color-name-to-hex": "0.1.1",
     "default-shell": "1.0.1",
     "electron-config": "0.2.0",
@@ -15,6 +14,7 @@
     "mkdirp": "0.5.1",
     "ms": "0.7.1",
     "shell-env": "0.1.2",
+    "ptyw.js": "^0.4.0",
     "uid2": "0.0.3"
   },
   "devDependencies": {

--- a/session.js
+++ b/session.js
@@ -4,7 +4,8 @@ const defaultShell = require('default-shell');
 
 let spawn;
 try {
-  spawn = require('child_pty').spawn;
+  // using fork of pty until https://github.com/chjj/pty.js/issues/131 resolved
+  spawn = require('ptyw.js').spawn;
 } catch (err) {
   console.error(
     'A native module failed to load. Typically this means ' +
@@ -33,7 +34,7 @@ module.exports = class Session extends EventEmitter {
       this.emit('data', data.toString('utf8'));
     });
 
-    this.pty.on('exit', () => {
+    this.pty.on('close', () => {
       if (!this.ended) {
         this.ended = true;
         this.emit('exit');
@@ -98,7 +99,7 @@ module.exports = class Session extends EventEmitter {
 
   resize ({ cols: columns, rows }) {
     try {
-      this.pty.stdout.resize({ columns, rows });
+      this.pty.stdout.resize(columns, rows);
     } catch (err) {
       console.error(err.stack);
     }


### PR DESCRIPTION
This PR consists couple of changes to enable preliminary support on Windows platform, by
- replace `child_pty` to `ptyw.js`
  : original module `pty` currently have known issues with windows build (https://github.com/chjj/pty.js/issues/131), introduced `ptyw` until issue's fully resolved.
- add initial configuration to `appveyor` to trigger windows build.
  : currently only install dependenceis / bulid native modules, does not packaging it yet.
  : resues existing install script (`install.sh`), so anyone want to build locally may require *nix shell environment still.

As this PR replaces one of core module, I agree this can be risky change especially there isn't enough test coverage. Please feel freely reject if this need not to be considered at this moment.
