### PR TITLE
fix undefined fish shell match

### DIFF
--- a/app/plugins.js
+++ b/app/plugins.js
@@ -241,7 +241,7 @@ function install(fn) {
       posix: 'npm prune && npm install --production'
     };
     // determine the shell we're running in
-    const whichShell = cfgShell.match(/fish/) ? 'fish' : 'posix';
+    const whichShell = (typeof cfgShell === 'string' && cfgShell.match(/fish/)) ? 'fish' : 'posix';
     // Use the install command that is appropriate for our shell
     exec(installCommands[whichShell], {
       cwd: path,

--- a/app/plugins.js
+++ b/app/plugins.js
@@ -241,7 +241,7 @@ function install(fn) {
       posix: 'npm prune && npm install --production'
     };
     // determine the shell we're running in
-    const whichShell = shell.match(/fish/) ? 'fish' : 'posix';
+    const whichShell = cfgShell.match(/fish/) ? 'fish' : 'posix';
     // Use the install command that is appropriate for our shell
     exec(installCommands[whichShell], {
       cwd: path,


### PR DESCRIPTION
<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`

Thanks, again! -->

Fixes #1513 

Basically if you have no shell specifically set in config then `const shell` is set to `undefined` which match fails on because it can't match on `undefined`.

This commit matches against `cfgShell` instead.