### PR TITLE
Cleanup getWindowHeaderConfig

### DIFF
--- a/lib/components/header.js
+++ b/lib/components/header.js
@@ -102,19 +102,21 @@ export default class Header extends Component {
 
   getWindowHeaderConfig() {
     const {showHamburgerMenu, showWindowControls} = this.props;
-    const ret = {
+
+    const defaults = {
       hambMenu: process.platform === 'win32', // show by default on windows
       winCtrls: !this.props.isMac // show by default on windows and linux
     };
-    if (!this.props.isMac) { // allow the user to override the defaults if not on macOS
-      if (showHamburgerMenu !== '') {
-        ret.hambMenu = showHamburgerMenu;
-      }
-      if (showWindowControls !== '') {
-        ret.winCtrls = showWindowControls;
-      }
+
+    // don't allow the user to change defaults on MacOS
+    if (this.props.isMac) {
+      return defaults;
     }
-    return ret;
+
+    return {
+      hambMenu: showHamburgerMenu === '' ? defaults.hambMenu : showHamburgerMenu,
+      winCtrls: showWindowControls === '' ? defaults.winCtrls : showWindowControls
+    };
   }
 
   template(css) {


### PR DESCRIPTION
For some reason XO didn't like if i did it like this:
```js
return {
  hambMenu: showHamburgerMenu !== '' ? showHamburgerMenu : defaults.hambMenu,
  winCtrls: showWindowControls !== '' ? showWindowControls : defaults.winCtrls
};
```
which to me looks a lot simpler, but this will do!