### PR TITLE
Remove prevUid test from setActiveSession

### DIFF
--- a/lib/actions/sessions.js
+++ b/lib/actions/sessions.js
@@ -101,21 +101,10 @@ export const userExitSession = createExitAction(SESSION_USER_EXIT);
 export const ptyExitSession = createExitAction(SESSION_PTY_EXIT);
 
 export function setActiveSession(uid) {
-  return (dispatch, getState) => {
-    const state = getState();
-    const prevUid = state.sessions.activeUid;
+  return dispatch => {
     dispatch({
       type: SESSION_SET_ACTIVE,
-      uid,
-      effect() {
-        // This goes away when we are able to poll
-        // for the title ourseleves, instead of relying
-        // on Session and focus/blur to subscribe
-        if (prevUid) {
-          rpc.emit('blur', {uid: prevUid});
-        }
-        rpc.emit('focus', {uid});
-      }
+      uid
     });
   };
 }


### PR DESCRIPTION
<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`

Thanks, again! -->

### Ready to be merged

#892 removed the blur and focus on the session.
Therefore we don't need to test the `prevUid`
