### PR TITLE
README: brew cask update to brew update

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You can download the latest release [here](https://hyper.is/#installation).
 If you're on macOS, you can also use [Homebrew Cask](https://caskroom.github.io/) to download the app by running these commands:
 
 ```bash
-$ brew cask update
+$ brew update
 $ brew cask install hyper
 ```
 


### PR DESCRIPTION
Refs https://github.com/wulkano/kap/pull/49#issuecomment-253209340.

`brew cask update` is simply a convenience alias to `brew update`. We don’t really promote `brew cask update` as that leads users to erroneously `brew update && brew cask update`, basically running the same command twice.