### PR TITLE
Add support for cursor styles 5 and 6 to hterm

### DIFF
--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -427,5 +427,31 @@ lib.colors.hexToRGB = function (arg) {
   return arg;
 };
 
+// add support for cursor styles 5 and 6, fixes #270
+hterm.VT.CSI[' q'] = function (parseState) {
+  const arg = parseState.args[0];
+  if (arg === '0' || arg === '1') {
+    this.terminal.setCursorShape(hterm.Terminal.cursorShape.BLOCK);
+    this.terminal.setCursorBlink(true);
+  } else if (arg === '2') {
+    this.terminal.setCursorShape(hterm.Terminal.cursorShape.BLOCK);
+    this.terminal.setCursorBlink(false);
+  } else if (arg === '3') {
+    this.terminal.setCursorShape(hterm.Terminal.cursorShape.UNDERLINE);
+    this.terminal.setCursorBlink(true);
+  } else if (arg === '4') {
+    this.terminal.setCursorShape(hterm.Terminal.cursorShape.UNDERLINE);
+    this.terminal.setCursorBlink(false);
+  } else if (arg === '5') {
+    this.terminal.setCursorShape(hterm.Terminal.cursorShape.BEAM);
+    this.terminal.setCursorBlink(true);
+  } else if (arg === '6') {
+    this.terminal.setCursorShape(hterm.Terminal.cursorShape.BEAM);
+    this.terminal.setCursorBlink(false);
+  } else {
+    console.warn('Unknown cursor style: ' + arg);
+  }
+};
+
 export default hterm;
 export {lib};


### PR DESCRIPTION
This fixes #270, cursor shape changing in Neovim.