### PR TITLE
[UI] Make scrollbar look the same on all platforms

### DIFF
--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -232,9 +232,8 @@ export default class Term extends Component {
         font-size: ${this.props.fontSize}px;
       }
     `;
-    let osSpecificCss = '';
-    if (process.platform === 'win32') {
-      osSpecificCss = `::-webkit-scrollbar {
+    let osSpecificCss = `
+      ::-webkit-scrollbar {
         width: 5px;
       }
       ::-webkit-scrollbar-thumb {
@@ -244,18 +243,8 @@ export default class Term extends Component {
       }
       ::-webkit-scrollbar-thumb:window-inactive {
         background: ${this.props.borderColor};
-      }`;
-    } else if (process.platform === 'darwin') {
-      osSpecificCss = `::-webkit-scrollbar {
-        width: 9px;
-        background: transparent;
-       }
-       ::-webkit-scrollbar-thumb {
-        -webkit-border-radius: 10px;
-        border-radius: 10px;
-        -webkit-box-shadow: inset 0 0 0 1px ${this.props.borderColor};
-       }`;
-    }
+      }
+    `;
     return URL.createObjectURL(new Blob([`
       .cursor-node[focus="false"] {
          border-width: 1px !important;

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -232,7 +232,7 @@ export default class Term extends Component {
         font-size: ${this.props.fontSize}px;
       }
     `;
-    const osSpecificCss = `
+    const scrollBarCss = `
       ::-webkit-scrollbar {
         width: 5px;
       }
@@ -254,7 +254,7 @@ export default class Term extends Component {
         border-bottom-width: 2px;
       }
       ${hyperCaret}
-      ${osSpecificCss}
+      ${scrollBarCss}
       ${css}
     `], {type: 'text/css'}));
   }

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -232,7 +232,7 @@ export default class Term extends Component {
         font-size: ${this.props.fontSize}px;
       }
     `;
-    let osSpecificCss = `
+    const osSpecificCss = `
       ::-webkit-scrollbar {
         width: 5px;
       }


### PR DESCRIPTION
Linux suffers from the same issue as other platforms where the scrollbar is that ugly electron style. 
This commit will fix this and make it look the same on all platforms and cut down code.

How it looks by default.
![](https://i.imgur.com/eTYQCKQ.jpg)

How it looks after this commit.
![](https://i.imgur.com/RDwbtfG.jpg)