### PR TITLE
Add support for composed chars and fix issues with "foreign" keyboard layouts

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -121,7 +121,8 @@ app.on('ready', () => installDevExtensions(isDev).then(() => {
       // HYPERTERM_DEBUG for backwards compatibility with hyperterm
       show: process.env.HYPER_DEBUG || process.env.HYPERTERM_DEBUG || isDev,
       x: startX,
-      y: startY
+      y: startY,
+      acceptFirstMouse: true
     };
     const browserOptions = plugins.getDecoratedBrowserOptions(browserDefaults);
 

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -131,7 +131,7 @@ export default class Term extends Component {
   }
 
   getCursorColor() {
-    return this.validateColor(this.props.cursorColor, 'rgba(255,255,255,0.5)')
+    return this.validateColor(this.props.cursorColor, 'rgba(255,255,255,0.5)');
   }
 
   // ensure that our contenteditable caret is injected
@@ -364,8 +364,8 @@ export default class Term extends Component {
           }}
           /> :
         [
-          <div key="caret" contentEditable className="hyper-caret" ref={this.onCaret} />,
-          <div
+          <div key="caret" contentEditable className="hyper-caret" ref={this.onCaret}/>,
+          <div // eslint-disable-line react/jsx-indent
             key="scrollbar"
             className={css('scrollbarShim')}
             onMouseEnter={this.handleScrollEnter}

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -144,7 +144,7 @@ export default class Term extends Component {
       this.caret_.style.fontFamily = this.props.fontFamily;
       this.caret_.style.fontSize = this.props.fontSize + 'px';
     }
-    this.caret_.focus();
+    this.focus();
   }
 
   // note: this is temporary. we want to move this into hterm
@@ -197,7 +197,7 @@ export default class Term extends Component {
   }
 
   focus() {
-    // this.term.focus();
+    this.caret_.focus();
   }
 
   clear() {

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -137,12 +137,12 @@ export default class Term extends Component {
   // ensure that our contenteditable caret is injected
   // inside the term's cursor node
   ensureCaret() {
-    if (!this.caret_.parentNode !== this.term.cursorNode_) {
-      this.term.cursorNode_.appendChild(this.caret_);
-      this.caret_.style.color = 'transparent';
-      this.caret_.style.textShadow = '0 0 0 black';
-      this.caret_.style.fontFamily = this.props.fontFamily;
-      this.caret_.style.fontSize = this.props.fontSize + 'px';
+    if (!this.hyperCaret.parentNode !== this.term.cursorNode_) {
+      this.term.cursorNode_.appendChild(this.hyperCaret);
+      this.hyperCaret.style.color = 'transparent';
+      this.hyperCaret.style.textShadow = '0 0 0 black';
+      this.hyperCaret.style.fontFamily = this.props.fontFamily;
+      this.hyperCaret.style.fontSize = this.props.fontSize + 'px';
     }
     this.focus();
   }
@@ -151,7 +151,7 @@ export default class Term extends Component {
   // prototype extensions directly, as it has nothing to do
   // with the <Term/> logic
   focusCaret() {
-    const p = this.caret_;
+    const p = this.hyperCaret;
     const doc = this.term.document_;
     const win = doc.defaultView;
     const s = win.getSelection();
@@ -162,7 +162,7 @@ export default class Term extends Component {
   }
 
   onCaret(caret) {
-    this.caret_ = caret;
+    this.hyperCaret = caret;
 
     if (caret !== null) { // will be null when the component unmounts
       // we can ignore `compositionstart` since chromium always fire it with ''
@@ -197,7 +197,7 @@ export default class Term extends Component {
   }
 
   focus() {
-    this.caret_.focus();
+    this.hyperCaret.focus();
   }
 
   clear() {
@@ -309,7 +309,7 @@ export default class Term extends Component {
 
     if (this.props.fontSize !== nextProps.fontSize) {
       prefs.set('font-size', nextProps.fontSize);
-      this.caret_.style.fontSize = nextProps.fontSize + 'px';
+      this.hyperCaret.style.fontSize = nextProps.fontSize + 'px';
     }
 
     if (this.props.foregroundColor !== nextProps.foregroundColor) {
@@ -318,7 +318,7 @@ export default class Term extends Component {
 
     if (this.props.fontFamily !== nextProps.fontFamily) {
       prefs.set('font-family', nextProps.fontFamily);
-      this.caret_.style.fontFamily = nextProps.fontFamily;
+      this.hyperCaret.style.fontFamily = nextProps.fontFamily;
     }
 
     if (this.props.fontSmoothing !== nextProps.fontSmoothing) {

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -13,6 +13,7 @@ export default class Term extends Component {
     super(props);
     this.handleWheel = this.handleWheel.bind(this);
     this.handleMouseDown = this.handleMouseDown.bind(this);
+    this.handleMouseUp = this.handleMouseUp.bind(this);
     this.handleScrollEnter = this.handleScrollEnter.bind(this);
     this.handleScrollLeave = this.handleScrollLeave.bind(this);
     this.handleFocus = this.handleFocus.bind(this);
@@ -90,7 +91,7 @@ export default class Term extends Component {
     const iframeWindow = this.getTermDocument().defaultView;
     iframeWindow.addEventListener('wheel', this.handleWheel);
 
-    this.getScreenNode().addEventListener('focus', this.handleFocus);
+    this.getScreenNode().addEventListener('mouseup', this.handleMouseUp);
   }
 
   handleWheel(e) {
@@ -125,11 +126,14 @@ export default class Term extends Component {
     // called, which is unecessary.
     // Should investigate if it matters.
     this.props.onActive();
-    setTimeout(() => {
-      if (this.term.document_.getSelection().type !== 'Range') {
-        this.term.focusHyperCaret();
-      }
-    }, 500);
+    this.term.focusHyperCaret();
+  }
+
+  handleMouseUp() {
+    this.props.onActive();
+    if (this.term.document_.getSelection().type !== 'Range') {
+      this.term.focusHyperCaret();
+    }
   }
 
   getCursorColor() {

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -140,6 +140,7 @@ export default class Term extends Component {
     if (!this.caret_.parentNode !== this.term.cursorNode_) {
       this.term.cursorNode_.appendChild(this.caret_);
       this.caret_.style.color = 'transparent';
+      this.caret_.style.textShadow = '0 0 0 black';
       this.caret_.style.fontFamily = this.props.fontFamily;
       this.caret_.style.fontSize = this.props.fontSize + 'px';
     }
@@ -162,6 +163,35 @@ export default class Term extends Component {
 
   onCaret(caret) {
     this.caret_ = caret;
+
+    if (caret !== null) { // will be null when the component unmounts
+      // we can ignore `compositionstart` since chromium always fire it with ''
+      caret.addEventListener('compositionupdate', e => {
+        e.target.parentElement.style.backgroundColor = 'yellow';
+        e.target.parentElement.style.borderColor = 'yellow';
+      });
+
+      // at this point the char(s) is ready
+      caret.addEventListener('compositionend', e => {
+        e.target.parentElement.style.backgroundColor = '';
+        this.term.setCursorShape(this.props.cursorShape);
+        e.target.parentElement.style.borderColor = this.getCursorColor();
+        e.target.innerText = '';
+      });
+
+      // we need to capture pastes, prevent then and send the content to the terminal
+      caret.addEventListener('paste', e => {
+        e.stopPropagation();
+        e.preventDefault();
+        const text = e.clipboardData.getData('text');
+        this.term.onVTKeystroke(text);
+      });
+
+      caret.addEventListener('focus', () => {
+        console.log('caret focus');
+        this.handleFocus();
+      });
+    }
   }
 
   write(data) {
@@ -226,8 +256,6 @@ export default class Term extends Component {
   getStylesheet(css) {
     const blob = new Blob([`
       .hyper-caret {
-        width: 5px;
-        height: 12px;
         outline: none;
         display: inline-block;
       }

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -187,10 +187,8 @@ export default class Term extends Component {
         this.term.onVTKeystroke(text);
       });
 
-      caret.addEventListener('focus', () => {
-        console.log('caret focus');
-        this.handleFocus();
-      });
+      caret.addEventListener('focus', () => caret.parentElement.setAttribute('focus', true));
+      caret.addEventListener('blur', () => caret.parentElement.setAttribute('focus', false));
     }
   }
 

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -16,6 +16,7 @@ export default class Term extends Component {
     this.handleScrollEnter = this.handleScrollEnter.bind(this);
     this.handleScrollLeave = this.handleScrollLeave.bind(this);
     this.handleFocus = this.handleFocus.bind(this);
+    this.onCaret = this.onCaret.bind(this);
     props.ref_(this);
   }
 
@@ -77,6 +78,7 @@ export default class Term extends Component {
       // emit onTitle event when hterm instance
       // wants to set the title of its tab
       this.term.setWindowTitle = props.onTitle;
+      this.ensureCaret();
     };
     this.term.decorate(this.termRef);
     this.term.installKeyboard();
@@ -87,6 +89,9 @@ export default class Term extends Component {
     const iframeWindow = this.getTermDocument().defaultView;
     iframeWindow.addEventListener('wheel', this.handleWheel);
 
+    this.term.primaryScreen_.syncSelectionCaret = () => {
+      this.focusCaret();
+    };
     this.getScreenNode().addEventListener('focus', this.handleFocus);
   }
 
@@ -122,6 +127,41 @@ export default class Term extends Component {
     // called, which is unecessary.
     // Should investigate if it matters.
     this.props.onActive();
+    this.ensureCaret();
+  }
+
+  getCursorColor() {
+    return this.validateColor(this.props.cursorColor, 'rgba(255,255,255,0.5)')
+  }
+
+  // ensure that our contenteditable caret is injected
+  // inside the term's cursor node
+  ensureCaret() {
+    if (!this.caret_.parentNode !== this.term.cursorNode_) {
+      this.term.cursorNode_.appendChild(this.caret_);
+      this.caret_.style.color = 'transparent';
+      this.caret_.style.fontFamily = this.props.fontFamily;
+      this.caret_.style.fontSize = this.props.fontSize + 'px';
+    }
+    this.caret_.focus();
+  }
+
+  // note: this is temporary. we want to move this into hterm
+  // prototype extensions directly, as it has nothing to do
+  // with the <Term/> logic
+  focusCaret() {
+    const p = this.caret_;
+    const doc = this.term.document_;
+    const win = doc.defaultView;
+    const s = win.getSelection();
+    const r = doc.createRange();
+    r.selectNodeContents(p);
+    s.removeAllRanges();
+    s.addRange(r);
+  }
+
+  onCaret(caret) {
+    this.caret_ = caret;
   }
 
   write(data) {
@@ -129,7 +169,7 @@ export default class Term extends Component {
   }
 
   focus() {
-    this.term.focus();
+    // this.term.focus();
   }
 
   clear() {
@@ -185,6 +225,12 @@ export default class Term extends Component {
 
   getStylesheet(css) {
     const blob = new Blob([`
+      .hyper-caret {
+        width: 5px;
+        height: 12px;
+        outline: none;
+        display: inline-block;
+      }
       .cursor-node[focus="false"] {
         border-width: 1px !important;
       }
@@ -237,6 +283,7 @@ export default class Term extends Component {
 
     if (this.props.fontSize !== nextProps.fontSize) {
       prefs.set('font-size', nextProps.fontSize);
+      this.caret_.style.fontSize = nextProps.fontSize + 'px';
     }
 
     if (this.props.foregroundColor !== nextProps.foregroundColor) {
@@ -245,6 +292,7 @@ export default class Term extends Component {
 
     if (this.props.fontFamily !== nextProps.fontFamily) {
       prefs.set('font-family', nextProps.fontFamily);
+      this.caret_.style.fontFamily = nextProps.fontFamily;
     }
 
     if (this.props.fontSmoothing !== nextProps.fontSmoothing) {
@@ -315,11 +363,15 @@ export default class Term extends Component {
             height: '100%'
           }}
           /> :
-            <div
-              className={css('scrollbarShim')}
-              onMouseEnter={this.handleScrollEnter}
-              onMouseLeave={this.handleScrollLeave}
-              />
+        [
+          <div key="caret" contentEditable className="hyper-caret" ref={this.onCaret} />,
+          <div
+            key="scrollbar"
+            className={css('scrollbarShim')}
+            onMouseEnter={this.handleScrollEnter}
+            onMouseLeave={this.handleScrollLeave}
+            />
+        ]
       }
       { this.props.customChildren }
     </div>);

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -16,13 +16,14 @@ export default class Term extends Component {
     this.handleScrollEnter = this.handleScrollEnter.bind(this);
     this.handleScrollLeave = this.handleScrollLeave.bind(this);
     this.handleFocus = this.handleFocus.bind(this);
-    this.onCaret = this.onCaret.bind(this);
+    this.onHyperCaret = this.onHyperCaret.bind(this);
     props.ref_(this);
   }
 
   componentDidMount() {
     const {props} = this;
     this.term = props.term || new hterm.Terminal(uuid.v4());
+    this.term.onHyperCaret(this.hyperCaret);
 
     // the first term that's created has unknown size
     // subsequent new tabs have size
@@ -78,7 +79,7 @@ export default class Term extends Component {
       // emit onTitle event when hterm instance
       // wants to set the title of its tab
       this.term.setWindowTitle = props.onTitle;
-      this.ensureCaret();
+      this.term.focusHyperCaret();
     };
     this.term.decorate(this.termRef);
     this.term.installKeyboard();
@@ -89,9 +90,6 @@ export default class Term extends Component {
     const iframeWindow = this.getTermDocument().defaultView;
     iframeWindow.addEventListener('wheel', this.handleWheel);
 
-    this.term.primaryScreen_.syncSelectionCaret = () => {
-      this.focusCaret();
-    };
     this.getScreenNode().addEventListener('focus', this.handleFocus);
   }
 
@@ -127,69 +125,15 @@ export default class Term extends Component {
     // called, which is unecessary.
     // Should investigate if it matters.
     this.props.onActive();
-    this.ensureCaret();
+    this.term.focusHyperCaret();
   }
 
   getCursorColor() {
     return this.validateColor(this.props.cursorColor, 'rgba(255,255,255,0.5)');
   }
 
-  // ensure that our contenteditable caret is injected
-  // inside the term's cursor node
-  ensureCaret() {
-    if (!this.hyperCaret.parentNode !== this.term.cursorNode_) {
-      this.term.cursorNode_.appendChild(this.hyperCaret);
-      this.hyperCaret.style.color = 'transparent';
-      this.hyperCaret.style.textShadow = '0 0 0 black';
-      this.hyperCaret.style.fontFamily = this.props.fontFamily;
-      this.hyperCaret.style.fontSize = this.props.fontSize + 'px';
-    }
-    this.focus();
-  }
-
-  // note: this is temporary. we want to move this into hterm
-  // prototype extensions directly, as it has nothing to do
-  // with the <Term/> logic
-  focusCaret() {
-    const p = this.hyperCaret;
-    const doc = this.term.document_;
-    const win = doc.defaultView;
-    const s = win.getSelection();
-    const r = doc.createRange();
-    r.selectNodeContents(p);
-    s.removeAllRanges();
-    s.addRange(r);
-  }
-
-  onCaret(caret) {
+  onHyperCaret(caret) {
     this.hyperCaret = caret;
-
-    if (caret !== null) { // will be null when the component unmounts
-      // we can ignore `compositionstart` since chromium always fire it with ''
-      caret.addEventListener('compositionupdate', e => {
-        e.target.parentElement.style.backgroundColor = 'yellow';
-        e.target.parentElement.style.borderColor = 'yellow';
-      });
-
-      // at this point the char(s) is ready
-      caret.addEventListener('compositionend', e => {
-        e.target.parentElement.style.backgroundColor = '';
-        this.term.setCursorShape(this.props.cursorShape);
-        e.target.parentElement.style.borderColor = this.getCursorColor();
-        e.target.innerText = '';
-      });
-
-      // we need to capture pastes, prevent then and send the content to the terminal
-      caret.addEventListener('paste', e => {
-        e.stopPropagation();
-        e.preventDefault();
-        const text = e.clipboardData.getData('text');
-        this.term.onVTKeystroke(text);
-      });
-
-      caret.addEventListener('focus', () => caret.parentElement.setAttribute('focus', true));
-      caret.addEventListener('blur', () => caret.parentElement.setAttribute('focus', false));
-    }
   }
 
   write(data) {
@@ -197,7 +141,7 @@ export default class Term extends Component {
   }
 
   focus() {
-    this.hyperCaret.focus();
+    this.term.focusHyperCaret();
   }
 
   clear() {
@@ -256,6 +200,10 @@ export default class Term extends Component {
       .hyper-caret {
         outline: none;
         display: inline-block;
+        color: transparent;
+        text-shadow: 0 0 0 black;
+        font-family: ${this.props.fontFamily};
+        font-size: ${this.props.fontSize}px;
       }
       .cursor-node[focus="false"] {
         border-width: 1px !important;
@@ -390,7 +338,7 @@ export default class Term extends Component {
           }}
           /> :
         [
-          <div key="caret" contentEditable className="hyper-caret" ref={this.onCaret}/>,
+          <div key="hyper-caret" contentEditable className="hyper-caret" ref={this.onHyperCaret}/>,
           <div // eslint-disable-line react/jsx-indent
             key="scrollbar"
             className={css('scrollbarShim')}

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -125,7 +125,11 @@ export default class Term extends Component {
     // called, which is unecessary.
     // Should investigate if it matters.
     this.props.onActive();
-    this.term.focusHyperCaret();
+    setTimeout(() => {
+      if (this.term.document_.getSelection().type !== 'Range') {
+        this.term.focusHyperCaret();
+      }
+    }, 500);
   }
 
   getCursorColor() {

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -131,6 +131,10 @@ export default class Term extends Component {
 
   handleMouseUp() {
     this.props.onActive();
+    // this makes sure that we focus the hyper caret only
+    // if a click on the term does not result in a selection
+    // otherwise, if we focus without such check, it'd be
+    // impossible to select a piece of text
     if (this.term.document_.getSelection().type !== 'Range') {
       this.term.focusHyperCaret();
     }

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -136,10 +136,6 @@ export default class Term extends Component {
     }
   }
 
-  getCursorColor() {
-    return this.validateColor(this.props.cursorColor, 'rgba(255,255,255,0.5)');
-  }
-
   onHyperCaret(caret) {
     this.hyperCaret = caret;
   }

--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -258,7 +258,6 @@ hterm.Terminal.prototype.focusHyperCaret = function () {
 };
 
 hterm.Screen.prototype.syncSelectionCaret = function () {
-  console.log(this);
   const p = this.terminal.hyperCaret;
   const doc = this.terminal.document_;
   const win = doc.defaultView;

--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -212,6 +212,63 @@ hterm.ScrollPort.prototype.setBackgroundColor = function () {
   this.screen_.style.backgroundColor = 'transparent';
 };
 
+// will be called by the <Term/> right after the `hterm.Terminal` is instantiated
+hterm.Terminal.prototype.onHyperCaret = function (caret) {
+  this.hyperCaret = caret;
+
+  // we can ignore `compositionstart` since chromium always fire it with ''
+  caret.addEventListener('compositionupdate', () => {
+    this.cursorNode_.style.backgroundColor = 'yellow';
+    this.cursorNode_.style.borderColor = 'yellow';
+  });
+
+  // at this point the char(s) is ready
+  caret.addEventListener('compositionend', () => {
+    this.cursorNode_.style.backgroundColor = '';
+    this.setCursorShape(this.getCursorShape());
+    this.cursorNode_.style.borderColor = this.getCursorColor();
+    caret.innerText = '';
+  });
+
+  // we need to capture pastes, prevent them and send its contents to the terminal
+  caret.addEventListener('paste', e => {
+    e.stopPropagation();
+    e.preventDefault();
+    const text = e.clipboardData.getData('text');
+    this.onVTKeystroke(text);
+  });
+
+  // here we replicate the focus/blur state of our caret on the `hterm` caret
+  caret.addEventListener('focus', () => this.cursorNode_.setAttribute('focus', true));
+  caret.addEventListener('blur', () => this.cursorNode_.setAttribute('focus', false));
+
+  // this is necessary because we need to access the `document_` and the hyperCaret
+  // on `hterm.Screen.prototype.syncSelectionCaret`
+  this.primaryScreen_.terminal = this;
+  this.alternateScreen_.terminal = this;
+};
+
+// ensure that our contenteditable caret is injected
+// inside the term's cursor node and that it's focused
+hterm.Terminal.prototype.focusHyperCaret = function () {
+  if (!this.hyperCaret.parentNode !== this.cursorNode_) {
+    this.cursorNode_.appendChild(this.hyperCaret);
+  }
+  this.hyperCaret.focus();
+};
+
+hterm.Screen.prototype.syncSelectionCaret = function () {
+  console.log(this);
+  const p = this.terminal.hyperCaret;
+  const doc = this.terminal.document_;
+  const win = doc.defaultView;
+  const s = win.getSelection();
+  const r = doc.createRange();
+  r.selectNodeContents(p);
+  s.removeAllRanges();
+  s.addRange(r);
+};
+
 // fixes a bug in hterm, where the shorthand hex
 // is not properly converted to rgb
 lib.colors.hexToRGB = function (arg) {

--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -213,6 +213,16 @@ hterm.Screen.prototype.syncSelectionCaret = function () {
   s.addRange(r);
 };
 
+// fixes a bug in hterm, where the cursor goes back to `BLOCK`
+// after the bell rings
+const oldRingBell = hterm.Terminal.prototype.ringBell;
+hterm.Terminal.prototype.ringBell = function() {
+  oldRingBell.call(this);
+  setTimeout(() => {
+    this.restyleCursor_();
+  }, 200);
+};
+
 // fixes a bug in hterm, where the shorthand hex
 // is not properly converted to rgb
 lib.colors.hexToRGB = function (arg) {

--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -183,7 +183,7 @@ hterm.Terminal.prototype.onHyperCaret = function (caret) {
     this.restyleCursor_();
   });
   caret.addEventListener('blur', () => {
-    this.cursorNode_.setAttribute('focus', false)
+    this.cursorNode_.setAttribute('focus', false);
     this.restyleCursor_();
   });
 
@@ -216,7 +216,7 @@ hterm.Screen.prototype.syncSelectionCaret = function () {
 // fixes a bug in hterm, where the cursor goes back to `BLOCK`
 // after the bell rings
 const oldRingBell = hterm.Terminal.prototype.ringBell;
-hterm.Terminal.prototype.ringBell = function() {
+hterm.Terminal.prototype.ringBell = function () {
   oldRingBell.call(this);
   setTimeout(() => {
     this.restyleCursor_();

--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -1,5 +1,5 @@
 import {hterm, lib} from 'hterm-umdjs';
-import fromCharCode from './utils/key-code';
+// import fromCharCode from './utils/key-code';
 
 const selection = require('./utils/selection');
 
@@ -38,106 +38,106 @@ hterm.Terminal.prototype.copySelectionToClipboard = function () {
 
 // passthrough all the commands that are meant to control
 // hyper and not the terminal itself
-const oldKeyDown = hterm.Keyboard.prototype.onKeyDown_;
-hterm.Keyboard.prototype.onKeyDown_ = function (e) {
-  const modifierKeysConf = this.terminal.modifierKeys;
-
-  /**
-   * Add fixes for U.S. International PC Keyboard layout
-   * These keys are sent through as 'Dead' keys, as they're used as modifiers.
-   * Ignore that and insert the correct character.
-   */
-  if (e.key === 'Dead') {
-    if (e.code === 'Quote' && e.shiftKey === false) {
-      this.terminal.onVTKeystroke('\'');
-      return;
-    }
-    if (e.code === 'Quote' && e.shiftKey === true) {
-      this.terminal.onVTKeystroke('"');
-      return;
-    }
-    if ((e.code === 'IntlBackslash' || e.code === 'Backquote') && e.shiftKey === true) {
-      this.terminal.onVTKeystroke('~');
-      return;
-    }
-    // This key is also a tilde on all tested keyboards
-    if (e.code === 'KeyN' && e.altKey === true && modifierKeysConf.altIsMeta === false) {
-      this.terminal.onVTKeystroke('~');
-      return;
-    }
-    if ((e.code === 'IntlBackslash' || e.code === 'Backquote') && e.shiftKey === false) {
-      this.terminal.onVTKeystroke('`');
-      return;
-    }
-    if (e.code === 'Digit6') {
-      this.terminal.onVTKeystroke('^');
-      return;
-    }
-    // German keyboard layout
-    if (e.code === 'Equal' && e.shiftKey === false) {
-      this.terminal.onVTKeystroke('´');
-      return;
-    }
-    if (e.code === 'Equal' && e.shiftKey === true) {
-      this.terminal.onVTKeystroke('`');
-      return;
-    }
-    // Italian keyboard layout
-    if (e.code === 'Digit9' && e.altKey === true && modifierKeysConf.altIsMeta === false) {
-      this.terminal.onVTKeystroke('`');
-      return;
-    }
-    if (e.code === 'Digit8' && e.altKey === true && modifierKeysConf.altIsMeta === false) {
-      this.terminal.onVTKeystroke('´');
-      // To fix issue with changing the terminal prompt
-      e.preventDefault();
-      return;
-    }
-    // French keyboard layout
-    if (e.code === 'BracketLeft') {
-      this.terminal.onVTKeystroke('^');
-      return;
-    }
-    if (e.code === 'Backslash') {
-      this.terminal.onVTKeystroke('`');
-      return;
-    }
-    console.warn('Uncaught dead key on international keyboard', e);
-  }
-
-  if (e.altKey &&
-      e.which !== 16 && // Ignore other modifer keys
-      e.which !== 17 &&
-      e.which !== 18 &&
-      e.which !== 91 &&
-      modifierKeysConf.altIsMeta) {
-    const char = fromCharCode(e);
-    this.terminal.onVTKeystroke('\x1b' + char);
-    e.preventDefault();
-  }
-
-  if (e.metaKey &&
-      e.code !== 'MetaLeft' &&
-      e.code !== 'MetaRight' &&
-      e.which !== 16 &&
-      e.which !== 17 &&
-      e.which !== 18 &&
-      e.which !== 91 &&
-      modifierKeysConf.cmdIsMeta) {
-    const char = fromCharCode(e);
-    this.terminal.onVTKeystroke('\x1b' + char);
-    e.preventDefault();
-  }
-
-  if (e.metaKey || e.altKey || (e.ctrlKey && e.code === 'Tab')) {
-    return;
-  }
-  if ((!e.ctrlKey || e.code !== 'ControlLeft') && !e.shiftKey && e.code !== 'CapsLock') {
-    //  Test for valid keys in order to clear the terminal selection
-    selection.clear(this.terminal);
-  }
-  return oldKeyDown.call(this, e);
-};
+// const oldKeyDown = hterm.Keyboard.prototype.onKeyDown_;
+// hterm.Keyboard.prototype.onKeyDown_ = function (e) {
+//   const modifierKeysConf = this.terminal.modifierKeys;
+//
+//   /**
+//    * Add fixes for U.S. International PC Keyboard layout
+//    * These keys are sent through as 'Dead' keys, as they're used as modifiers.
+//    * Ignore that and insert the correct character.
+//    */
+//   if (e.key === 'Dead') {
+//     if (e.code === 'Quote' && e.shiftKey === false) {
+//       this.terminal.onVTKeystroke('\'');
+//       return;
+//     }
+//     if (e.code === 'Quote' && e.shiftKey === true) {
+//       this.terminal.onVTKeystroke('"');
+//       return;
+//     }
+//     if ((e.code === 'IntlBackslash' || e.code === 'Backquote') && e.shiftKey === true) {
+//       this.terminal.onVTKeystroke('~');
+//       return;
+//     }
+//     // This key is also a tilde on all tested keyboards
+//     if (e.code === 'KeyN' && e.altKey === true && modifierKeysConf.altIsMeta === false) {
+//       this.terminal.onVTKeystroke('~');
+//       return;
+//     }
+//     if ((e.code === 'IntlBackslash' || e.code === 'Backquote') && e.shiftKey === false) {
+//       this.terminal.onVTKeystroke('`');
+//       return;
+//     }
+//     if (e.code === 'Digit6') {
+//       this.terminal.onVTKeystroke('^');
+//       return;
+//     }
+//     // German keyboard layout
+//     if (e.code === 'Equal' && e.shiftKey === false) {
+//       this.terminal.onVTKeystroke('´');
+//       return;
+//     }
+//     if (e.code === 'Equal' && e.shiftKey === true) {
+//       this.terminal.onVTKeystroke('`');
+//       return;
+//     }
+//     // Italian keyboard layout
+//     if (e.code === 'Digit9' && e.altKey === true && modifierKeysConf.altIsMeta === false) {
+//       this.terminal.onVTKeystroke('`');
+//       return;
+//     }
+//     if (e.code === 'Digit8' && e.altKey === true && modifierKeysConf.altIsMeta === false) {
+//       this.terminal.onVTKeystroke('´');
+//       // To fix issue with changing the terminal prompt
+//       e.preventDefault();
+//       return;
+//     }
+//     // French keyboard layout
+//     if (e.code === 'BracketLeft') {
+//       this.terminal.onVTKeystroke('^');
+//       return;
+//     }
+//     if (e.code === 'Backslash') {
+//       this.terminal.onVTKeystroke('`');
+//       return;
+//     }
+//     console.warn('Uncaught dead key on international keyboard', e);
+//   }
+//
+//   if (e.altKey &&
+//       e.which !== 16 && // Ignore other modifer keys
+//       e.which !== 17 &&
+//       e.which !== 18 &&
+//       e.which !== 91 &&
+//       modifierKeysConf.altIsMeta) {
+//     const char = fromCharCode(e);
+//     this.terminal.onVTKeystroke('\x1b' + char);
+//     e.preventDefault();
+//   }
+//
+//   if (e.metaKey &&
+//       e.code !== 'MetaLeft' &&
+//       e.code !== 'MetaRight' &&
+//       e.which !== 16 &&
+//       e.which !== 17 &&
+//       e.which !== 18 &&
+//       e.which !== 91 &&
+//       modifierKeysConf.cmdIsMeta) {
+//     const char = fromCharCode(e);
+//     this.terminal.onVTKeystroke('\x1b' + char);
+//     e.preventDefault();
+//   }
+//
+//   if (e.metaKey || e.altKey || (e.ctrlKey && e.code === 'Tab')) {
+//     return;
+//   }
+//   if ((!e.ctrlKey || e.code !== 'ControlLeft') && !e.shiftKey && e.code !== 'CapsLock') {
+//     //  Test for valid keys in order to clear the terminal selection
+//     selection.clear(this.terminal);
+//   }
+//   return oldKeyDown.call(this, e);
+// };
 
 const oldKeyPress = hterm.Keyboard.prototype.onKeyPress_;
 hterm.Keyboard.prototype.onKeyPress_ = function (e) {

--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -178,8 +178,14 @@ hterm.Terminal.prototype.onHyperCaret = function (caret) {
   });
 
   // here we replicate the focus/blur state of our caret on the `hterm` caret
-  caret.addEventListener('focus', () => this.cursorNode_.setAttribute('focus', true));
-  caret.addEventListener('blur', () => this.cursorNode_.setAttribute('focus', false));
+  caret.addEventListener('focus', () => {
+    this.cursorNode_.setAttribute('focus', true);
+    this.restyleCursor_();
+  });
+  caret.addEventListener('blur', () => {
+    this.cursorNode_.setAttribute('focus', false)
+    this.restyleCursor_();
+  });
 
   // this is necessary because we need to access the `document_` and the hyperCaret
   // on `hterm.Screen.prototype.syncSelectionCaret`

--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -1,5 +1,5 @@
 import {hterm, lib} from 'hterm-umdjs';
-// import fromCharCode from './utils/key-code';
+import fromCharCode from './utils/key-code';
 
 const selection = require('./utils/selection');
 
@@ -38,106 +38,45 @@ hterm.Terminal.prototype.copySelectionToClipboard = function () {
 
 // passthrough all the commands that are meant to control
 // hyper and not the terminal itself
-// const oldKeyDown = hterm.Keyboard.prototype.onKeyDown_;
-// hterm.Keyboard.prototype.onKeyDown_ = function (e) {
-//   const modifierKeysConf = this.terminal.modifierKeys;
-//
-//   /**
-//    * Add fixes for U.S. International PC Keyboard layout
-//    * These keys are sent through as 'Dead' keys, as they're used as modifiers.
-//    * Ignore that and insert the correct character.
-//    */
-//   if (e.key === 'Dead') {
-//     if (e.code === 'Quote' && e.shiftKey === false) {
-//       this.terminal.onVTKeystroke('\'');
-//       return;
-//     }
-//     if (e.code === 'Quote' && e.shiftKey === true) {
-//       this.terminal.onVTKeystroke('"');
-//       return;
-//     }
-//     if ((e.code === 'IntlBackslash' || e.code === 'Backquote') && e.shiftKey === true) {
-//       this.terminal.onVTKeystroke('~');
-//       return;
-//     }
-//     // This key is also a tilde on all tested keyboards
-//     if (e.code === 'KeyN' && e.altKey === true && modifierKeysConf.altIsMeta === false) {
-//       this.terminal.onVTKeystroke('~');
-//       return;
-//     }
-//     if ((e.code === 'IntlBackslash' || e.code === 'Backquote') && e.shiftKey === false) {
-//       this.terminal.onVTKeystroke('`');
-//       return;
-//     }
-//     if (e.code === 'Digit6') {
-//       this.terminal.onVTKeystroke('^');
-//       return;
-//     }
-//     // German keyboard layout
-//     if (e.code === 'Equal' && e.shiftKey === false) {
-//       this.terminal.onVTKeystroke('´');
-//       return;
-//     }
-//     if (e.code === 'Equal' && e.shiftKey === true) {
-//       this.terminal.onVTKeystroke('`');
-//       return;
-//     }
-//     // Italian keyboard layout
-//     if (e.code === 'Digit9' && e.altKey === true && modifierKeysConf.altIsMeta === false) {
-//       this.terminal.onVTKeystroke('`');
-//       return;
-//     }
-//     if (e.code === 'Digit8' && e.altKey === true && modifierKeysConf.altIsMeta === false) {
-//       this.terminal.onVTKeystroke('´');
-//       // To fix issue with changing the terminal prompt
-//       e.preventDefault();
-//       return;
-//     }
-//     // French keyboard layout
-//     if (e.code === 'BracketLeft') {
-//       this.terminal.onVTKeystroke('^');
-//       return;
-//     }
-//     if (e.code === 'Backslash') {
-//       this.terminal.onVTKeystroke('`');
-//       return;
-//     }
-//     console.warn('Uncaught dead key on international keyboard', e);
-//   }
-//
-//   if (e.altKey &&
-//       e.which !== 16 && // Ignore other modifer keys
-//       e.which !== 17 &&
-//       e.which !== 18 &&
-//       e.which !== 91 &&
-//       modifierKeysConf.altIsMeta) {
-//     const char = fromCharCode(e);
-//     this.terminal.onVTKeystroke('\x1b' + char);
-//     e.preventDefault();
-//   }
-//
-//   if (e.metaKey &&
-//       e.code !== 'MetaLeft' &&
-//       e.code !== 'MetaRight' &&
-//       e.which !== 16 &&
-//       e.which !== 17 &&
-//       e.which !== 18 &&
-//       e.which !== 91 &&
-//       modifierKeysConf.cmdIsMeta) {
-//     const char = fromCharCode(e);
-//     this.terminal.onVTKeystroke('\x1b' + char);
-//     e.preventDefault();
-//   }
-//
-//   if (e.metaKey || e.altKey || (e.ctrlKey && e.code === 'Tab')) {
-//     return;
-//   }
-//   if ((!e.ctrlKey || e.code !== 'ControlLeft') && !e.shiftKey && e.code !== 'CapsLock') {
-//     //  Test for valid keys in order to clear the terminal selection
-//     selection.clear(this.terminal);
-//   }
-//   return oldKeyDown.call(this, e);
-// };
+const oldKeyDown = hterm.Keyboard.prototype.onKeyDown_;
+hterm.Keyboard.prototype.onKeyDown_ = function (e) {
+  const modifierKeysConf = this.terminal.modifierKeys;
+
+  if (e.altKey &&
+      e.which !== 16 && // Ignore other modifer keys
+      e.which !== 17 &&
+      e.which !== 18 &&
+      e.which !== 91 &&
+      modifierKeysConf.altIsMeta) {
+    const char = fromCharCode(e);
+    this.terminal.onVTKeystroke('\x1b' + char);
+    e.preventDefault();
+  }
+
+  if (e.metaKey &&
+      e.code !== 'MetaLeft' &&
+      e.code !== 'MetaRight' &&
+      e.which !== 16 &&
+      e.which !== 17 &&
+      e.which !== 18 &&
+      e.which !== 91 &&
+      modifierKeysConf.cmdIsMeta) {
+    const char = fromCharCode(e);
+    this.terminal.onVTKeystroke('\x1b' + char);
+    e.preventDefault();
+  }
+
+  if (e.metaKey || e.altKey || (e.ctrlKey && e.code === 'Tab')) {
+    return;
+  }
+  if ((!e.ctrlKey || e.code !== 'ControlLeft') &&
+      !e.shiftKey && e.code !== 'CapsLock' &&
+      e.key !== 'Dead') {
+    //  Test for valid keys in order to clear the terminal selection
+    selection.clear(this.terminal);
+  }
+  return oldKeyDown.call(this, e);
+};
 
 const oldKeyPress = hterm.Keyboard.prototype.onKeyPress_;
 hterm.Keyboard.prototype.onKeyPress_ = function (e) {

--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -160,7 +160,7 @@ hterm.Terminal.prototype.onHyperCaret = function (caret) {
     ongoingComposition = true;
   });
 
-  // we can ignore `compositionstart` since chromium always fire it with '' 
+  // we can ignore `compositionstart` since chromium always fire it with ''
   caret.addEventListener('compositionupdate', () => {
     this.cursorNode_.style.backgroundColor = 'yellow';
     this.cursorNode_.style.borderColor = 'yellow';

--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -154,8 +154,13 @@ hterm.ScrollPort.prototype.setBackgroundColor = function () {
 // will be called by the <Term/> right after the `hterm.Terminal` is instantiated
 hterm.Terminal.prototype.onHyperCaret = function (caret) {
   this.hyperCaret = caret;
+  let ongoingComposition = false;
 
-  // we can ignore `compositionstart` since chromium always fire it with ''
+  caret.addEventListener('compositionstart', () => {
+    ongoingComposition = true;
+  });
+
+  // we can ignore `compositionstart` since chromium always fire it with '' 
   caret.addEventListener('compositionupdate', () => {
     this.cursorNode_.style.backgroundColor = 'yellow';
     this.cursorNode_.style.borderColor = 'yellow';
@@ -163,10 +168,29 @@ hterm.Terminal.prototype.onHyperCaret = function (caret) {
 
   // at this point the char(s) is ready
   caret.addEventListener('compositionend', () => {
+    ongoingComposition = false;
     this.cursorNode_.style.backgroundColor = '';
     this.setCursorShape(this.getCursorShape());
     this.cursorNode_.style.borderColor = this.getCursorColor();
     caret.innerText = '';
+  });
+
+  // if you open the `Emoji & Symbols` (ctrl+cmd+space)
+  // and select an emoji, it'll be inserted into our caret
+  // and stay there until you star a compositon event.
+  // to avoid that, we'll just check if there's an ongoing
+  // compostion event. if there's one, we do nothing.
+  // otherwise, we just remove the emoji and stop the event
+  // propagation.
+  // PS: this event will *not* be fired when a standard char
+  // (a, b, c, 1, 2, 3, etc) is typed – only for composed
+  // ones and `Emoji & Symbols`
+  caret.addEventListener('input', e => {
+    if (!ongoingComposition) {
+      caret.innerText = '';
+      e.stopPropagation();
+      e.preventDefault();
+    }
   });
 
   // we need to capture pastes, prevent them and send its contents to the terminal


### PR DESCRIPTION
![kapture 2016-11-16 at 15 22 03](https://cloud.githubusercontent.com/assets/4721750/20357784/75e126d8-ac10-11e6-8aa8-1f6550043f48.gif)

## Summary

This PR introduces an attempt to fix all the following issues:

Major:
* **Users on some "foreign" keyboard layouts (Portuguese and Norwegian, for example) weren't able to type characters like `~`, `'`, `"` and so on**
* **Characters that need a composition event couldn't be typed – `á`, `é`, `ü` and so on**

Minor:
* After the bell, the cursor would go back to a `BLOCK` – #674 
* Selecting pane on blurred window requires two clicks – #861 

Other than that, this changes _should_ fix the following:
* Some people can't paste unless Hyper receives a click – #897
* Issues with copy-pasting – #484 #479 

## Prebuilt binaries

Check [here] for a `.dmg`, a `.exe`, a `.deb` and a `.rpm` 😄

## How

The work I did on this PR was just an improvement on top of @rauchg's [method] – huge thanks to him for developing it! Also, thanks @nfcampos for your work on #214 🙌 

We inject a `hyper-caret` div that has `contenteditable="true"` inside `hterm`'s cursor. With that, we're able to show an intermediate state of composition – so you can see (and type) the character you want. 
When the char is ready, `hterm` automatically captures it – that means we only need to worry about showing that intermediate state.

Closes #29; Closes #66; Closes #466; Closes #518; Closes #579;

[method]: https://github.com/zeit/hyper/commit/6ef13a2c3b525910250bc86f252eb3dc5f0f8744
[here]: https://drive.google.com/drive/folders/0BzynZtaOcjwMNGVaVlFXeFBwdFE?usp=sharing