### PR TITLE
Add support for the fish shell

### DIFF
--- a/app/plugins.js
+++ b/app/plugins.js
@@ -236,7 +236,15 @@ function install(fn) {
     env.npm_config_target = process.versions.electron;
     env.npm_config_disturl = 'https://atom.io/download/atom-shell';
     /* eslint-enable camelcase  */
-    exec('npm prune && npm install --production', {
+    // Shell-specific installation commands
+    const installCommands = {
+      fish: 'npm prune; and npm install --production',
+      default: 'npm prune && npm install --production'
+    };
+    // determine the shell we're running in
+    const whichShell = shell.match(/fish/) ? 'fish' : 'default';
+    // Use the install command that is appropriate for our shell
+    exec(installCommands[whichShell], {
       cwd: path,
       env,
       shell

--- a/app/plugins.js
+++ b/app/plugins.js
@@ -239,10 +239,10 @@ function install(fn) {
     // Shell-specific installation commands
     const installCommands = {
       fish: 'npm prune; and npm install --production',
-      default: 'npm prune && npm install --production'
+      posix: 'npm prune && npm install --production'
     };
     // determine the shell we're running in
-    const whichShell = shell.match(/fish/) ? 'fish' : 'default';
+    const whichShell = shell.match(/fish/) ? 'fish' : 'posix';
     // Use the install command that is appropriate for our shell
     exec(installCommands[whichShell], {
       cwd: path,


### PR DESCRIPTION
Fixes #1142

The fish shell is not POSIX-compliant.  As a result, the installation
command's use of `&&` caused `updatePlugins` to fail, erroneously
claiming there would be details in `~/.hyper_plugins/npm-debug.log`.

They of course weren't there because the command it tried to run was an
invalid command.  I've added an object to choose the install command to
run based on the shell you're in, and a very basic test to determine if
we're in fish.  Most shells should be able to be handled by the
'default' key, so for now it just checks to see if it's fish by doing a
regex on the configured `shell` option.