### PR TITLE
Expose decorate to plugins

### DIFF
--- a/lib/utils/plugins.js
+++ b/lib/utils/plugins.js
@@ -19,6 +19,8 @@ Module._load = function (path) {
       return notify;
     case 'hyper/Notification':
       return Notification;
+    case 'hyper/decorate':
+      return decorate;
     default:
       return originalLoad.apply(this, arguments);
   }


### PR DESCRIPTION
This adds the ability to `require('hyper/decorate')` to register your own decorators from plugins 🌟
Will allow plugins to create a React component that can be extended by other plugins.

Example:
```javascript
import React, {Component} from 'react'
import decorate from 'hyper/decorate'

class MyComponent extends Component {
  render () {
    return (<div>My Component</div>)
  }
}

export default decorate(MyComponent, 'MyComponent')
```

Then in plugin code:
```javascript
import React, {Component} from 'react'
export function decorateMyComponent (MyComponent) {
  return class extends Component {
    render () {
      return (
        <div>
          <MyComponent {...this.props}>
          <div>Something else</div>
        </div>
      )
    }
  }
}
```