### PR TITLE
Fix replaceParent reducer on termgroup exit

### DIFF
--- a/lib/reducers/term-groups.js
+++ b/lib/reducers/term-groups.js
@@ -145,6 +145,7 @@ const replaceParent = (state, parent, child) => {
 
     state = state
       .set('activeTermGroup', child.uid)
+      .set('activeRootGroup', child.uid)
       .set('activeSessions', newSessions);
   }
 


### PR DESCRIPTION
<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`

Thanks, again! -->
activeRootGroup is not cleared when a child become a root termgroup
It happens when you exit a term with only two terms opened. The remaining termgroup containing a session replaces its parent and become root.  