### PR TITLE
keymap feature

### DIFF
--- a/app/config-default.js
+++ b/app/config-default.js
@@ -81,7 +81,12 @@ module.exports = {
   //   `hyperpower`
   //   `@company/project`
   //   `project#1.0.1`
-  plugins: [],
+  //
+  // Make sure, you dont remove 'hyper-keymap' plugin,
+  // unless you know what you are doing
+  plugins: [
+    'hyper-keymap'
+  ],
 
   // in development, you can create a directory under
   // `~/.hyper_plugins/local/` and include it here

--- a/app/menu.js
+++ b/app/menu.js
@@ -22,7 +22,7 @@ module.exports = ({createWindow, updatePlugins}) => {
       },
       {
         label: 'Preferences...',
-        accelerator: 'Cmd+,',
+        command: 'show-settings',
         click(item, focusedWindow) {
           if (focusedWindow) {
             focusedWindow.rpc.emit('preferences');
@@ -64,14 +64,14 @@ module.exports = ({createWindow, updatePlugins}) => {
     submenu: [
       {
         label: 'New Window',
-        accelerator: 'CmdOrCtrl+N',
+        command: 'new-window',
         click() {
           createWindow();
         }
       },
       {
         label: 'New Tab',
-        accelerator: 'CmdOrCtrl+T',
+        command: 'new-tab',
         click(item, focusedWindow) {
           if (focusedWindow) {
             focusedWindow.rpc.emit('termgroup add req');
@@ -85,7 +85,7 @@ module.exports = ({createWindow, updatePlugins}) => {
       },
       {
         label: 'Split Vertically',
-        accelerator: isMac ? 'Cmd+D' : 'Ctrl+Shift+E',
+        command: 'split-vertical',
         click(item, focusedWindow) {
           if (focusedWindow) {
             focusedWindow.rpc.emit('split request vertical');
@@ -94,7 +94,7 @@ module.exports = ({createWindow, updatePlugins}) => {
       },
       {
         label: 'Split Horizontally',
-        accelerator: isMac ? 'Cmd+Shift+D' : 'Ctrl+Shift+O',
+        command: 'split-horizontal',
         click(item, focusedWindow) {
           if (focusedWindow) {
             focusedWindow.rpc.emit('split request horizontal');
@@ -106,7 +106,7 @@ module.exports = ({createWindow, updatePlugins}) => {
       },
       {
         label: 'Close',
-        accelerator: 'CmdOrCtrl+W',
+        command: 'close',
         click(item, focusedWindow) {
           if (focusedWindow) {
             focusedWindow.rpc.emit('termgroup close req');
@@ -115,8 +115,8 @@ module.exports = ({createWindow, updatePlugins}) => {
       },
       {
         label: isMac ? 'Close Terminal Window' : 'Quit',
-        role: 'close',
-        accelerator: 'CmdOrCtrl+Shift+W'
+        command: 'close-window',
+        role: 'close'
       }
     ]
   };
@@ -150,13 +150,51 @@ module.exports = ({createWindow, updatePlugins}) => {
       },
       {
         label: 'Clear',
-        accelerator: 'CmdOrCtrl+K',
+        command: 'clear',
         click(item, focusedWindow) {
           if (focusedWindow) {
             focusedWindow.rpc.emit('session clear req');
           }
         }
       }
+      /**
+      ,{
+        type: 'separator'
+      },
+       * @TODO: implemented in rpc, ./lib/index.js
+      ...[{
+        label: 'Move word Left',
+        command: 'move-word-left',
+      }, {
+        label: 'Move word Right',
+        command: 'move-word-right',
+      }, {
+        label: 'Delete word Left',
+        command: 'delete-word-left',
+      }, {
+        label: 'Delete word Right',
+        command: 'delete-word-right',
+      }, {
+        label: 'Delete line',
+        command: 'delete-line',
+      }, {
+        label: 'Move to line start',
+        command: 'move-to-line-start',
+      }, {
+        label: 'Move to line end',
+        command: 'move-to-line-end',
+      }, {
+        label: 'Select All',
+        command: 'select-all',
+      }].map(submenuItem => {
+        item.click = function click(item, focusedWindow) {
+          if (focusedWindow) {
+            focusedWindow.rpc.emit(submenuItem.command);
+          }
+        };
+        return item;
+      }),
+      */
     ]
   };
 
@@ -165,7 +203,7 @@ module.exports = ({createWindow, updatePlugins}) => {
       {type: 'separator'},
       {
         label: 'Preferences...',
-        accelerator: 'Cmd+,',
+        command: 'show-settings',
         click(item, focusedWindow) {
           if (focusedWindow) {
             focusedWindow.rpc.emit('preferences');
@@ -182,7 +220,7 @@ module.exports = ({createWindow, updatePlugins}) => {
     submenu: [
       {
         label: 'Reload',
-        accelerator: 'CmdOrCtrl+R',
+        command: 'reload',
         click(item, focusedWindow) {
           if (focusedWindow) {
             focusedWindow.rpc.emit('reload');
@@ -191,7 +229,7 @@ module.exports = ({createWindow, updatePlugins}) => {
       },
       {
         label: 'Full Reload',
-        accelerator: 'CmdOrCtrl+Shift+R',
+        command: 'reload-full',
         click(item, focusedWindow) {
           if (focusedWindow) {
             focusedWindow.reload();
@@ -200,7 +238,7 @@ module.exports = ({createWindow, updatePlugins}) => {
       },
       {
         label: 'Toggle Developer Tools',
-        accelerator: isMac ? 'Alt+Command+I' : 'Ctrl+Shift+I',
+        command: 'toggle-devtools',
         click(item, focusedWindow) {
           if (focusedWindow) {
             focusedWindow.webContents.toggleDevTools();
@@ -212,7 +250,7 @@ module.exports = ({createWindow, updatePlugins}) => {
       },
       {
         label: 'Reset Zoom Level',
-        accelerator: 'CmdOrCtrl+0',
+        command: 'zoom-reset',
         click(item, focusedWindow) {
           if (focusedWindow) {
             focusedWindow.rpc.emit('reset fontSize req');
@@ -221,7 +259,7 @@ module.exports = ({createWindow, updatePlugins}) => {
       },
       {
         label: 'Zoom In',
-        accelerator: 'CmdOrCtrl+plus',
+        command: 'zoom-in',
         click(item, focusedWindow) {
           if (focusedWindow) {
             focusedWindow.rpc.emit('increase fontSize req');
@@ -230,13 +268,28 @@ module.exports = ({createWindow, updatePlugins}) => {
       },
       {
         label: 'Zoom Out',
-        accelerator: 'CmdOrCtrl+-',
+        command: 'zoom-out',
         click(item, focusedWindow) {
           if (focusedWindow) {
             focusedWindow.rpc.emit('decrease fontSize req');
           }
         }
       }
+      /**
+      * @TODO: implemented in rpc, ./lib/index.js
+      ,{
+        type: 'separator'
+      },
+      ...[ 1, 2, 3, 4, 5, 6, 7, 8, 'last' ].map((value, index) => ({
+        label: `Show ${value} Tab`,
+        command: `tab-show-${ value === 'last' ? value : index }`,
+        click(item, focusedWindow) {
+          if (focusedWindow) {
+            focusedWindow.rpc.emit(`move req ${ value === 'last' ? value : index }`);
+          }
+        }
+      })),
+      */
     ]
   };
 
@@ -245,7 +298,7 @@ module.exports = ({createWindow, updatePlugins}) => {
     submenu: [
       {
         label: 'Update All Now',
-        accelerator: 'CmdOrCtrl+Shift+U',
+        command: 'update-plugins',
         click() {
           updatePlugins();
         }
@@ -267,7 +320,7 @@ module.exports = ({createWindow, updatePlugins}) => {
       },
       {
         label: 'Show Previous Tab',
-        accelerator: 'CmdOrCtrl+Option+Left',
+        command: 'prev-tab',
         click(item, focusedWindow) {
           if (focusedWindow) {
             focusedWindow.rpc.emit('move left req');
@@ -276,7 +329,7 @@ module.exports = ({createWindow, updatePlugins}) => {
       },
       {
         label: 'Show Next Tab',
-        accelerator: 'CmdOrCtrl+Option+Right',
+        command: 'next-tab',
         click(item, focusedWindow) {
           if (focusedWindow) {
             focusedWindow.rpc.emit('move right req');
@@ -287,20 +340,20 @@ module.exports = ({createWindow, updatePlugins}) => {
         type: 'separator'
       },
       {
-        label: 'Select Next Pane',
-        accelerator: 'Ctrl+Alt+Tab',
+        label: 'Select Previous Pane',
+        command: 'prev-pane',
         click(item, focusedWindow) {
           if (focusedWindow) {
-            focusedWindow.rpc.emit('next pane req');
+            focusedWindow.rpc.emit('prev pane req');
           }
         }
       },
       {
-        label: 'Select Previous Pane',
-        accelerator: 'Ctrl+Shift+Alt+Tab',
+        label: 'Select Next Pane',
+        command: 'next-pane',
         click(item, focusedWindow) {
           if (focusedWindow) {
-            focusedWindow.rpc.emit('prev pane req');
+            focusedWindow.rpc.emit('next pane req');
           }
         }
       },

--- a/lib/containers/hyper.js
+++ b/lib/containers/hyper.js
@@ -16,6 +16,14 @@ const isMac = /Mac/.test(navigator.userAgent);
 class Hyper extends Component {
   constructor(props) {
     super(props);
+    /**
+     * attachKeyListeners and resetKeyListeners
+     * should be removed after being implemented in rpc
+     * see app/menu.js
+     */
+    this.attachKeyListeners = this.attachKeyListeners.bind(this);
+    this.resetKeyListeners = this.resetKeyListeners.bind(this);
+
     this.handleFocusActive = this.handleFocusActive.bind(this);
     this.onTermsRef = this.onTermsRef.bind(this);
   }
@@ -36,7 +44,7 @@ class Hyper extends Component {
   }
 
   attachKeyListeners() {
-    const {moveTo, moveLeft, moveRight} = this.props;
+    const {moveTo} = this.props;
     const term = this.terms.getActiveTerm();
     if (!term) {
       return;
@@ -44,6 +52,7 @@ class Hyper extends Component {
     const lastIndex = this.terms.getLastTermIndex();
     const document = term.getTermDocument();
     const keys = new Mousetrap(document);
+
     keys.bind('command+1', moveTo.bind(this, 0));
     keys.bind('command+2', moveTo.bind(this, 1));
     keys.bind('command+3', moveTo.bind(this, 2));
@@ -53,15 +62,6 @@ class Hyper extends Component {
     keys.bind('command+7', moveTo.bind(this, 6));
     keys.bind('command+8', moveTo.bind(this, 7));
     keys.bind('command+9', moveTo.bind(this, lastIndex));
-
-    keys.bind('command+shift+left', moveLeft);
-    keys.bind('command+shift+right', moveRight);
-    keys.bind('command+shift+[', moveLeft);
-    keys.bind('command+shift+]', moveRight);
-    keys.bind('command+alt+left', moveLeft);
-    keys.bind('command+alt+right', moveRight);
-    keys.bind('ctrl+shift+tab', moveLeft);
-    keys.bind('ctrl+tab', moveRight);
 
     const bound = method => term[method].bind(term);
     keys.bind('alt+left', bound('moveWordLeft'));
@@ -75,24 +75,26 @@ class Hyper extends Component {
     this.keys = keys;
   }
 
+  resetKeyListeners() {
+    if (this.keys) {
+      this.keys.reset();
+    }
+  }
+
   onTermsRef(terms) {
     this.terms = terms;
   }
 
   componentDidUpdate(prev) {
     if (prev.activeSession !== this.props.activeSession) {
-      if (this.keys) {
-        this.keys.reset();
-      }
+      this.resetKeyListeners();
       this.handleFocusActive();
       this.attachKeyListeners();
     }
   }
 
   componentWillUnmount() {
-    if (this.keys) {
-      this.keys.reset();
-    }
+    this.resetKeyListeners();
     document.body.style.backgroundColor = 'inherit';
   }
 
@@ -146,14 +148,6 @@ const HyperContainer = connect(
     return {
       moveTo: i => {
         dispatch(uiActions.moveTo(i));
-      },
-
-      moveLeft: () => {
-        dispatch(uiActions.moveLeft());
-      },
-
-      moveRight: () => {
-        dispatch(uiActions.moveRight());
       }
     };
   },


### PR DESCRIPTION
_PR needs feedback_

I want flexible keymap for Hyper #872. First approach to use single RPC to communicate all the didnt really work out well, because of two separate RPCs, one for Electron and on for Renderer windows. So there is another approach to use Menu as kind of one entry-point to bind all hotkeys.
- 995bfa0 Remove all possible to implement via Menu hotkeys
- f629cc1 Change hard coded Menu accelerators to "convention"ed `command` field, which can be used to identify what for this menu item is responsible
- 69e4fd8 Add [hyper-keymap](https://github.com/iamstarkov/hyper-keymap) as standard plugin
### 🤔 Suggestion:
- keep keymap management as a default, but still separate plugin <sub>Atom is doing it with everything</sub>
- Move hyper-keymap into hyper org <sub>should we create one?</sub>
- Find a way to to notify end users about need to have hyper-keymap in their configs. Might be possible to use [`question messageBox`](http://electron.atom.io/docs/api/dialog/#dialogshowmessageboxbrowserwindow-options-callback) with "add it" or "dont bother me" buttons.
#### 😟 Cons (temporarily):
- at the time PR is being submitted `hyper-keymap` is not working fully, due to existing key bindings declared in `lib/containers/hyper.js`. Though, this pull-request almost fixes it.
- remaining key bindings, like `move-word-{left,right}` needs to be implemented the same way as everything else. I think this is possible, because as far as it is hotkey, there is no need in passing additional arguments, so it should possible to implement. That said, i seek for help to do that.
#### 😎 Pros:
- 🎉 Configured keymap, yay! 
- 👍 Even in one place 
- 🆓 [Documentation](https://github.com/iamstarkov/hyper-keymap#usage) about all [existing hotkeys](https://github.com/iamstarkov/hyper-keymap/blob/master/src/default-keymap.js) in one place, for free!

I tried my best, to bring keymap management to Hyper and now looking for feedback and discussion. What do you think about proposed approach?
