### PR TITLE
Ensure line endings are correct on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.sh eol=lf


### PR DESCRIPTION
This allows Windows users to check out the repo and send in PRs without messing up the line endings, see https://help.github.com/articles/dealing-with-line-endings for more