### PR TITLE
[Win] Improve design of the scrollbars

### DIFF
--- a/lib/components/term-group.js
+++ b/lib/components/term-group.js
@@ -71,7 +71,8 @@ class TermGroup_ extends Component {
       onResize: this.bind(this.props.onResize, null, uid),
       onTitle: this.bind(this.props.onTitle, null, uid),
       onData: this.bind(this.props.onData, null, uid),
-      onURLAbort: this.bind(this.props.onURLAbort, null, uid)
+      onURLAbort: this.bind(this.props.onURLAbort, null, uid),
+      borderColor: this.props.borderColor
     });
 
     // This will create a new ref_ function for every render,

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -204,7 +204,7 @@ export default class Term extends Component {
   }
 
   getStylesheet(css) {
-    const blob = new Blob([`
+    const hyperCaret = `
       .hyper-caret {
         outline: none;
         display: inline-block;
@@ -213,13 +213,29 @@ export default class Term extends Component {
         font-family: ${this.props.fontFamily};
         font-size: ${this.props.fontSize}px;
       }
+    `;
+    const osSpecificCss = process.platform === 'win32' ?
+      `::-webkit-scrollbar {
+            width: 5px;
+          }
+          ::-webkit-scrollbar-thumb {
+            -webkit-border-radius: 10px;
+            border-radius: 10px;
+            background: #fff;
+          }
+          ::-webkit-scrollbar-thumb:window-inactive {
+            background: #fff;
+          }` : ''
+    ;
+    return URL.createObjectURL(new Blob([`
       .cursor-node[focus="false"] {
-        border-width: 1px !important;
+         border-width: 1px !important;
       }
+      ${hyperCaret}
+      ${osSpecificCss}
       ${css}
-    `], {type: 'text/css'});
-    return URL.createObjectURL(blob);
-  }
+    `], {type: 'text/css'}));
+    }
 
   validateColor(color, alternative = 'rgb(255,255,255)') {
     try {
@@ -381,5 +397,4 @@ export default class Term extends Component {
       }
     };
   }
-
 }

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -235,7 +235,7 @@ export default class Term extends Component {
       ${osSpecificCss}
       ${css}
     `], {type: 'text/css'}));
-    }
+  }
 
   validateColor(color, alternative = 'rgb(255,255,255)') {
     try {

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -221,10 +221,10 @@ export default class Term extends Component {
           ::-webkit-scrollbar-thumb {
             -webkit-border-radius: 10px;
             border-radius: 10px;
-            background: #fff;
+            background: ${this.props.borderColor};
           }
           ::-webkit-scrollbar-thumb:window-inactive {
-            background: #fff;
+            background: ${this.props.borderColor};
           }` : ''
     ;
     return URL.createObjectURL(new Blob([`


### PR DESCRIPTION
<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`

Thanks, again! -->

Hyper on Windows uses default scrollbars that do not go well with the new design for Windows. 
I updated the design to change only on win32 so that MacOS and Linux remain the same.

Would love to get some feedback on this (code or design). 