### PR TITLE
Define widths for BEAM and UNDERLINE cursors. Fixes #1372

### DIFF
--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -260,6 +260,10 @@ export default class Term extends Component {
       .cursor-node[focus="false"] {
          border-width: 1px !important;
       }
+      .cursor-node[focus="true"] {
+        border-left-width: 1px;
+        border-bottom-width: 2px;
+      }
       ${hyperCaret}
       ${osSpecificCss}
       ${css}


### PR DESCRIPTION
This is a pretty self-explanatory commit ⚡️

` border-left` affects `BEAM`,
`border-bottom` affects `UNDERLINE`

I didn't take the time to familiarize myself with Hyper's preferences, but this could definitely be something configurable.

![cursor shapes](https://cloud.githubusercontent.com/assets/861964/21865496/54dcf66c-d814-11e6-933d-bcdf80c97030.gif)
