### PR TITLE
Change URL regex - fixes #867

### DIFF
--- a/lib/utils/url-command.js
+++ b/lib/utils/url-command.js
@@ -1,6 +1,6 @@
 import * as regex from './url-regex';
 
-export const domainRegex = /\b((?=[a-z0-9-]{1,63}\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,63}\b|^localhost$|^127(?:\.[0-9]+){0,2}\.[0-9]+$|^(?:0*:)*?:?0*1$/;
+export const domainRegex = /([0-9]+[:.]*)+|([a-zA-Z0-9.]+[.][a-zA-Z0-9.]+([:][0-9]+)*){1}/;
 
 export default function isUrlCommand(shell, data) {
   const matcher = regex[shell]; // eslint-disable-line import/namespace
@@ -22,7 +22,8 @@ export default function isUrlCommand(shell, data) {
     // extract the domain portion from the url
     const domain = path.split('/')[0];
     if (domainRegex.test(domain)) {
-      return `http://${path}`;
+      const result = path.match(domainRegex)[0];
+      return `http://${result}`;
     }
   }
 


### PR DESCRIPTION
Hi,

This fix addresses an issue in which URLs were passed too kindly resulting in the terminal regularly being redirected to a blank screen (as the location it was being redirected to did not make sense).

I have re-written the URL regex and matching system, and this PR is ready to be merged. Some obscure IPV6 addresses are not matched which will need to be fixed in the future, but for now it is better that we miss a few URLs than occasionally breaking the terminal.