### PR TITLE
Restore a behavior to open preference macOS

### DIFF
--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -212,12 +212,33 @@ export function moveTo(i) {
 }
 
 export function showPreferences() {
+  const isWin = process.platform === 'win32';
+  // eslint-disable-next-line no-template-curly-in-string
+  const command = isWin ? ' start notepad "%userprofile%\\.hyper.js"' : ' bash -c \'exec env ${EDITOR:=nano} ~/.hyper.js\'';
+  const message = [];
+  message.push(isWin ?
+    ' echo Attempting to open ^%userprofile^%\\.hyper.js with notepad' :
+    ' echo Attempting to open ~/.hyper.js with your \\$EDITOR');
+  message.push(' echo If it fails, open it manually with your favorite editor!');
+
   return dispatch => {
     dispatch({
       type: UI_SHOW_PREFERENCES,
       effect() {
-        dispatch(
-          shell.showItemInFolder(path.join(os.homedir(), '.hyper.js')));
+        if (isWin) {
+          dispatch(
+            shell.showItemInFolder(path.join(os.homedir(), '.hyper.js')));
+        } else {
+          dispatch(requestSession());
+          // Replace this hack with an async action
+          rpc.once('session add', ({uid}) => {
+            rpc.once('session data', () => {
+              dispatch(sendSessionData(
+                uid, [...message, command, ''].join(os.EOL)
+              ));
+            });
+          });
+        }
       }
     });
   };

--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -213,28 +213,19 @@ export function moveTo(i) {
 
 export function showPreferences() {
   const isWin = process.platform === 'win32';
-  // eslint-disable-next-line no-template-curly-in-string
-  const command = isWin ? ' start notepad "%userprofile%\\.hyper.js"' : ' bash -c \'exec env ${EDITOR:=nano} ~/.hyper.js\'';
-  const message = [];
-  message.push(isWin ?
-    ' echo Attempting to open ^%userprofile^%\\.hyper.js with notepad' :
-    ' echo Attempting to open ~/.hyper.js with your \\$EDITOR');
-  message.push(' echo If it fails, open it manually with your favorite editor!');
-
   return dispatch => {
     dispatch({
       type: UI_SHOW_PREFERENCES,
       effect() {
         if (isWin) {
-          dispatch(
-            shell.showItemInFolder(path.join(os.homedir(), '.hyper.js')));
+          dispatch(shell.showItemInFolder(path.join(os.homedir(), '.hyper.js')));
         } else {
           dispatch(requestSession());
           // Replace this hack with an async action
           rpc.once('session add', ({uid}) => {
             rpc.once('session data', () => {
               dispatch(sendSessionData(
-                uid, [...message, command, ''].join(os.EOL)
+                uid, `bash -c 'exec env \${EDITOR:=nano} ~/.hyper.js'; exit ${os.EOL}`
               ));
             });
           });


### PR DESCRIPTION
Restore a behavior to open preference with `EDITOR` using `cmd+,` at the macOS.
It was disabled at #1138.

I can't open the preference smoothly on macOS.
I used to open `~/.hyper.js` via `$EDITOR` when user `Cmd + ,` hotkey on macOS.
However, I can't open the preference using this hotkey.

![hyper_open_finder_no_dots](https://cloud.githubusercontent.com/assets/1206676/22519823/40096bac-e8f5-11e6-9e2b-8f245cb9bf44.gif)

This behavior is specification or rollback?
If it is new specification then please close this PR.