### PR TITLE
Using Consolas as the default font on Windows

### DIFF
--- a/app/config-default.js
+++ b/app/config-default.js
@@ -4,7 +4,7 @@ module.exports = {
     fontSize: 12,
 
     // font family with optional fallbacks
-    fontFamily: 'Menlo, "DejaVu Sans Mono", "Lucida Console", monospace',
+    fontFamily: 'Menlo, "DejaVu Sans Mono", Consolas, "Lucida Console", monospace',
 
     // terminal cursor background color and opacity (hex, rgb, hsl, hsv, hwb or cmyk)
     cursorColor: 'rgba(248,28,229,0.8)',


### PR DESCRIPTION
Just added Consolas to the list of fonts in the default fonts since it's the native fixed-width font on Windows. Lucida Console is on Windows, so it has to come before it in the list.