### PR TITLE
Fix inverted text display. Fix #883

### DIFF
--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -37,6 +37,10 @@ export default class Term extends Component {
     prefs.set('cursor-color', this.validateColor(props.cursorColor, 'rgba(255,255,255,0.5)'));
     prefs.set('enable-clipboard-notice', false);
     prefs.set('foreground-color', props.foregroundColor);
+
+    // hterm.ScrollPort.prototype.setBackgroundColor is overriden
+    // to make hterm's background transparent. we still need to set
+    // background-color for proper text rendering
     prefs.set('background-color', props.backgroundColor);
     prefs.set('color-palette-overrides', getColorList(props.colors));
     prefs.set('user-css', this.getStylesheet(props.customCSS));

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -37,7 +37,7 @@ export default class Term extends Component {
     prefs.set('cursor-color', this.validateColor(props.cursorColor, 'rgba(255,255,255,0.5)'));
     prefs.set('enable-clipboard-notice', false);
     prefs.set('foreground-color', props.foregroundColor);
-    prefs.set('background-color', 'transparent');
+    prefs.set('background-color', props.backgroundColor);
     prefs.set('color-palette-overrides', getColorList(props.colors));
     prefs.set('user-css', this.getStylesheet(props.customCSS));
     prefs.set('scrollbar-visible', false);

--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -207,6 +207,11 @@ hterm.Terminal.prototype.onMouse_ = function (e) {
   return oldOnMouse.call(this, e);
 };
 
+// make background transparent to avoid transparency issues
+hterm.ScrollPort.prototype.setBackgroundColor = function () {
+  this.screen_.style.backgroundColor = 'transparent';
+};
+
 // fixes a bug in hterm, where the shorthand hex
 // is not properly converted to rgb
 lib.colors.hexToRGB = function (arg) {


### PR DESCRIPTION
This is similar to #821 but preserves background transparency.

hterm swaps `foreground` and `background` text attributes when handling inverted text (e.g. `echo -e "Normal \e[7minverted"`). Therefore, we can't set `background-color` as transparent as we'll get invisible text in this case.