### PR TITLE
Prevent loosing focus after a char composition ended by Tab key. Fix #1341

### DIFF
--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -182,11 +182,22 @@ hterm.Terminal.prototype.copySelectionToClipboard = function () {
   }
 };
 
+let lastEventTimeStamp;
+let lastEventKey;
 // passthrough all the commands that are meant to control
 // hyper and not the terminal itself
 const oldKeyDown = hterm.Keyboard.prototype.onKeyDown_;
 hterm.Keyboard.prototype.onKeyDown_ = function (e) {
   const modifierKeysConf = this.terminal.modifierKeys;
+  if (e.timeStamp === lastEventTimeStamp && e.key === lastEventKey) {
+    // Event was already processed.
+    // It seems to occur after a char composition ended by Tab and cause a blur.
+    // See https://github.com/zeit/hyper/issues/1341
+    e.preventDefault();
+    return;
+  }
+  lastEventTimeStamp = e.timeStamp;
+  lastEventKey = e.key;
 
   if (e.altKey &&
       e.which !== 16 && // Ignore other modifer keys


### PR DESCRIPTION
<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`

Thanks, again! -->
When a char composition ends with a Tab key, after a first `onKeyDown_(e)` call, another one occurs with a different keycode (192) but the same timestamp and same key (Tab).
This second `onKeyDown_` event cause a blur and Term loose its focus.

Notice: A breakpoint in `onTextInput_` prevent this second event. Race condition ?