### PR TITLE
🐛 Fix copy/paste shortcuts on Windows/Linux 🎉

### DIFF
--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -223,22 +223,29 @@ hterm.Keyboard.prototype.onKeyDown_ = function (e) {
     e.preventDefault();
   }
 
+  // hterm shouldn't consume a hyper accelerator
   if (e.altKey || e.metaKey || isAccelerator(e)) {
-    // hterm shouldn't consume a hyper accelerator
-    // // Was the hyperCaret removed for selectAll
-    if (e.key === 'v' && !this.terminal.cursorNode_.contains(this.hyperCaret)) {
+    // If the `hyperCaret` was removed on `selectAll`, we need to insert it back
+    if (e.key === 'v' && this.terminal.hyperCaret.parentNode !== this.terminal.cursorNode_) {
       this.terminal.focusHyperCaret();
     }
     return;
   }
 
   // Test for valid keys in order to accept clear status
-  if (e.code !== 'Control' && e.key !== 'Shift' && e.code !== 'CapsLock' && e.key !== 'Dead') {
+  const clearBlacklist = [
+    'control',
+    'shift',
+    'capslock',
+    'dead'
+  ];
+  if (!clearBlacklist.includes(e.code.toLowerCase()) &&
+      !clearBlacklist.includes(e.key.toLowerCase())) {
     selection.clear(this.terminal);
   }
 
-  // Was the hyperCaret removed for selectAll
-  if (!this.terminal.cursorNode_.contains(this.hyperCaret)) {
+  // If the `hyperCaret` was removed on `selectAll`, we need to insert it back
+  if (this.terminal.hyperCaret.parentNode !== this.terminal.cursorNode_) {
     this.terminal.focusHyperCaret();
   }
   return oldKeyDown.call(this, e);


### PR DESCRIPTION
This PR fixes the copy and paste shortcuts for Windows and Linux 🕵️ 

There was two problems: 
* An active text selection was being cleared when `Ctrl` was pressed – you couldn't copy anything
* The `hyper-caret` was always being focused, even when it was already inserted into the `cursor-node`. This was preventing both copy and paste shortcuts from working

Closes #1328, #1381, #1394 