### PR TITLE
Run the one tests that exists in Travis before a release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ install:
 - npm install
 - npm prune
 
-script:
+after_success:
 - npm run release
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,13 @@ sudo: required
 dist: trusty
 
 language: node_js
-node_js: 6
 
 matrix:
   include:
     - os: osx
+      node_js: 6
     - os: linux
+      node_js: 6
       env: CC=clang CXX=clang++ npm_config_clang=1
       compiler: clang
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: required
 dist: trusty
 
 language: node_js
-node: 6
+node_js: 6
 
 matrix:
   include:
@@ -33,14 +33,13 @@ addons:
 before_install:
   - mkdir -p /tmp/git-lfs && curl -L https://github.com/github/git-lfs/releases/download/v1.2.1/git-lfs-$([ "$TRAVIS_OS_NAME" == "linux" ] && echo "linux" || echo "darwin")-amd64-1.2.1.tar.gz | tar -xz -C /tmp/git-lfs --strip-components 1 && /tmp/git-lfs/git-lfs pull
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start; sleep 3; fi
+  - npm install electron-builder@next # force install next version to test electron-builder
 
-install:
-- npm install electron-builder@next # force install next version to test electron-builder
-- npm install
-- npm prune
+before_script:
+  - npm prune
 
 after_success:
-- npm run release
+  - npm run release
 
 branches:
   except:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-osx_image: xcode7.3
-
 sudo: required
 dist: trusty
 
@@ -15,10 +13,10 @@ matrix:
 
 cache:
   directories:
-  - node_modules
-  - app/node_modules
-  - $HOME/.electron
-  - $HOME/.cache
+    - node_modules
+    - app/node_modules
+    - $HOME/.electron
+    - $HOME/.cache
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ osx_image: xcode7.3
 sudo: required
 dist: trusty
 
-language: c
+language: node_js
+node: 6
 
 matrix:
   include:
@@ -34,7 +35,6 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start; sleep 3; fi
 
 install:
-- nvm install 6
 - npm install electron-builder@next # force install next version to test electron-builder
 - npm install
 - npm prune


### PR DESCRIPTION
So this did a few things:

* changed project from `c` to `node_js` project
* defaulted to node v6
* no longer overriding `install` nor `script` (test) steps in Travis. We're now using the default inferred values -- `npm install` and `npm test` respectively.
* We only run `npm run dist` if the tests pass
