### PR TITLE
Fix a bug related to the alpha hex calculation

### DIFF
--- a/app/utils/to-electron-background-color.js
+++ b/app/utils/to-electron-background-color.js
@@ -8,6 +8,8 @@ module.exports = bgColor => {
   if (color.alpha() === 1) {
     return color.hexString();
   }
-  // (╯°□°）╯︵ ┻━┻
-  return '#' + Math.floor(color.alpha() * 100) + color.hexString().substr(1);
+
+  // http://stackoverflow.com/a/11019879/1202488
+  const alphaHex = Math.round(color.alpha() * 255).toString(16);
+  return '#' + alphaHex + color.hexString().substr(1);
 };


### PR DESCRIPTION
I was running into an issue on OSX, where I'd set the backgroundColor to something like `'rgba(0, 0, 0, 0.8)'`, and everything would look great, until I closed Hyper, and re-opened it. Once I did that, it would still have transparency, but it'd be more transparent.

I tracked this down to the change I made. Basically, what was being done before is `0.8` would be converted to the decimal number 80, which is not correct. What should happen is that `0.8` should be a percentage of 100% opacity, which is 255, then converted to a hex string (via `toString(16)`). Hopefully that makes sense.

I'm not 100% sure, but I think this might also resolve #873, but I'd need @Lindenk to confirm.

