### PR TITLE
Add border radius to lib/component/notification.js

### DIFF
--- a/lib/components/notification.js
+++ b/lib/components/notification.js
@@ -98,6 +98,7 @@ export default class Notification extends Component {
         cursor: 'default',
         WebkitUserSelect: 'none',
         background: 'rgba(255, 255, 255, .2)',
+        borderRadius: '2px',
         padding: '8px 14px 9px',
         marginLeft: '10px',
         transition: '150ms opacity ease',


### PR DESCRIPTION
It's a small one liner; added a border radius to the `lib/component/notification.js`. I think it looks slightly friendlier, but feel free to disregard. Screenshot below:

<img width="480" alt="screen shot 2016-10-16 at 11 35 15 am" src="https://cloud.githubusercontent.com/assets/2067774/19418578/caef9d1a-9394-11e6-9e71-5b80daad57be.png">
