### PR TITLE
Specify cols key when spawning pty shell

### DIFF
--- a/app/session.js
+++ b/app/session.js
@@ -36,7 +36,7 @@ module.exports = class Session extends EventEmitter {
 
     try {
       this.pty = spawn(shell || defaultShell, shellArgs || defaultShellArgs, {
-        columns,
+        cols: columns,
         rows,
         cwd,
         env: getDecoratedEnv(baseEnv)


### PR DESCRIPTION
<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`

Thanks, again! -->

The column size param in pty.js is named ‘cols’, but the shorthand notation treats it as ‘columns’, causing the column count to not be correct.

I was seeing the issue described in zeit/hyper#1030 both on Mac and PC, and this fixed the issue.