### PR TITLE
Ignore file watch errors

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -40,6 +40,9 @@ function watch() {
         });
       }
     });
+    this.on('error', () => {
+      // Ignore file watching errors
+    });
   });
 }
 


### PR DESCRIPTION
Fixes GH-225

This ignores all errors gaze hits when watching files. With `EventEmitter`, if you don't supply at least 1 listener for `error` events, they get thrown. See https://github.com/nodejs/node/blob/master/lib/events.js#L149

I was able to repro using these steps: https://github.com/zeit/hyper/issues/225#issuecomment-253762729 and can confirm it no longer hard errors with this patch.