### PR TITLE
Added condition for update failing (FEED_URL)

### DIFF
--- a/app/auto-updater.js
+++ b/app/auto-updater.js
@@ -10,6 +10,9 @@ const platform = process.platform === 'darwin' ?
   'osx' :
   process.platform;
 const FEED_URL = `https://hyper-updates.now.sh/update/${platform}`;
+if (FEED_URL = false) {
+  console.error('Error while looking for updates. Website is not available.')
+}
 let isInit = false;
 
 function init() {


### PR DESCRIPTION
I thought it would be nice some return from Hyper when failing the update searching process, so I added an condition to check if the website returned some package. If not, the console.error will appear. Simple as that. =)