### PR TITLE
Added http and https handler for will-navigate event

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -313,6 +313,9 @@ app.on('ready', () => installDevExtensions(isDev).then(() => {
         event.preventDefault();
         const path = fileUriToPath(url).replace(/ /g, '\\ ');
         rpc.emit('session data send', {data: path});
+      } else if (protocol === 'http:' || protocol === 'https:') {
+        event.preventDefault();
+        rpc.emit('session data send', {data: url});
       }
     });
 


### PR DESCRIPTION
This fixes #1319 and should be good to merge.

Based on the suggestion from the issue I've prevented navigation when a user drops content from a browser into a terminal. Instead, it enters in the URL of the content the user dropped.

Seemed like a simple issue to tip my toes in to an awesome project!

<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`

Thanks, again! -->
