### PR TITLE
Disable linebreak-style

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
       "new-cap": 0,
       "complexity": 0,
       "react/prop-types": 0,
-      "react/jsx-no-bind": 0
+      "react/jsx-no-bind": 0,
+      "linebreak-style": 0
     },
     "ignores": [
       "build/**",


### PR DESCRIPTION
On Windows, xo will throw errors for literally every line of the app. Almost nobody makes this mistake IRL, let's disable this for now and if it gets to be a problem, we'll figure out what to do.