### PR TITLE
Install hpm by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     }
   },
   "scripts": {
+    "postinstall": "npm install -g hpm",
     "start": "electron index",
     "lint": "eslint *.js"
   }


### PR DESCRIPTION
This is an easy solution to issue #277. Installs hyperterm package manager (hpm) by @matheuss after installing hyperterm.

Further discussion possibly needed, maybe this should be in core?
