### PR TITLE
fix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,9 @@ before_install:
   - mkdir -p /tmp/git-lfs && curl -L https://github.com/github/git-lfs/releases/download/v1.2.1/git-lfs-$([ "$TRAVIS_OS_NAME" == "linux" ] && echo "linux" || echo "darwin")-amd64-1.2.1.tar.gz | tar -xz -C /tmp/git-lfs --strip-components 1 && /tmp/git-lfs/git-lfs pull
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start; sleep 3; fi
 
+install:
+  - npm install
+
 before_script:
   - npm prune
 


### PR DESCRIPTION
I'm running into discrepancies with local tests vs travis builds. Can see in #1353 and saw it mentioned in #1354.

The culprit is the lack of a `install` in the `.travis.yml` This is a result of the auto-magic of the install when travis sees a `yarn.lock` file. [More info here](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Travis-CI-supports-yarn)