### PR TITLE
Change cask install to hyper

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you're on macOS, you can also use [Homebrew Cask](https://caskroom.github.io/
 
 ```bash
 $ brew cask update
-$ brew cask install hyperterm
+$ brew cask install hyper
 ```
 
 ## Contribute


### PR DESCRIPTION
It looks like the cask package name has changed in the renaming

```
brew cask install hyperterm
Error: No available Cask for hyperterm
Error: nothing to install
```