### PR TITLE
Add artifacts publishing on windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,3 +29,4 @@ test_script:
 
 on_success:
   - npm run dist
+  - ps: ls .\dist\win\*.exe | % { Push-AppveyorArtifact $_.FullName }


### PR DESCRIPTION
Publish `Hyper Setup x.x.x.exe` file to AppVeyor artifacts tab.
This way, it's very easy to share recent windows builds with people.

It also would be nice to add appveyor build badge to the README.md, but only the admins on the appveyor projects can get the badge URL. https://www.appveyor.com/docs/status-badges/