### PR TITLE
Fix/pty.js build

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "copy-webpack-plugin": "^4.0.0",
     "cross-env": "3.1.3",
     "electron": "1.4.5",
-    "electron-builder": "^7.11.4",
+    "electron-builder": "8.6.0",
     "electron-devtools-installer": "^2.0.0",
     "eslint-config-xo-react": "^0.10.0",
     "eslint-plugin-react": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,11 @@
         "AppImage"
       ]
     },
+    "win": {
+      "target": [
+        "squirrel"
+      ]
+    },
     "mac": {
       "category": "public.app-category.developer-tools"
     }

--- a/test/index.js
+++ b/test/index.js
@@ -12,7 +12,7 @@ test.before(async () => {
 
   switch (process.platform) {
     case 'linux':
-      pathToBinary = path.join(__dirname, '../dist/linux-unpacked/Hyper');
+      pathToBinary = path.join(__dirname, '../dist/linux-unpacked/hyper');
       break;
 
     case 'darwin':


### PR DESCRIPTION
Fixes #988 if both Travis and AppVeyor passes 🙏 

I pinned the `electron-builder` version because `semver`'s `^` was causing a lot of trouble – some people were able to reproduce the issue, some people weren't, some builds passed on CI, some builds didn't 😕 

**HUGE** thanks to @vors – #999 😄 
**HUGE** thanks to @stefanivic for helping to debug it on [zeit.chat] 🙌 

[zeit.chat]: https://zeit.chat