### PR TITLE
Always create a new session when creating a new window

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -153,17 +153,16 @@ app.on('ready', () => installDevExtensions(isDev).then(() => {
     rpc.on('init', () => {
       win.show();
 
-      // If no callback is passed to createWindow,
-      // a new session will be created by default.
-      if (!fn) {
-        fn = win => win.rpc.emit('termgroup add req');
-      }
+      // create a new session
+      win.rpc.emit('termgroup add req');
 
       // app.windowCallback is the createWindow callback
       // that can be set before the 'ready' app event
       // and createWindow deifinition. It's executed in place of
       // the callback passed as parameter, and deleted right after.
-      (app.windowCallback || fn)(win);
+      if (app.windowCallback || fn) {
+        (app.windowCallback || fn)(win);
+      }
       delete (app.windowCallback);
 
       fetchNotifications(win);
@@ -309,6 +308,8 @@ app.on('ready', () => installDevExtensions(isDev).then(() => {
         app.quit();
       }
     });
+
+    return win;
   }
 
   // when opening create a new window


### PR DESCRIPTION
**DO NOT MERGE** until we get a change to discuss further.

I am not sure of any case where you would want to create a new window and not start a new session? This is changed behavior and makes some plugins that created a new window appear to be broken (a window opens, but you can't interact until you create a new tab).

I see this was added in #329, for something to do with opening files.

This behavior is kind of confusing for people who want to create a new "regular window" and have a reference to that window (`app.createWindow` currently does not return anything). So they _have_ to pass a callback, but then that causes their window to appear "broken" as mentioned.

See https://github.com/zeit/hyper/pull/329#r87125720 