### PR TITLE
increase notification timeout up to 30m

### DIFF
--- a/app/notifications.js
+++ b/app/notifications.js
@@ -12,7 +12,7 @@ const matchVersion = versions => (
 module.exports = function fetchNotifications(win) {
   const {rpc} = win;
   const retry = err => {
-    setTimeout(() => fetchNotifications(win), ms(err ? '10s' : '5m'));
+    setTimeout(() => fetchNotifications(win), ms('30m'));
     if (err) {
       console.error('Notification messages fetch error', err.stack);
     }


### PR DESCRIPTION
fetchNotifications error can happen in two cases:
* https://hyper-news.now.sh is down
* you are offline

In both cases it doesn't hurt to wait half an hour.

PS. right now it hurts, when you are offline and developing
anything for Hyper, `console.error` logs the same error
every 10s and ruins your investigation.