### PR TITLE
🙌 cmd+A

### DIFF
--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -15,9 +15,13 @@ const containers = [];
 
 // Provide selectAll to terminal viewport
 hterm.Terminal.prototype.selectAll = function () {
-  // We need to clear the DOM range to reset anchorNode
-  selection.clear(this);
-  selection.all(this);
+  // If the cursorNode_ having hyperCaret we need to remove it
+  if (this.cursorNode_.contains(this.hyperCaret)) {
+    this.cursorNode_.removeChild(this.hyperCaret);
+    // We need to clear the DOM range to reset anchorNode
+    selection.clear(this);
+    selection.all(this);
+  }
 };
 
 const oldSetFontSize = hterm.Terminal.prototype.setFontSize;
@@ -218,6 +222,10 @@ hterm.Terminal.prototype.copySelectionToClipboard = function () {
 // hyper and not the terminal itself
 const oldKeyDown = hterm.Keyboard.prototype.onKeyDown_;
 hterm.Keyboard.prototype.onKeyDown_ = function (e) {
+  // Was the hyperCaret removed for selectAll
+  if (!this.terminal.cursorNode_.contains(this.hyperCaret)) {
+    this.terminal.focusHyperCaret();
+  }
   const modifierKeysConf = this.terminal.modifierKeys;
 
   if (e.altKey &&


### PR DESCRIPTION
`focusHyperCaret` made cmd+A not working by stealing the focus and by adding the `hyperCaret`