### PR TITLE
Add snap support to packages.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
       "target": [
         "deb",
         "AppImage",
-        "rpm"
+        "rpm",
+        "snap"
       ]
     },
     "win": {
@@ -70,6 +71,10 @@
     },
     "mac": {
       "category": "public.app-category.developer-tools"
+    },
+    "snap": {
+      "confinement": "classic",
+      "grade": "stable"
     }
   },
   "license": "MIT",
@@ -112,7 +117,7 @@
     "copy-webpack-plugin": "^4.0.0",
     "cross-env": "3.1.3",
     "electron": "1.4.7",
-    "electron-builder": "8.6.0",
+    "electron-builder": "13.6.0",
     "electron-devtools-installer": "^2.0.0",
     "electron-rebuild": "1.5.6",
     "eslint-config-xo-react": "^0.10.0",


### PR DESCRIPTION
Hi,

This pull request adds [snap](http://snapcraft.io) builds to Hyper. 

  * I've tested building Hyper using this patch on Ubuntu 16.04.2, it successfully produced a `.snap` alongside the existing `.deb`, `.rpm` and `.AppImage`. I am now using the Hyper snap 😊
  * I've bumped the version of `electron-builder` to 13.6.0, which is required to build snaps.
  * `snapcraft` is currently only available for Ubuntu 16.04 but due to land in 14.04 soon. So building snaps will require an Ubuntu 16.04 host/vm/docker.