### PR TITLE
increase timeout for update checks

### DIFF
--- a/app/auto-updater.js
+++ b/app/auto-updater.js
@@ -19,6 +19,10 @@ function init() {
 
   autoUpdater.setFeedURL(`${FEED_URL}/${version}`);
 
+  setTimeout(() => {
+    autoUpdater.checkForUpdates();
+  }, ms('10s'));
+
   setInterval(() => {
     autoUpdater.checkForUpdates();
   }, ms('30m'));

--- a/app/auto-updater.js
+++ b/app/auto-updater.js
@@ -19,13 +19,9 @@ function init() {
 
   autoUpdater.setFeedURL(`${FEED_URL}/${version}`);
 
-  setTimeout(() => {
-    autoUpdater.checkForUpdates();
-  }, ms('10s'));
-
   setInterval(() => {
     autoUpdater.checkForUpdates();
-  }, ms('5m'));
+  }, ms('30m'));
 
   isInit = true;
 }


### PR DESCRIPTION
_PR is ready for code-review_

It seems like, there are lots of them and GitHub is not happy.
So increasing timeout 6x should fix that. In the end there is no need
to check updates every 5 minutes.

Fix #880