### PR TITLE
Add Spanish keyboard compatibility #584

### DIFF
--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -62,6 +62,11 @@ hterm.Keyboard.prototype.onKeyDown_ = function (e) {
       this.terminal.onVTKeystroke('~');
       return;
     }
+    // Spanish keyboard layout
+    if (e.code === 'Semicolon' && e.altKey === true) {
+      this.terminal.onVTKeystroke('~');
+      return;
+    }
     if ((e.code === 'IntlBackslash' || e.code === 'Backquote') && e.shiftKey === false) {
       this.terminal.onVTKeystroke('`');
       return;


### PR DESCRIPTION
The problem with the character `~` was not fixed for Spanish keyboards, which is `Alt+Ñ`.
