### PR TITLE
fix ps filtering for detecting current process

### DIFF
--- a/app/session.js
+++ b/app/session.js
@@ -88,13 +88,9 @@ module.exports = class Session extends EventEmitter {
     let tty = this.pty.stdout.ttyname;
     tty = tty.replace(/^\/dev\/tty/, '');
 
-    // try to exclude grep from the results
-    // by grepping for `[s]001` instead of `s001`
-    tty = `[${tty[0]}]${tty.substr(1)}`;
-
     // TODO: limit the concurrency of how many processes we run?
     // TODO: only tested on mac
-    exec(`ps uxac | grep ${tty} | head -n 1`, (err, out) => {
+    exec(`ps uxac | grep ${tty} | grep -v 'grep\\|ps' | head -n 1`, (err, out) => {
       this.fetching = false;
       if (this.ended) {
         return;


### PR DESCRIPTION
Instead of relying on

```
$ ps aux | grep [s]001
```

to filter out grep from ps output, let's use

```
$ ps aux | grep -v 'grep\|ps' | grep s001
```

_Examples_

```
$ ps uxac | grep [s]000
hrvoje          82052   0.5  0.0  2463080   2420 s000  Ss   10:54AM   0:01.13 bash
root            65951   0.1  0.0  2438504   1028 s000  R+   12:27PM   0:00.01 ps
hrvoje          65952   0.0  0.0  2424596    400 s000  R+   12:27PM   0:00.00 grep
```

```
$ ps uxac | grep s000 | grep -v 'grep\|ps'
hrvoje          82052   0.0  0.0  2463080   2420 s000  Ss   10:54AM   0:01.14 bash
```
