### PR TITLE
[WIP] support composed characters

### DIFF
--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -99,7 +99,21 @@ export default class Term extends Component {
   write (data) {
     requestAnimationFrame(() => {
       this.term.io.writeUTF8(data);
+      this.updateCurrentRow();
     });
+  }
+
+  updateCurrentRow () {
+    const nextCurrentRow = this.term.getCursorRow();
+
+    if (this.prevCurrentRow !== nextCurrentRow) {
+      const {rowsArray} = this.term.screen_;
+      if (this.prevCurrentRow !== undefined) {
+        rowsArray[this.prevCurrentRow].removeAttribute('contentEditable');
+      }
+      rowsArray[nextCurrentRow].contentEditable = true;
+      this.prevCurrentRow = nextCurrentRow;
+    }
   }
 
   focus () {

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -231,6 +231,10 @@ export default class Term extends Component {
       this.term.prefs_.set('font-size', nextProps.fontSize);
     }
 
+    if (this.props.customCSS !== nextProps.customCSS) {
+      this.term.prefs_.set('user-css', this.getStylesheet(nextProps.customCSS));
+    }
+
     if (this.props.foregroundColor !== nextProps.foregroundColor) {
       this.setCssVariable('--foreground-color', nextProps.foregroundColor);
     }
@@ -257,10 +261,6 @@ export default class Term extends Component {
 
     if (this.props.colors !== nextProps.colors) {
       this.term.prefs_.set('color-palette-overrides', getColorList(nextProps.colors));
-    }
-
-    if (this.props.customCSS !== nextProps.customCSS) {
-      this.term.prefs_.set('user-css', this.getStylesheet(nextProps.customCSS));
     }
 
     if (this.props.bell === 'SOUND') {

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -31,9 +31,10 @@ export default class Term extends Component {
     this.term.prefs_.set('font-smoothing', props.fontSmoothing);
     this.term.prefs_.set('cursor-color', this.validateColor(props.cursorColor, 'rgba(255,255,255,0.5)'));
     this.term.prefs_.set('enable-clipboard-notice', false);
-    this.term.prefs_.set('foreground-color', props.foregroundColor);
-    this.term.prefs_.set('background-color', props.backgroundColor);
+    this.term.prefs_.set('foreground-color', 'var(--foreground-color)');
+    this.term.prefs_.set('background-color', 'var(--background-color)');
     this.term.prefs_.set('color-palette-overrides', getColorList(props.colors));
+    this.term.prefs_.set('color-palette-overrides', props.colors);
     this.term.prefs_.set('user-css', this.getStylesheet(props.customCSS));
     this.term.prefs_.set('scrollbar-visible', false);
     this.term.prefs_.set('receive-encoding', 'raw');
@@ -167,8 +168,26 @@ export default class Term extends Component {
     return this.term.document_;
   }
 
+  setCssVariable (key, value) {
+    return this.getTermDocument().body.style.setProperty(key, value);
+  }
+
   getStylesheet (css) {
     const blob = new Blob([`
+      :root {
+        --background-color: ${this.props.backgroundColor};
+        --foreground-color: ${this.props.foregroundColor};
+      }
+
+      x-row {
+        text-shadow: 0 0 0 var(--foreground-color);
+        color: transparent;
+      }
+
+      x-row:focus {
+        outline: none;
+      }
+
       .cursor-node[focus="false"] {
         border-width: 1px !important;
       }
@@ -213,11 +232,11 @@ export default class Term extends Component {
     }
 
     if (this.props.foregroundColor !== nextProps.foregroundColor) {
-      this.term.prefs_.set('foreground-color', nextProps.foregroundColor);
+      this.setCssVariable('--foreground-color', nextProps.foregroundColor);
     }
 
     if (this.props.backgroundColor !== nextProps.backgroundColor) {
-      this.term.prefs_.set('background-color', nextProps.backgroundColor);
+      this.setCssVariable('--background-color', nextProps.backgroundColor);
     }
 
     if (this.props.fontFamily !== nextProps.fontFamily) {

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -34,7 +34,6 @@ export default class Term extends Component {
     this.term.prefs_.set('foreground-color', 'var(--foreground-color)');
     this.term.prefs_.set('background-color', 'var(--background-color)');
     this.term.prefs_.set('color-palette-overrides', getColorList(props.colors));
-    this.term.prefs_.set('color-palette-overrides', props.colors);
     this.term.prefs_.set('user-css', this.getStylesheet(props.customCSS));
     this.term.prefs_.set('scrollbar-visible', false);
     this.term.prefs_.set('receive-encoding', 'raw');

--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -103,7 +103,7 @@ hterm.Keyboard.prototype.onKeyDown_ = function (e) {
 
   if (e.metaKey || e.altKey) {
     return;
-  } else {
+  } else if (e.key !== 'Dead') {
     //  Test for valid keys in order to clear the terminal selection
     if ((!e.ctrlKey || e.code !== 'ControlLeft') && !e.shiftKey && e.code !== 'CapsLock') {
       selection.clear(this.terminal);

--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -38,69 +38,6 @@ hterm.Terminal.prototype.copySelectionToClipboard = function () {
 // hyperterm and not the terminal itself
 const oldKeyDown = hterm.Keyboard.prototype.onKeyDown_;
 hterm.Keyboard.prototype.onKeyDown_ = function (e) {
-  /**
-   * Add fixes for U.S. International PC Keyboard layout
-   * These keys are sent through as 'Dead' keys, as they're used as modifiers.
-   * Ignore that and insert the correct character.
-   */
-  if (e.key === 'Dead') {
-    if (e.code === 'Quote' && e.shiftKey === false) {
-      this.terminal.onVTKeystroke("'");
-      return;
-    }
-    if (e.code === 'Quote' && e.shiftKey === true) {
-      this.terminal.onVTKeystroke('"');
-      return;
-    }
-    if ((e.code === 'IntlBackslash' || e.code === 'Backquote') && e.shiftKey === true) {
-      this.terminal.onVTKeystroke('~');
-      return;
-    }
-    // This key is also a tilde on all tested keyboards
-    if (e.code === 'KeyN' && e.altKey === true) {
-      this.terminal.onVTKeystroke('~');
-      return;
-    }
-    if ((e.code === 'IntlBackslash' || e.code === 'Backquote') && e.shiftKey === false) {
-      this.terminal.onVTKeystroke('`');
-      return;
-    }
-    if (e.code === 'Digit6') {
-      this.terminal.onVTKeystroke('^');
-      return;
-    }
-    // German keyboard layout
-    if (e.code === 'Equal' && e.shiftKey === false) {
-      this.terminal.onVTKeystroke('´');
-      return;
-    }
-    if (e.code === 'Equal' && e.shiftKey === true) {
-      this.terminal.onVTKeystroke('`');
-      return;
-    }
-    // Italian keyboard layout
-    if (e.code === 'Digit9' && e.altKey === true) {
-      this.terminal.onVTKeystroke('`');
-      return;
-    }
-    if (e.code === 'Digit8' && e.altKey === true) {
-      this.terminal.onVTKeystroke('´');
-      // To fix issue with changing the terminal prompt
-      e.preventDefault();
-      return;
-    }
-    // French keyboard layout
-    if (e.code === 'BracketLeft') {
-      this.terminal.onVTKeystroke('^');
-      return;
-    }
-    if (e.code === 'Backslash') {
-      this.terminal.onVTKeystroke('`');
-      return;
-    }
-    console.warn('Uncaught dead key on international keyboard', e);
-  }
-
   if (e.metaKey || e.altKey) {
     return;
   } else if (e.key !== 'Dead') {

--- a/lib/reducers/ui.js
+++ b/lib/reducers/ui.js
@@ -37,7 +37,15 @@ const initial = Immutable({
   fontSizeOverride: null,
   fontSmoothingOverride: 'antialiased',
   css: '',
-  termCSS: '',
+  termCSS: '' +
+    'x-row {' +
+    '  text-shadow: 0 0 0 #fff;' +
+    '  color: transparent;' +
+    '}' +
+    'x-row:focus {' +
+    '  outline: none;' +
+    '}' +
+  '',
   openAt: {},
   resizeAt: 0,
   colors: {

--- a/lib/reducers/ui.js
+++ b/lib/reducers/ui.js
@@ -37,15 +37,7 @@ const initial = Immutable({
   fontSizeOverride: null,
   fontSmoothingOverride: 'antialiased',
   css: '',
-  termCSS: '' +
-    'x-row {' +
-    '  text-shadow: 0 0 0 #fff;' +
-    '  color: transparent;' +
-    '}' +
-    'x-row:focus {' +
-    '  outline: none;' +
-    '}' +
-  '',
+  termCSS: '',
   openAt: {},
   resizeAt: 0,
   colors: {


### PR DESCRIPTION
should close #66 and part of #29 (stuff like trying to type `~` in some international keyboards and not seeing anything should be totally fixed with this)

todo:
- [x] row that has the cursor is set to contentEditable = true
- [x] hide default blue outline and cursor for contentEditable elements
- [x] figure out why cursor is now missing its fill (it's not focused...)
- [x] ~~figure out to make it possible to insert emojis~~

this should fix most issues with international keyboards + composed characters
also makes it possible to use the native mac emoji dialog (emojis aren't still being written to the terminal for some reason, not sure why)
