### PR TITLE
Open Preferences in Default JS Editor on Windows

### DIFF
--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -213,12 +213,11 @@ function getDefaultJsEditor() {
     if (err) {
       // In case of error, return default editor
       return 'notepad.exe';
-    } else {
-      // Default is "C:\Windows\System32\Notepad.exe %1"
-      entry = entry.substring(0, entry.indexOf(' %1'));
-      entry = entry.substring(entry.lastIndexOf('\\'), entry.length);
-      return entry;
-    }
+    } 
+    // Default is "C:\Windows\System32\Notepad.exe %1"
+    entry = entry.substring(0, entry.indexOf(' %1'));
+    entry = entry.substring(entry.lastIndexOf('\\'), entry.length);
+    return entry;
   });
 }
 

--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -1,5 +1,5 @@
 import os from 'os';
-import shell from 'electron';
+import {shell} from 'electron';
 import path from 'path';
 
 import * as shellEscape from 'php-escape-shell';

--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -213,7 +213,7 @@ function getDefaultJsEditor() {
     if (err) {
       // In case of error, return default editor
       return 'notepad.exe';
-    } 
+    }
     // Default is "C:\Windows\System32\Notepad.exe %1"
     entry = entry.substring(0, entry.indexOf(' %1'));
     entry = entry.substring(entry.lastIndexOf('\\'), entry.length);

--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -1,4 +1,4 @@
-import {EOL} from 'os';
+import os from 'os';
 
 import * as shellEscape from 'php-escape-shell';
 import last from '../utils/array';
@@ -29,10 +29,10 @@ import {
 } from '../constants/ui';
 
 import {setActiveGroup} from './term-groups';
+import {shell} from 'electron';
+import path from 'path';
 
 const {stat} = window.require('fs');
-const {shell} = window.require('electron');
-const {Registry} = window.require('winreg');
 
 export function increaseFontSize() {
   return (dispatch, getState) => {
@@ -204,69 +204,16 @@ export function moveTo(i) {
   };
 }
 
-function getDefaultJsEditor() {
-  const regKey = '\\JSFile\\Shell\\Edit\\Command';
-  new Registry({
-    hive: 'HKCR',
-    key: regKey
-  }).get(Registry.DEFAULT_VALUE, (err, entry) => {
-    if (err) {
-      // In case of error, return default editor
-      return 'notepad.exe';
-    }
-    // Default is "C:\Windows\System32\Notepad.exe %1"
-    entry = entry.substring(0, entry.indexOf(' %1'));
-    entry = entry.substring(entry.lastIndexOf('\\'), entry.length);
-    return entry;
-  });
-}
-
 export function showPreferences() {
-  const isWin = process.platform === 'win32';
-  // eslint-disable-next-line no-template-curly-in-string
-  let command = ' bash -c \'exec env ${EDITOR:=nano} ~/.hyper.js\'';
-  let handled = false;
-
-  if (isWin) {
-    const jsEditor = getDefaultJsEditor();
-    if (!jsEditor || jsEditor.toLowerCase() === 'notepad.exe') {
-      handled = true;
-      shell.showItemInFolder('%userprofile%\\.hyper.js');
-    } else {
-      // eslint-disable-next-line no-template-curly-in-string
-      command = ' start ${jsEditor} "%userprofile%\\.hyper.js"';
-    }
-  }
-
-  if (!handled) {
-    const message = [];
-    message.push(isWin ?
-      ' echo Attempting to open ^%userprofile^%\\.hyper.js with your default JS editor' :
-      ' echo Attempting to open ~/.hyper.js with your \\$EDITOR');
-    message.push(' echo If it fails, open it manually with your favorite editor!');
-
-    return dispatch => {
-      dispatch({
-        type: UI_SHOW_PREFERENCES,
-        effect() {
-          dispatch(requestSession());
-          // Replace this hack with an async action
-          rpc.once('session add', ({uid}) => {
-            rpc.once('session data', () => {
-              dispatch(sendSessionData(
-                uid,
-                [
-                  ...message,
-                  command,
-                  ''
-                ].join(EOL)
-              ));
-            });
-          });
-        }
-      });
-    };
-  }
+  return dispatch => {
+    dispatch({
+      type: UI_SHOW_PREFERENCES,
+      effect() {
+        dispatch(
+          shell.showItemInFolder(path.join(os.homedir(), '.hyper.js')));
+      }
+    });
+  };
 }
 
 export function windowMove() {

--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -1,4 +1,6 @@
 import os from 'os';
+import shell from 'electron';
+import path from 'path';
 
 import * as shellEscape from 'php-escape-shell';
 import last from '../utils/array';
@@ -29,8 +31,6 @@ import {
 } from '../constants/ui';
 
 import {setActiveGroup} from './term-groups';
-import {shell} from 'electron';
-import path from 'path';
 
 const {stat} = window.require('fs');
 

--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -31,6 +31,7 @@ import {
 import {setActiveGroup} from './term-groups';
 
 const {stat} = window.require('fs');
+const Registry = window.require('winreg');
 
 export function increaseFontSize() {
   return (dispatch, getState) => {
@@ -202,37 +203,70 @@ export function moveTo(i) {
   };
 }
 
+function getDefaultJsEditor() {
+  const regKey = "\\JSFile\\Shell\\Edit\\Command";
+  new Registry({
+    hive: 'HKCR',
+    key: regKey
+  }).get(Registry.DEFAULT_VALUE, (err, entry) => {
+    if(!err) {
+      // Default is "C:\Windows\System32\Notepad.exe %1"
+      entry = entry.substring(0, entry.indexOf(' %1'));
+      entry = entry.substring(entry.lastIndexOf("\\"),entry.length);
+      return entry;
+    } else {
+      // In case of error, return default editor
+      return "notepad.exe";
+    }
+  });
+}
+
 export function showPreferences() {
   const isWin = process.platform === 'win32';
-  // eslint-disable-next-line no-template-curly-in-string
-  const command = isWin ? ' start wordpad "%userprofile%\\.hyper.js"' : ' bash -c \'exec env ${EDITOR:=nano} ~/.hyper.js\'';
-  const message = [];
-  message.push(isWin ?
-    ' echo Attempting to open ^%userprofile^%\\.hyper.js with wordpad' :
-    ' echo Attempting to open ~/.hyper.js with your \\$EDITOR');
-  message.push(' echo If it fails, open it manually with your favorite editor!');
+  // eslint-disable-next-line no-template-curly-in-string  
+  var command = ' bash -c \'exec env ${EDITOR:=nano} ~/.hyper.js\'';
+  var handled = false;
 
-  return dispatch => {
-    dispatch({
-      type: UI_SHOW_PREFERENCES,
-      effect() {
-        dispatch(requestSession());
-        // Replace this hack with an async action
-        rpc.once('session add', ({uid}) => {
-          rpc.once('session data', () => {
-            dispatch(sendSessionData(
-              uid,
-              [
-                ...message,
-                command,
-                ''
-              ].join(EOL)
-            ));
+  if(isWin) {
+    const jsEditor = getDefaultJsEditor();
+    if(!jsEditor || jsEditor.toLowerCase() === "notepad.exe") {
+      handled = true;
+      shell.showItemInFolder('%userprofile%\\.hyper.js');
+    } else {
+      // eslint-disable-next-line no-template-curly-in-string  
+      command = ' start ${jsEditor} "%userprofile%\\.hyper.js"';
+    }
+  }
+
+  if(!handled) {
+    const message = [];
+    message.push(isWin ?
+      ' echo Attempting to open ^%userprofile^%\\.hyper.js with your default JS editor' :
+      ' echo Attempting to open ~/.hyper.js with your \\$EDITOR');
+    message.push(' echo If it fails, open it manually with your favorite editor!');
+
+    return dispatch => {
+      dispatch({
+        type: UI_SHOW_PREFERENCES,
+        effect() {
+          dispatch(requestSession());
+          // Replace this hack with an async action
+          rpc.once('session add', ({uid}) => {
+            rpc.once('session data', () => {
+              dispatch(sendSessionData(
+                uid,
+                [
+                  ...message,
+                  command,
+                  ''
+                ].join(EOL)
+              ));
+            });
           });
-        });
-      }
-    });
-  };
+        }
+      });
+    };
+  }
 }
 
 export function windowMove() {

--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -31,7 +31,8 @@ import {
 import {setActiveGroup} from './term-groups';
 
 const {stat} = window.require('fs');
-const Registry = window.require('winreg');
+const {shell} = window.require('electron');
+const {Registry} = window.require('winreg');
 
 export function increaseFontSize() {
   return (dispatch, getState) => {
@@ -204,41 +205,41 @@ export function moveTo(i) {
 }
 
 function getDefaultJsEditor() {
-  const regKey = "\\JSFile\\Shell\\Edit\\Command";
+  const regKey = '\\JSFile\\Shell\\Edit\\Command';
   new Registry({
     hive: 'HKCR',
     key: regKey
   }).get(Registry.DEFAULT_VALUE, (err, entry) => {
-    if(!err) {
+    if (err) {
+      // In case of error, return default editor
+      return 'notepad.exe';
+    } else {
       // Default is "C:\Windows\System32\Notepad.exe %1"
       entry = entry.substring(0, entry.indexOf(' %1'));
-      entry = entry.substring(entry.lastIndexOf("\\"),entry.length);
+      entry = entry.substring(entry.lastIndexOf('\\'), entry.length);
       return entry;
-    } else {
-      // In case of error, return default editor
-      return "notepad.exe";
     }
   });
 }
 
 export function showPreferences() {
   const isWin = process.platform === 'win32';
-  // eslint-disable-next-line no-template-curly-in-string  
-  var command = ' bash -c \'exec env ${EDITOR:=nano} ~/.hyper.js\'';
-  var handled = false;
+  // eslint-disable-next-line no-template-curly-in-string
+  let command = ' bash -c \'exec env ${EDITOR:=nano} ~/.hyper.js\'';
+  let handled = false;
 
-  if(isWin) {
+  if (isWin) {
     const jsEditor = getDefaultJsEditor();
-    if(!jsEditor || jsEditor.toLowerCase() === "notepad.exe") {
+    if (!jsEditor || jsEditor.toLowerCase() === 'notepad.exe') {
       handled = true;
       shell.showItemInFolder('%userprofile%\\.hyper.js');
     } else {
-      // eslint-disable-next-line no-template-curly-in-string  
+      // eslint-disable-next-line no-template-curly-in-string
       command = ' start ${jsEditor} "%userprofile%\\.hyper.js"';
     }
   }
 
-  if(!handled) {
+  if (!handled) {
     const message = [];
     message.push(isWin ?
       ' echo Attempting to open ^%userprofile^%\\.hyper.js with your default JS editor' :

--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -205,10 +205,10 @@ export function moveTo(i) {
 export function showPreferences() {
   const isWin = process.platform === 'win32';
   // eslint-disable-next-line no-template-curly-in-string
-  const command = isWin ? ' start notepad "%userprofile%\\.hyper.js"' : ' bash -c \'exec env ${EDITOR:=nano} ~/.hyper.js\'';
+  const command = isWin ? ' start wordpad "%userprofile%\\.hyper.js"' : ' bash -c \'exec env ${EDITOR:=nano} ~/.hyper.js\'';
   const message = [];
   message.push(isWin ?
-    ' echo Attempting to open ^%userprofile^%\\.hyper.js with notepad' :
+    ' echo Attempting to open ^%userprofile^%\\.hyper.js with wordpad' :
     ' echo Attempting to open ~/.hyper.js with your \\$EDITOR');
   message.push(' echo If it fails, open it manually with your favorite editor!');
 


### PR DESCRIPTION
Notepad doesn't handle `\n` line breaks, so config file is unreadable. 

Updated PR does the following:
* If not Windows, follows same logic as before
* If Windows, checks for default JS editor. If set and not notepad, opens hyper.js in default JS editor.
* If default JS editor not set or notepad, shows file in folder using electron shell command.

PR is ready to be merged, I'm not aware of any related PRs, and you're free to edit in any way.

Fixes #1126.