### PR TITLE
Use homedir() from os package instead of env vars

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -25,6 +25,7 @@ if (process.platform === 'win32') {
 
 // Native
 const {resolve, isAbsolute} = require('path');
+const {homedir} = require('os');
 
 // Packages
 const {parse: parseUrl} = require('url');
@@ -203,7 +204,7 @@ app.on('ready', () => installDevExtensions(isDev).then(() => {
       }
     });
 
-    rpc.on('new', ({rows = 40, cols = 100, cwd = process.argv[1] && isAbsolute(process.argv[1]) ? process.argv[1] : process.env.HOMEPATH || process.env.HOME, splitDirection}) => {
+    rpc.on('new', ({rows = 40, cols = 100, cwd = process.argv[1] && isAbsolute(process.argv[1]) ? process.argv[1] : homedir(), splitDirection}) => {
       const shell = cfg.shell;
       const shellArgs = cfg.shellArgs && Array.from(cfg.shellArgs);
 


### PR DESCRIPTION
I was seeing the issue described in zeit/hyper#1039 on a Windows machine, and it seemed to start happening after 0c30fc0bcfe1b6667b958896bf0bdbf801afe077 (where HOME and HOMEPATH were reversed). In any case, switching to use os.homedir() in place of the environmental variables worked for me.