### PR TITLE
Keyboard shortcut prefix fix for Windows, Linux (Ctrl+Shift). Fixes #1069.

### DIFF
--- a/app/accelerators.js
+++ b/app/accelerators.js
@@ -2,7 +2,7 @@ const platform = process.platform;
 
 const isMac = platform === 'darwin';
 
-const prefix = isMac ? 'Cmd' : 'Ctrl';
+const prefix = isMac ? 'Cmd' : 'Ctrl+Shift';
 
 const applicationMenu = { // app/menu.js
   preferences: ',',
@@ -11,16 +11,16 @@ const applicationMenu = { // app/menu.js
   // Shell/File menu
   newWindow: 'N',
   newTab: 'T',
-  splitVertically: isMac ? 'D' : 'Shift+E',
-  splitHorizontally: isMac ? 'Shift+D' : 'Shift+O',
+  splitVertically: 'D',
+  splitHorizontally: isMac ? 'Shift+D' : 'E',
   closeSession: 'W',
-  closeWindow: 'Shift+W',
+  closeWindow: isMac ? 'Shift+W' : 'Q',
 
   // Edit menu
   undo: 'Z',
-  redo: 'Shift+Z',
+  redo: isMac ? 'Shift+Z' : 'Y',
   cut: 'X',
-  copy: isMac ? 'C' : 'Shift+C',
+  copy: 'C',
   paste: 'V',
   selectAll: 'A',
   clear: 'K',
@@ -28,21 +28,21 @@ const applicationMenu = { // app/menu.js
 
   // View menu
   reload: 'R',
-  fullReload: 'Shift+R',
-  toggleDevTools: isMac ? 'Alt+I' : 'Shift+I',
+  fullReload: isMac ? 'Shift+R' : 'F5',
+  toggleDevTools: isMac ? 'Alt+I' : 'I',
   resetZoom: '0',
   zoomIn: 'plus',
   zoomOut: '-',
 
   // Plugins menu
-  updatePlugins: 'Shift+U',
+  updatePlugins: isMac ? 'Shift+U' : 'U',
 
   // Window menu
   minimize: 'M',
   showPreviousTab: 'Alt+Left',
   showNextTab: 'Alt+Right',
   selectNextPane: 'Ctrl+Alt+Tab',
-  selectPreviousPane: 'Ctrl+Shift+Alt+Tab',
+  selectPreviousPane: isMac ? 'Ctrl+Shift+Alt+Tab' : 'Ctrl+Z+Alt+Tab',
   enterFullScreen: isMac ? 'Ctrl+Cmd+F' : 'F11'
 };
 
@@ -58,13 +58,13 @@ const mousetrap = { // lib/containers/hyper.js
   moveToLast: '9',
 
   // here `1`, `2` etc are used to "emulate" something like `moveLeft: ['...', '...', etc]`
-  moveLeft1: 'Shift+Left',
-  moveRight1: 'Shift+Right',
-  moveLeft2: 'Shift+{',
-  moveRight2: 'Shift+}',
+  moveLeft1: isMac ? 'Shift+Left' : 'Z+Left',
+  moveRight1: isMac ? 'Shift+Right' : 'Z+Right',
+  moveLeft2: isMac ? 'Shift+{' : '{',
+  moveRight2: isMac ? 'Shift+}' : '}',
   moveLeft3: 'Alt+Left',
   moveRight3: 'Alt+Right',
-  moveLeft4: 'Ctrl+Shift+Tab',
+  moveLeft4: isMac ? 'Ctrl+Shift+Tab' : 'Z+Tab',
   moveRight4: 'Ctrl+Tab',
 
   // here we add `+` at the beginning to prevent the prefix from being added

--- a/app/accelerators.js
+++ b/app/accelerators.js
@@ -39,8 +39,8 @@ const applicationMenu = { // app/menu.js
 
   // Window menu
   minimize: 'M',
-  showPreviousTab: 'Alt+Left',
-  showNextTab: 'Alt+Right',
+  showPreviousTab: isMac ? 'Alt+Left' : '+Ctrl+PageDown',
+  showNextTab: isMac ? 'Alt+Right' : '+Ctrl+PageUp',
   selectNextPane: 'Ctrl+Alt+Tab',
   selectPreviousPane: isMac ? 'Ctrl+Shift+Alt+Tab' : 'Ctrl+Z+Alt+Tab',
   enterFullScreen: isMac ? 'Ctrl+Cmd+F' : 'F11'
@@ -68,8 +68,8 @@ const mousetrap = { // lib/containers/hyper.js
   moveRight4: 'Ctrl+Tab',
 
   // here we add `+` at the beginning to prevent the prefix from being added
-  moveWordLeft: '+Alt+Left',
-  moveWordRight: '+Alt+Right',
+  moveWordLeft: isMac ? '+Alt+Left' : '+Ctrl+Left',
+  moveWordRight: isMac ? '+Alt+Right' : '+Ctrl+Right',
   deleteWordLeft: '+Alt+Backspace',
   deleteWordRight: '+Alt+Delete',
   deleteLine: 'Backspace',


### PR DESCRIPTION
This pull request fixes #1069 (and related issues like #1100).

### Overview

Interactive command line applications commonly bind to <kbd>Ctrl</kbd>+<kbd>&lt;key&gt;</kbd> keyboard shortcuts. For example, `nano` uses <kbd>Ctrl</kbd>+(<kbd>G</kbd>, <kbd>O</kbd>, <kbd>W</kbd>, <kbd>K</kbd>, <kbd>J</kbd>, <kbd>C</kbd>, <kbd>X</kbd>, <kbd>R</kbd>, <kbd>\\</kbd>, <kbd>U</kbd>, <kbd>T</kbd>, <kbd>_</kbd>, <kbd>V</kbd>) for essential functionality like reading and writing files and exiting the program. Other applications are similar, like `tmux` and `screen`, relying on keyboard shortcuts to manage the program's basic functionality.

This isn't an issue when using `hyper` on Macs, as the modifier prefix for interacting with the `hyper` windows is <kbd>Cmd</kbd>. On non-Macs (like Windows and Linux machines), the default prefix is `Ctrl`, which causes many conflicts.

This pull request proposes to address these conflicts by setting the default prefix on non-Macs to <kbd>Ctrl</kbd>+<kbd>Shift</kbd>, which is common for terminal emulators in linux. The <kbd>Super</kbd> key has been suggested as an alternative, but this would conflict with several shortcuts built into the Windows OS as well as many linux-focused desktop environment like Unity and Gnome. To avoid conflicts with defaults that already used <kbd>Ctrl</kbd>+<kbd>Shift</kbd>, some shortcuts were changed to (hopefully) reasonable alternatives. This pull request does not change any shortcuts on Macs.

### Summary of changes

1. Default shortcut prefix on non-Macs changed from <kbd>Ctrl</kbd> to <kbd>Ctrl</kbd>+<kbd>Shift</kbd>.

2. Some shortcuts that already used <kbd>Ctrl</kbd>+<kbd>Shift</kbd> were changed to be more similar to their Mac counterparts:
    - split vertically was changed from <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>E</kbd> to <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>D</kbd>

3. Some shortcuts already used <kbd>Ctrl</kbd>+<kbd>Shift</kbd> and are unchanged
    - copy is <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>C</kbd>
    - devtools is <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>I</kbd>
    - update plugins is <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>U</kbd>
    - `moveLeft2` and `moveRight2` are <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>{</kbd> and <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>}</kbd>

4. Some shortcuts were changed to (hopefully) reasonable alternatives
   - split horizontally was changed from <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>O</kbd> to <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>E</kbd>
    - redo was changed from <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Z</kbd> (now undo) to <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Y</kbd>
    - closing the entire window was changed from <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>W</kbd> (now close tab) to <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Q</kbd>
    - full reload was changed from <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>R</kbd> (now reload) to <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>F5</kbd>

5. I didn't know what to do with some of the shortcuts, so in those cases I replaced <kbd>Shift</kbd> with Z (please review/change!)
    - previous pane was changed from <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Alt</kbd>+<kbd>Tab</kbd> to <kbd>Ctrl</kbd>+<kbd>Z</kbd>+<kbd>Alt</kbd>+<kbd>Tab</kbd>.
    - `moveLeft1` was changed from <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Left</kbd> to <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Z</kbd>+<kbd>Left</kbd>
    - `moveRight1` was changed from <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Right</kbd> to <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Z</kbd>+<kbd>Right</kbd>
    - `moveLeft4` was changed from <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Tab</kbd> to <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Z</kbd>+<kbd>Tab</kbd>

One of the shortcuts in that last case already involved five simultaneous keypresses, even on a Mac, so I'll humbly suggest it be switched to something else entirely!

I was unable to test whether the `undo` functionality was broken by using <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Z</kbd>+<kbd>&lt;key&gt;</kbd>. I'm not actually sure what `undo` is supposed to do in `hyper` (or the moveLeft1/2/3/4 options). Are they bound to any actions?

It may also be worthwhile to review Atom's shortcuts for linux + windows for better defaults. Windows version here https://github.com/atom/atom/blob/master/keymaps/win32.cson and linux version here https://github.com/atom/atom/blob/master/keymaps/linux.cson.

### From hyper's pull request template

- *To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged*: 
  - This PR is ready to be merged
- *If there's anything left to do and if there are any related PRs*
  - Someone should review the new defaults to make sure they don't break conventions. I'm also unsure what to do with the 4 cases where I used <kbd>Z</kbd> instead of <kbd>Shift</kbd>, though it didn't seem to break anything for me.
  - Pull requests related to shortcuts would need to be updated, particularly #925 
- *It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`*
  - Done!