### PR TITLE
Make the close menu items less ambiguous

### DIFF
--- a/app/menu.js
+++ b/app/menu.js
@@ -105,7 +105,7 @@ module.exports = ({createWindow, updatePlugins}) => {
         type: 'separator'
       },
       {
-        label: 'Close',
+        label: 'Close Session',
         accelerator: 'CmdOrCtrl+W',
         click(item, focusedWindow) {
           if (focusedWindow) {
@@ -114,7 +114,7 @@ module.exports = ({createWindow, updatePlugins}) => {
         }
       },
       {
-        label: isMac ? 'Close Terminal Window' : 'Quit',
+        label: isMac ? 'Close Window' : 'Quit',
         role: 'close',
         accelerator: 'CmdOrCtrl+Shift+W'
       }


### PR DESCRIPTION
<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`

Thanks, again! -->

@Tyriar brought up a good point in #123 that the close menu items can be
ambiguous and misleading. This clarifies them so you know exactly what
you're closing.

Fixes #123.