### PR TITLE
Use white background on webviews

### DIFF
--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -290,7 +290,7 @@ export default class Term extends Component {
           src={this.props.url}
           onFocus={this.handleFocus}
           style={{
-            background: '#000',
+            background: '#fff',
             position: 'absolute',
             top: 0,
             left: 0,


### PR DESCRIPTION
## Description
Most web clients apply a default white background to web pages, so some websites omit explicitly setting their page backgrounds to white. The default black background on the webview component was making some sites unreadable. This commit just changes it from black to white.

## Notes
I had to do a `git push --no-verify` as there are some failing tests (linting) on `origin/master`. I ran the tests before pushing, though, and it doesn't look like my changes have added to the failures.

**Fixes my previously-raised issue #797.**