### PR TITLE
Move notification fetching to the main process

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -15,6 +15,7 @@ const toElectronBackgroundColor = require('./utils/to-electron-background-color'
 const createMenu = require('./menu');
 const createRPC = require('./rpc');
 const notify = require('./notify');
+const fetchNotifications = require('./notifications');
 
 app.commandLine.appendSwitch('js-flags', '--harmony');
 
@@ -165,6 +166,7 @@ app.on('ready', () => installDevExtensions(isDev).then(() => {
       (app.windowCallback || fn)(win);
       delete (app.windowCallback);
 
+      fetchNotifications(win);
       // auto updates
       if (!isDev && process.platform !== 'linux') {
         AutoUpdater(win);

--- a/app/notifications.js
+++ b/app/notifications.js
@@ -1,0 +1,39 @@
+const ms = require('ms');
+const fetch = require('node-fetch');
+const {satisfies} = require('semver');
+
+const {version} = './package';
+
+const NEWS_URL = 'https://hyper-news.now.sh';
+const matchVersion = versions => (
+  versions.some(v => v === '*' || satisfies(version, v))
+);
+
+module.exports = function fetchNotifications(win) {
+  const {rpc} = win;
+  const retry = err => {
+    setTimeout(() => fetchNotifications(win), ms(err ? '10s' : '5m'));
+    if (err) {
+      console.error('Notification messages fetch error', err.stack);
+    }
+  };
+
+  console.log('Checking for notification messages');
+  fetch(NEWS_URL)
+  .then(res => res.json())
+  .then(data => {
+    const {messages} = data || {};
+    if (!messages) {
+      throw new Error('Bad response');
+    }
+    const message = messages.find(msg => matchVersion(msg.versions));
+    if (message) {
+      rpc.emit('add notification', message);
+    } else {
+      console.log('No matching notification messages');
+    }
+
+    retry();
+  })
+  .catch(retry);
+};

--- a/app/package.json
+++ b/app/package.json
@@ -21,6 +21,7 @@
     "git-describe": "3.0.2",
     "mkdirp": "0.5.1",
     "ms": "0.7.1",
+    "node-fetch": "1.6.3",
     "shell-env": "0.2.0",
     "uuid": "2.0.2"
   }

--- a/lib/actions/notifications.js
+++ b/lib/actions/notifications.js
@@ -1,6 +1,3 @@
-import ms from 'ms';
-import {satisfies} from 'semver';
-import {version} from '../../package';
 import {
   NOTIFICATION_MESSAGE,
   NOTIFICATION_DISMISS
@@ -20,45 +17,4 @@ export function addNotificationMessage(text, url = null, dismissable = true) {
     url,
     dismissable
   };
-}
-
-export function fetchNotifications() {
-  return dispatch => {
-    const retry = err => {
-      setTimeout(() => dispatch(fetchNotifications()), ms(err ? '10s' : '5m'));
-      if (err) {
-        console.error('Notification messages fetch error', err.stack);
-      }
-    };
-
-    console.log('Checking for notification messages');
-    fetch('https://hyper-news.now.sh')
-    .then(res => res.json())
-    .then(data => {
-      const {messages} = data || {};
-      if (!messages) {
-        throw new Error('Bad response');
-      }
-      const message = messages.find(msg => {
-        return matchVersion(msg.versions);
-      });
-      if (message) {
-        dispatch(addNotificationMessage(
-          message.text,
-          message.url,
-          message.dismissable
-        ));
-      } else {
-        console.log('No matching notification messages');
-      }
-      retry();
-    })
-    .catch(retry);
-  };
-}
-
-function matchVersion(versions) {
-  return versions.some(v => {
-    return v === '*' || satisfies(version, v);
-  });
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,9 +12,9 @@ import * as uiActions from './actions/ui';
 import * as updaterActions from './actions/updater';
 import * as sessionActions from './actions/sessions';
 import * as termGroupActions from './actions/term-groups';
-import {fetchNotifications} from './actions/notifications';
-import HyperTermContainer from './containers/hyperterm';
+import {addNotificationMessage} from './actions/notifications';
 import {loadConfig, reloadConfig} from './actions/config';
+import HyperTermContainer from './containers/hyperterm';
 import configureStore from './store/configure-store';
 
 // Disable pinch zoom
@@ -37,7 +37,6 @@ config.subscribe(() => {
 // and subscribe to all user intents for example from menus
 rpc.on('ready', () => {
   store_.dispatch(init());
-  store_.dispatch(fetchNotifications());
   store_.dispatch(uiActions.setFontSmoothing());
 });
 
@@ -123,6 +122,10 @@ rpc.on('update available', ({releaseName, releaseNotes}) => {
 
 rpc.on('move', () => {
   store_.dispatch(uiActions.windowMove());
+});
+
+rpc.on('add notification', ({text, url, dismissable}) => {
+  store_.dispatch(addNotificationMessage(text, url, dismissable));
 });
 
 const app = render(

--- a/package.json
+++ b/package.json
@@ -103,7 +103,8 @@
     }
   },
   "scripts": {
-    "start": "concurrently --kill-others --raw \"npm run dev\" \"electron app\"",
+    "start": "concurrently --kill-others --raw \"npm run dev\" \"npm run app\"",
+    "app": "electron app",
     "dev": "webpack -w",
     "build": "NODE_ENV=production webpack",
     "test": "npm run dist && xo && ava",


### PR DESCRIPTION
Right now the new notification fetching is done in each window, this makes sure it's done in the main process instead.

I've also added `npm run start-app`, so that it's possible to start the electron app without needing `./node_modules/.bin` in your path.