### PR TITLE
Use the same accelerator as iterm for navigation between split panes

### DIFF
--- a/app/accelerators.js
+++ b/app/accelerators.js
@@ -41,8 +41,8 @@ const applicationMenu = { // app/menu.js
   minimize: 'M',
   showPreviousTab: 'Alt+Left',
   showNextTab: 'Alt+Right',
-  selectNextPane: 'Ctrl+Alt+Tab',
-  selectPreviousPane: 'Ctrl+Shift+Alt+Tab',
+  selectNextPane: isMac ? ']' : 'Ctrl+Alt+]',
+  selectPreviousPane: isMac ? '[' : 'Ctrl+Alt+[',
   enterFullScreen: isMac ? 'Ctrl+Cmd+F' : 'F11'
 };
 


### PR DESCRIPTION
<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`

Thanks, again! -->

This fixes `Cmd+] and Cmd+[ navigates among split panes in order of use` in #828. Should be ready to be merged, but I am not sure if the linux accelerator is the ideal one, can you please verify this?
