### PR TITLE
implemented support for mutliple shell definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@ npm-debug.log
 # optional dev config file and plugins directory
 .hyper.js
 .hyper_plugins
-

--- a/app/index.js
+++ b/app/index.js
@@ -49,7 +49,6 @@ const isDev = require('electron-is-dev');
 // Ours
 const AutoUpdater = require('./auto-updater');
 const toElectronBackgroundColor = require('./utils/to-electron-background-color');
-const createMenu = require('./menu');
 const createRPC = require('./rpc');
 const notify = require('./notify');
 const fetchNotifications = require('./notifications');
@@ -61,6 +60,7 @@ const config = require('./config');
 
 config.init();
 
+const createMenu = require('./menu');
 const plugins = require('./plugins');
 const Session = require('./session');
 
@@ -198,7 +198,8 @@ app.on('ready', () => installDevExtensions(isDev).then(() => {
       // If no callback is passed to createWindow,
       // a new session will be created by default.
       if (!fn) {
-        fn = win => win.rpc.emit('termgroup add req');
+        const shellOpts = options.shellOpts || {};
+        fn = win => win.rpc.emit('termgroup add req', {shellOpts});
       }
 
       // app.windowCallback is the createWindow callback
@@ -217,9 +218,9 @@ app.on('ready', () => installDevExtensions(isDev).then(() => {
       }
     });
 
-    rpc.on('new', ({rows = 40, cols = 100, cwd = process.argv[1] && isAbsolute(process.argv[1]) ? process.argv[1] : homedir(), splitDirection}) => {
-      const shell = cfg.shell;
-      const shellArgs = cfg.shellArgs && Array.from(cfg.shellArgs);
+    rpc.on('new', ({rows = 40, cols = 100, shellOpts = {}, cwd = process.argv[1] && isAbsolute(process.argv[1]) ? process.argv[1] : homedir(), splitDirection}) => {
+      const shell = shellOpts.path || cfg.shell;
+      const shellArgs = shellOpts.args || (cfg.shellArgs && Array.from(cfg.shellArgs));
 
       initSession({rows, cols, cwd, shell, shellArgs}, (uid, session) => {
         sessions.set(uid, session);

--- a/lib/actions/term-groups.js
+++ b/lib/actions/term-groups.js
@@ -12,14 +12,16 @@ import getRootGroups from '../selectors';
 import {setActiveSession, ptyExitSession, userExitSession} from './sessions';
 
 function requestSplit(direction) {
-  return () => (dispatch, getState) => {
+  return options => (dispatch, getState) => {
+    const {shellOpts} = options || {};
     const {ui} = getState();
     dispatch({
       type: SESSION_REQUEST,
       effect: () => {
         rpc.emit('new', {
           splitDirection: direction,
-          cwd: ui.cwd
+          cwd: ui.cwd,
+          shellOpts
         });
       }
     });
@@ -37,8 +39,9 @@ export function resizeTermGroup(uid, sizes) {
   };
 }
 
-export function requestTermGroup() {
+export function requestTermGroup(options) {
   return (dispatch, getState) => {
+    const {shellOpts} = options || {};
     const {ui} = getState();
     const {cols, rows, cwd} = ui;
     dispatch({
@@ -48,7 +51,8 @@ export function requestTermGroup() {
           isNewGroup: true,
           cols,
           rows,
-          cwd
+          cwd,
+          shellOpts
         });
       }
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -86,16 +86,16 @@ rpc.on('session clear req', () => {
   store_.dispatch(sessionActions.clearActiveSession());
 });
 
-rpc.on('termgroup add req', () => {
-  store_.dispatch(termGroupActions.requestTermGroup());
+rpc.on('termgroup add req', options => {
+  store_.dispatch(termGroupActions.requestTermGroup(options));
 });
 
-rpc.on('split request horizontal', () => {
-  store_.dispatch(termGroupActions.requestHorizontalSplit());
+rpc.on('split request horizontal', options => {
+  store_.dispatch(termGroupActions.requestHorizontalSplit(options));
 });
 
-rpc.on('split request vertical', () => {
-  store_.dispatch(termGroupActions.requestVerticalSplit());
+rpc.on('split request vertical', options => {
+  store_.dispatch(termGroupActions.requestVerticalSplit(options));
 });
 
 rpc.on('reset fontSize req', () => {


### PR DESCRIPTION
I've implemented an additional menu item in File which allows you to select other shells that may have been configured inside your config file. My use case was for Windows (Bash vs Powershell), but this would apply to macos and linux for anyone who uses more than a single shell flavour. I wanted to make this a plugin, however the work was too integrated for this to be possible (or rather so simple enough).

Possible enhancements to this PR:
 - [x] don't show menu item if shells is not defined in config
 - [ ] add possibility of accelerator shortcut definition from config file

Please let me know if any of the above or other fixes are required, and I'll jump on it as soon as I can.

P.S. PR checks are failing due to external code which I didn't touch. Seems someone pushed bad code to master...