### PR TITLE
Update old electron target engine for dependencies (ready to be merged)

### DIFF
--- a/app/plugins.js
+++ b/app/plugins.js
@@ -233,7 +233,7 @@ function install(fn) {
     }
     /* eslint-disable camelcase  */
     env.npm_config_runtime = 'electron';
-    env.npm_config_target = '1.3.0';
+    env.npm_config_target = process.versions.electron;
     env.npm_config_disturl = 'https://atom.io/download/atom-shell';
     /* eslint-enable camelcase  */
     exec('npm prune; npm install --production', {


### PR DESCRIPTION
This fixes dependencies of Hyper that build based on the engine being used ([`nodegit`](https://github.com/nodegit/nodegit) for example). Uses [electron’s process version](http://electron.atom.io/docs/api/process/#processversionselectron) so we’re always up to date.

Without this, plugins like [`hyperterm-sync-settings`](https://github.com/dfrankland/hyperterm-sync-settings) (will be renamed soon) will break.