### PR TITLE
Add `--help` and `--version` command line arguments.

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1,3 +1,15 @@
+// Remove the full path to electron and the name of this file from the arguments list.
+const args = process.argv.slice(2);
+// Print diagnostic information for a few arguments instead of running Hyper.
+if (args[0] === '--help' || args[0] === '-v' || args[0] === '--version') {
+  const {version} = require('./package');
+  const configLocation = process.platform === 'win32' ? process.env.userprofile + '\\.hyper.js' : '~/.hyper.js'
+  console.log('Hyper version ' + version);
+  console.log('Hyper does not accept any command line arguments. Please modify the config file instead.');
+  console.log('Hyper configuration file located at: ' + configLocation);
+  process.exit();
+}
+
 // handle startup squirrel events
 if (process.platform === 'win32') {
   // eslint-disable-next-line import/order

--- a/app/index.js
+++ b/app/index.js
@@ -1,6 +1,5 @@
-const firstArg = process.argv[1];
 // Print diagnostic information for a few arguments instead of running Hyper.
-if (firstArg === '--help' || firstArg === '-v' || firstArg === '--version') {
+if (['--help', '-v', '--version'].indexOf(process.argv[1]) !== -1) {
   const {version} = require('./package');
   const configLocation = process.platform === 'win32' ? process.env.userprofile + '\\.hyper.js' : '~/.hyper.js';
   console.log('Hyper version ' + version);

--- a/app/index.js
+++ b/app/index.js
@@ -1,12 +1,13 @@
 // Remove the full path to electron and the name of this file from the arguments list.
-const args = process.argv.slice(2);
+const firstArg = process.argv[1];
 // Print diagnostic information for a few arguments instead of running Hyper.
-if (args[0] === '--help' || args[0] === '-v' || args[0] === '--version') {
+if (firstArg === '--help' || firstArg === '-v' || firstArg === '--version') {
   const {version} = require('./package');
-  const configLocation = process.platform === 'win32' ? process.env.userprofile + '\\.hyper.js' : '~/.hyper.js'
+  const configLocation = process.platform === 'win32' ? process.env.userprofile + '\\.hyper.js' : '~/.hyper.js';
   console.log('Hyper version ' + version);
   console.log('Hyper does not accept any command line arguments. Please modify the config file instead.');
   console.log('Hyper configuration file located at: ' + configLocation);
+  // eslint-disable-next-line unicorn/no-process-exit
   process.exit();
 }
 

--- a/app/index.js
+++ b/app/index.js
@@ -1,10 +1,10 @@
 // Print diagnostic information for a few arguments instead of running Hyper.
-if (['--help', '-v', '--version'].indexOf(process.argv[1]) !== -1) {
+if (['--help', '-v', '--version'].includes(process.argv[1])) {
   const {version} = require('./package');
   const configLocation = process.platform === 'win32' ? process.env.userprofile + '\\.hyper.js' : '~/.hyper.js';
-  console.log('Hyper version ' + version);
+  console.log(`Hyper version ${version}`);
   console.log('Hyper does not accept any command line arguments. Please modify the config file instead.');
-  console.log('Hyper configuration file located at: ' + configLocation);
+  console.log(`Hyper configuration file located at: ${configLocation}`);
   // eslint-disable-next-line unicorn/no-process-exit
   process.exit();
 }

--- a/app/index.js
+++ b/app/index.js
@@ -1,4 +1,3 @@
-// Remove the full path to electron and the name of this file from the arguments list.
 const firstArg = process.argv[1];
 // Print diagnostic information for a few arguments instead of running Hyper.
 if (firstArg === '--help' || firstArg === '-v' || firstArg === '--version') {


### PR DESCRIPTION
As requested in #1212, it would be really nice if Hyper recognized the `--help` command line argument. 

Seeing as Hyper doesn't support any actual arguments, I opted to just print the version, location of the config file, and a brief message explaining that there are no command line arguments.

It felt weird supporting `--help` without `--version` so `--version` and `-v` do the same thing.

I've been trying to upload a screenshot but Github isn't cooperating right now so this will have to do:

```
$ ./Hyper.exe --help

Hyper version 1.0.1
Hyper does not accept any command line arguments. Please modify the config file instead.
Hyper configuration file located at: C:\Users\Sam\.hyper.js
```
