### PR TITLE
Unicode magic

### DIFF
--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -231,6 +231,9 @@ export default class Term extends Component {
       .cursor-node[focus="false"] {
          border-width: 1px !important;
       }
+      x-row {
+        line-height: 1em;
+      }
       ${hyperCaret}
       ${osSpecificCss}
       ${css}


### PR DESCRIPTION
Fix line height for `x-row` containing emoji.

Fixes #154 
