### PR TITLE
Add an active class on current session panel

### DIFF
--- a/lib/components/term-group.js
+++ b/lib/components/term-group.js
@@ -48,6 +48,7 @@ class TermGroup_ extends Component {
     const session = this.props.sessions[uid];
     const termRef = this.props.terms[uid];
     const props = getTermProps(uid, this.props, {
+      isSessionActive: uid === this.props.activeSession,
       term: termRef ? termRef.term : null,
       customCSS: this.props.customCSS,
       fontSize: this.props.fontSize,

--- a/lib/components/term-group.js
+++ b/lib/components/term-group.js
@@ -48,7 +48,7 @@ class TermGroup_ extends Component {
     const session = this.props.sessions[uid];
     const termRef = this.props.terms[uid];
     const props = getTermProps(uid, this.props, {
-      isSessionActive: uid === this.props.activeSession,
+      isTermActive: uid === this.props.activeSession,
       term: termRef ? termRef.term : null,
       customCSS: this.props.customCSS,
       fontSize: this.props.fontSize,

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -274,7 +274,7 @@ export default class Term extends Component {
       ref={component => {
         this.termWrapperRef = component;
       }}
-      className={css('fit', this.props.isSessionActive && 'active')}
+      className={css('fit', this.props.isTermActive && 'active')}
       onMouseDown={this.handleMouseDown}
       style={{padding: this.props.padding}}
       >

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -274,7 +274,7 @@ export default class Term extends Component {
       ref={component => {
         this.termWrapperRef = component;
       }}
-      className={css('fit', 'session', this.props.isSessionActive && 'session_active')}
+      className={css('fit', this.props.isSessionActive && 'active')}
       onMouseDown={this.handleMouseDown}
       style={{padding: this.props.padding}}
       >

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -274,7 +274,7 @@ export default class Term extends Component {
       ref={component => {
         this.termWrapperRef = component;
       }}
-      className={css('fit')}
+      className={css('fit', 'session', this.props.isSessionActive && 'session_active')}
       onMouseDown={this.handleMouseDown}
       style={{padding: this.props.padding}}
       >

--- a/lib/components/terms.js
+++ b/lib/components/terms.js
@@ -82,6 +82,7 @@ export default class Terms extends Component {
           const props = getTermGroupProps(uid, this.props, {
             termGroup,
             terms: this.terms,
+            activeSession: this.props.activeSession,
             sessions: this.props.sessions,
             customCSS: this.props.customCSS,
             fontSize: this.props.fontSize,


### PR DESCRIPTION
With an active class, users can easily add styles to panels in order to highlight the active session

e.g:

![highlight](https://cloud.githubusercontent.com/assets/2286385/19538281/9d3611ee-9653-11e6-816f-88c56ce409b6.png)
