### PR TITLE
Revert "Open Preferences in Default JS Editor on Windows"

### DIFF
--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -1,6 +1,4 @@
-import os from 'os';
-import {shell} from 'electron';
-import path from 'path';
+import {EOL} from 'os';
 
 import * as shellEscape from 'php-escape-shell';
 import last from '../utils/array';
@@ -212,12 +210,33 @@ export function moveTo(i) {
 }
 
 export function showPreferences() {
+  const isWin = process.platform === 'win32';
+  // eslint-disable-next-line no-template-curly-in-string
+  const command = isWin ? ' start notepad "%userprofile%\\.hyper.js"' : ' bash -c \'exec env ${EDITOR:=nano} ~/.hyper.js\'';
+  const message = [];
+  message.push(isWin ?
+    ' echo Attempting to open ^%userprofile^%\\.hyper.js with notepad' :
+    ' echo Attempting to open ~/.hyper.js with your \\$EDITOR');
+  message.push(' echo If it fails, open it manually with your favorite editor!');
+
   return dispatch => {
     dispatch({
       type: UI_SHOW_PREFERENCES,
       effect() {
-        dispatch(
-          shell.showItemInFolder(path.join(os.homedir(), '.hyper.js')));
+        dispatch(requestSession());
+        // Replace this hack with an async action
+        rpc.once('session add', ({uid}) => {
+          rpc.once('session data', () => {
+            dispatch(sendSessionData(
+              uid,
+              [
+                ...message,
+                command,
+                ''
+              ].join(EOL)
+            ));
+          });
+        });
       }
     });
   };


### PR DESCRIPTION
Reverts #1138

#1138 removed the `CMD+,` which wasn't intended.

Other than that, #1383 fixes the `\n` issue on Notepad, so the reasoning from #1138 (`Notepad doesn't handle \n line breaks, so config file is unreadable.`) is _invalid_.

Also, I don't see how the `Default JS Editor on Windows` is being used on `shell.showItemInFolder` 🤔 