### PR TITLE
Unicode Support / Cursor issues Fix

### DIFF
--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -1,7 +1,7 @@
 import {hterm, lib} from 'hterm-umdjs';
-import fromCharCode from './utils/key-code';
-import unicodeStringUtils from 'unicode-string-utils';
+import runes from 'runes';
 
+import fromCharCode from './utils/key-code';
 import selection from './utils/selection';
 
 hterm.defaultStorage = new lib.Storage.Memory();
@@ -29,7 +29,6 @@ hterm.Terminal.prototype.setFontSize = function (px) {
       container.style.width = `${container.wcNode ? charWidth * 2 : charWidth}px`;
     }
   });
-  console.debug(`char width is now ${charWidth}`);
 };
 
 const oldSyncFontFamily = hterm.Terminal.prototype.syncFontFamily;
@@ -58,30 +57,32 @@ hterm.Terminal.IO.prototype.writeUTF8 = function (string) {
   }
 
   if (containsNonLatinCodepoints(string)) {
-    const length = unicodeStringUtils.length(string);
-    for (let char = 0; char <= length; char++) {
-      this.terminal_.interpret(unicodeStringUtils.slice(string, char, char + 1));
+    const splitString = runes(string);
+    const length = splitString.length;
+    this.terminal_.getTextAttributes().hasUnicode = true;
+
+    for (let curChar = 0; curChar <= length; curChar++) {
+      this.terminal_.interpret(splitString[curChar]);
     }
+
+    this.terminal_.getTextAttributes().hasUnicode = false;
   } else {
     this.terminal_.interpret(string);
   }
 };
 
-// Override "createContainer" so that all text (even default formatted text) is in a container
 const oldCreateContainer = hterm.TextAttributes.prototype.createContainer;
 hterm.TextAttributes.prototype.createContainer = function (text) {
   const container = oldCreateContainer.call(this, text);
 
-  if (container.style && text.length === 1) {
+  if (container.style && text.length === 1 && containsNonLatinCodepoints(text)) {
     container.style.width = `${container.wcNode ? charWidth * 2 : charWidth}px`;
     container.style.display = 'inline-block';
 
     // If the container has unicode text, the char can overlap neigbouring containers. We need
     // to ensure that the text is not hidden behind other containers.
-    if (containsNonLatinCodepoints(text)) {
-      container.style.overflow = 'visible';
-      container.style.position = 'relative';
-    }
+    container.style.overflow = 'visible';
+    container.style.position = 'relative';
 
     // Remember this container to resize it later when font size changes.
     containers.push(container);
@@ -90,10 +91,34 @@ hterm.TextAttributes.prototype.createContainer = function (text) {
   return container;
 };
 
-// const oldMatchesContainer = hterm.TextAttributes.prototype.matchesContainer;
-hterm.TextAttributes.prototype.matchesContainer = function () {
-  // @TODO: Don't make a new container for every char
-  return false;
+// Do not match containers when one of them has unicode text (unicode chars need to be alone in their containers)
+const oldMatchesContainer = hterm.TextAttributes.prototype.matchesContainer;
+hterm.TextAttributes.prototype.matchesContainer = function (obj) {
+  const content = typeof obj === 'string' ? obj : obj.textContent;
+  if (containsNonLatinCodepoints(content)) {
+    return false;
+  }
+
+  if (this.hasUnicode) {
+    return false;
+  }
+
+  return oldMatchesContainer.call(this, obj);
+};
+
+/**
+ * Override 'containersMatch' so that containers with unicode do not match anything.
+ */
+const oldContainersMatch = hterm.TextAttributes.containersMatch;
+hterm.TextAttributes.containersMatch = function (obj1, obj2) {
+  const content1 = typeof obj1 === 'string' ? obj1 : obj1.textContent;
+  const content2 = typeof obj2 === 'string' ? obj2 : obj2.textContent;
+
+  if (containsNonLatinCodepoints(content1) || containsNonLatinCodepoints(content2)) {
+    return false;
+  }
+
+  return oldContainersMatch(obj1, obj2);
 };
 
 // there's no option to turn off the size overlay

--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -1,7 +1,8 @@
 import {hterm, lib} from 'hterm-umdjs';
 import fromCharCode from './utils/key-code';
+import unicodeStringUtils from 'unicode-string-utils';
 
-const selection = require('./utils/selection');
+import selection from './utils/selection';
 
 hterm.defaultStorage = new lib.Storage.Memory();
 
@@ -21,6 +22,40 @@ hterm.Terminal.prototype.onMouse_ = function (e) {
     return;
   }
   return oldMouse.call(this, e);
+};
+
+function containsNonLatinCodepoints (s) {
+  return /[^\u0000-\u00ff]/.test(s);
+}
+hterm.Terminal.IO.prototype.writeUTF8 = function (string) {
+  if (this.terminal_.io !== this) {
+    throw new Error('Attempt to print from inactive IO object.');
+  }
+  if (containsNonLatinCodepoints(string)) {
+    let length = unicodeStringUtils.length(string);
+    for (var char = 0; char <= length; char++) {
+      this.terminal_.interpret(unicodeStringUtils.slice(string, char, char + 1));
+    }
+  } else {
+    this.terminal_.interpret(string);
+  }
+};
+
+const oldCreateContainer = hterm.TextAttributes.prototype.createContainer;
+hterm.TextAttributes.prototype.createContainer = function (text) {
+  const container = oldCreateContainer.call(this, text);
+  // @TODO: Measure the actual width
+  if (containsNonLatinCodepoints(text) && unicodeStringUtils.length(text) === 1) {
+    container.style.width = '7.23438px';
+    container.style.display = 'inline-block';
+  }
+  return container;
+};
+
+// const oldMatchesContainer = hterm.TextAttributes.prototype.matchesContainer;
+hterm.TextAttributes.prototype.matchesContainer = function () {
+  // @TODO: Don't make a new container for every char
+  return false;
 };
 
 // there's no option to turn off the size overlay

--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -6,11 +6,36 @@ import selection from './utils/selection';
 
 hterm.defaultStorage = new lib.Storage.Memory();
 
+// The current width of characters rendered in hterm
+let charWidth;
+// Containers to resize when char width changes
+const containers = [];
+
 // Provide selectAll to terminal viewport
 hterm.Terminal.prototype.selectAll = function () {
   // We need to clear the DOM range to reset anchorNode
   selection.clear(this);
   selection.all(this);
+};
+
+const oldSetFontSize = hterm.Terminal.prototype.setFontSize;
+hterm.Terminal.prototype.setFontSize = function (px) {
+  oldSetFontSize.call(this, px);
+  charWidth = this.scrollPort_.characterSize.width;
+  // @TODO Maybe clear old spans from the list of spans to resize ?
+  // Resize all containers to match the new whar width.
+  containers.forEach(container => {
+    if (container && container.style) {
+      container.style.width = `${container.wcNode ? charWidth * 2 : charWidth}px`;
+    }
+  });
+  console.debug(`char width is now ${charWidth}`);
+};
+
+const oldSyncFontFamily = hterm.Terminal.prototype.syncFontFamily;
+hterm.Terminal.prototype.syncFontFamily = function () {
+  oldSyncFontFamily.call(this);
+  this.setFontSize();
 };
 
 // override double click behavior to copy
@@ -24,16 +49,17 @@ hterm.Terminal.prototype.onMouse_ = function (e) {
   return oldMouse.call(this, e);
 };
 
-function containsNonLatinCodepoints (s) {
+function containsNonLatinCodepoints(s) {
   return /[^\u0000-\u00ff]/.test(s);
 }
 hterm.Terminal.IO.prototype.writeUTF8 = function (string) {
   if (this.terminal_.io !== this) {
     throw new Error('Attempt to print from inactive IO object.');
   }
+
   if (containsNonLatinCodepoints(string)) {
-    let length = unicodeStringUtils.length(string);
-    for (var char = 0; char <= length; char++) {
+    const length = unicodeStringUtils.length(string);
+    for (let char = 0; char <= length; char++) {
       this.terminal_.interpret(unicodeStringUtils.slice(string, char, char + 1));
     }
   } else {
@@ -41,14 +67,26 @@ hterm.Terminal.IO.prototype.writeUTF8 = function (string) {
   }
 };
 
+// Override "createContainer" so that all text (even default formatted text) is in a container
 const oldCreateContainer = hterm.TextAttributes.prototype.createContainer;
 hterm.TextAttributes.prototype.createContainer = function (text) {
   const container = oldCreateContainer.call(this, text);
-  // @TODO: Measure the actual width
-  if (containsNonLatinCodepoints(text) && unicodeStringUtils.length(text) === 1) {
-    container.style.width = '7.23438px';
+
+  if (container.style && text.length === 1) {
+    container.style.width = `${container.wcNode ? charWidth * 2 : charWidth}px`;
     container.style.display = 'inline-block';
+
+    // If the container has unicode text, the char can overlap neigbouring containers. We need
+    // to ensure that the text is not hidden behind other containers.
+    if (containsNonLatinCodepoints(text)) {
+      container.style.overflow = 'visible';
+      container.style.position = 'relative';
+    }
+
+    // Remember this container to resize it later when font size changes.
+    containers.push(container);
   }
+
   return container;
 };
 

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "seamless-immutable": "6.1.3",
     "semver": "5.3.0",
     "uuid": "2.0.2",
-    "unicode-string-utils": "0.1.0"
+    "runes": "^0.3.0"
   },
   "devDependencies": {
     "ava": "^0.16.0",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
     "reselect": "2.5.4",
     "seamless-immutable": "6.1.3",
     "semver": "5.3.0",
-    "uuid": "2.0.2"
+    "uuid": "2.0.2",
+    "unicode-string-utils": "0.1.0"
   },
   "devDependencies": {
     "ava": "^0.16.0",


### PR DESCRIPTION
This is based on the work of @MrRio in his PR #535, so thanks to him for the work, I couldn't have done this without him.

This PR makes hterm add a `<span>` around every unicode character, even when they have default style. The span has the width of the font, which basically forces it to be a monospace font.

See this screenshot with vtop : 
![2016-09-23-224938_891x682_escrotum](https://cloud.githubusercontent.com/assets/17006335/18800911/0dfde6dc-81e0-11e6-8a05-5d7e5d38790f.png)

And you can see that the cursor is still well positioned, even with my prompt abusing wide characters : 
![2016-09-23-225103_895x682_escrotum](https://cloud.githubusercontent.com/assets/17006335/18800952/3afba520-81e0-11e6-95c2-a49f991fd3d5.png)

There are still some problems that can't be solved (in my opinion, if anyone has a brilliant idea I'll take it)
- Font rendering is done using OS libraries. I noticed that on some systems, some monospace fonts (for example SourceCodePro, which I use) are not monospace at all font-sizes. I'll post some screenshots on my debian work laptot on monday. Seems to be fine on ubuntu though. This can only be solved in Electron (even chromium probably).
- The double-width chars are detected by hterm using wc-width npm library, but it only works on some specific characters (i.e Chinese characters). If there are wider characters that don't use this property (font Awesome glyphs for example), they will overlap with their neighbours, as you can see here: 
  ![2016-09-23-225600_894x683_escrotum](https://cloud.githubusercontent.com/assets/17006335/18801062/ee466ca0-81e0-11e6-8315-3a559a5de303.png)

This is probably not a problem in prompts because there are spaces around, and there are not wide chars side-by-side all that often. We could theoretically measure each characters before inserting them, but then we'd need to fix hterm's cursor position.

What's left to do:
- [x] @MrRio's todo in the "matchesContainer" function
- [ ] Wait for someone else to test with their own use cases.

All feedback appreciated !
