### PR TITLE
log plugins' errors in Electron console

### DIFF
--- a/app/plugins.js
+++ b/app/plugins.js
@@ -295,6 +295,7 @@ function requirePlugins() {
 
       return mod;
     } catch (err) {
+      console.error(err);
       notify('Plugin error!', `Plugin "${basename(path)}" failed to load (${err.message})`);
     }
   };


### PR DESCRIPTION
_PR is ready to be reviewed and be merged._

Default `err.message` notification is not helpful,
because it lacks stack and context.

it doesnt hurt for end users to add `console.error(err)`,
because they arent gonna see it. Though, as far as `console.error`
is being logged in Electron console, developers will get
enough information to identify problems with plugin they are developing.