### PR TITLE
Fix url interpretation

### DIFF
--- a/lib/actions/sessions.js
+++ b/lib/actions/sessions.js
@@ -1,5 +1,5 @@
 import rpc from '../rpc';
-import getURL from '../utils/url-command';
+import isUrl from '../utils/url-command';
 import {keys} from '../utils/object';
 import findBySession from '../utils/term-groups';
 import {
@@ -56,7 +56,7 @@ export function addSessionData(uid, data) {
         const {shell} = getState().sessions.sessions[uid];
 
         const enterKey = Boolean(data.match(/\n/));
-        const url = enterKey ? getURL(shell, data) : null;
+        const url = enterKey ? isUrl(shell, data) : null;
 
         if (url) {
           dispatch({

--- a/lib/utils/url-command.js
+++ b/lib/utils/url-command.js
@@ -1,7 +1,5 @@
 import * as regex from './url-regex';
 
-export const domainRegex = /([0-9]+[:.]*)+|([a-zA-Z0-9.]+[.][a-zA-Z0-9]+([:][0-9]+)*){1}/;
-
 export default function isUrlCommand(shell, data) {
   const matcher = regex[shell]; // eslint-disable-line import/namespace
   if (undefined === matcher || !data) {
@@ -9,22 +7,10 @@ export default function isUrlCommand(shell, data) {
   }
 
   const match = data.match(matcher);
-  if (!match) {
-    return null;
-  }
-  const protocol = match[1];
-  const path = match[2];
+  const urlRegex = /(http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!]))?/;
 
-  if (path) {
-    if (protocol) {
-      return `${protocol}${path}`;
-    }
-    // extract the domain portion from the url
-    const domain = path.split('/')[0];
-    if (domainRegex.test(domain)) {
-      const result = path.match(domainRegex)[0];
-      return `http://${result}`;
-    }
+  if (match && urlRegex.test(match[2])) {
+    return `${match[2]}`;
   }
 
   return null;

--- a/lib/utils/url-command.js
+++ b/lib/utils/url-command.js
@@ -7,7 +7,7 @@ export default function isUrlCommand(shell, data) {
   }
 
   const match = data.match(matcher);
-  const urlRegex = /(http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!]))?/;
+  const urlRegex = /((?:https?:\/\/)(?:[-a-z0-9]+\.)*[-a-z0-9]+.*)/;
 
   if (match && urlRegex.test(match[2])) {
     return `${match[2]}`;

--- a/lib/utils/url-regex.js
+++ b/lib/utils/url-regex.js
@@ -1,4 +1,4 @@
-export const sh = /(?:ba)?sh: ((?:https?:\/\/)|(?:file:\/\/)|(?:\/\/))?(.*): (?:(?:command not found)|(?:No such file or directory))/;
+export const sh = /(?:ba)?sh: ((?:file:\/\/)|(?:\/\/))?(.*): (?:(?:command not found)|(?:No such file or directory))/;
 export const bash = sh;
-export const zsh = /zsh: (?:(?:command not found)|(?:no such file or directory)): ((?:https?:\/\/)|(?:file:\/\/)|(?:\/\/))?([^\n]+)/;
-export const fish = /fish: Unknown command '((?:https?:\/\/)|(?:file:\/\/)|(?:\/\/))?([^']+)'/;
+export const zsh = /zsh: (?:(?:command not found)|(?:no such file or directory)): ((?:file:\/\/)|(?:\/\/))?([^\n]+)/;
+export const fish = /fish: Unknown command '((?:file:\/\/)|(?:\/\/))?([^']+)'/;


### PR DESCRIPTION

Previous `url-command.js` used domainRegex
`export const domainRegex = /([0-9]+[:.]*)+|([a-zA-Z0-9.]+[.][a-zA-Z0-9]+([:][0-9]+)*){1}/`

```
    if (domainRegex.test(domain)) {
      const result = path.match(domainRegex)[0];
      return `http://${result}`;
    }
```
The forced http made command starting with 3 open in a `<webview>`

Exemple of supported url:
```
http://www.hyper.is
https://www.hyper.is
http://hyper.is/over/there?name=ferre
http://hyper.is/hello
http://www.q.hyper.is/hello
http://hyper.qc.ca/hello
http://localhost:1337/
http://hyper:1337/load?now=serve
http://localhost:1337/#/now
http://192.143.134/over/ok?there=hello
https://192.143.134:80/
```
Close : #1042 , #910, #594, #97