### PR TITLE
Fix selection extend when copyOnSelect is true

### DIFF
--- a/lib/utils/selection.js
+++ b/lib/utils/selection.js
@@ -11,6 +11,9 @@ exports.extend = function (terminal) {
   // Test if focusNode exist and nodeName is #text
   if (sel.focusNode && sel.focusNode.nodeName === '#text') {
     terminal.screen_.expandSelection(sel);
+    if (terminal.copyOnSelect) {
+      terminal.copyStringToClipboard();
+    }
   }
 };
 


### PR DESCRIPTION
<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`

Thanks, again! -->

My PR #632 added selection extend on dblClick.  If `hterm.copyOnSelect = true` Then we need to copy the new selection to the clipboard.
Close #974