### PR TITLE
Fix Unicode normalization on macOS

### DIFF
--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -59,6 +59,8 @@ hterm.Terminal.IO.prototype.writeUTF8 = function (string) {
   }
 
   if (containsNonLatinCodepoints(string)) {
+    string = string.normalize('NFC');
+
     const splitString = runes(string);
     const length = splitString.length;
     this.terminal_.getTextAttributes().hasUnicode = true;


### PR DESCRIPTION
This is an fix for #586.

Incorrect rendering before normalization (current behavior):
![2016-12-01 4 27 56](https://cloud.githubusercontent.com/assets/1373527/20785669/bc0ea254-b7e4-11e6-930c-7626c035086d.png)

and correct rendering with normalization:
![2016-12-01 4 28 19](https://cloud.githubusercontent.com/assets/1373527/20785671/bd3012e4-b7e4-11e6-81fd-62cbef2a56e7.png)

I just met with this nice terminal and haven't look at the codebase deeply.
So adding normalization here may not be appropriate. There may be an unexpected side effects.
Honestly, I'm not sure.

