### PR TITLE
autohide menubar by default

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -81,6 +81,7 @@ app.on('ready', () => {
     }
 
     const browserDefaults = {
+      autoHideMenuBar: true,
       width,
       height,
       minHeight: 190,


### PR DESCRIPTION
this seems like a non issue on a Mac, but I think majority of Linux/windows users also prefer not to waste their screen space on the menu bar.
