### PR TITLE
add better support for narrow tabs

### DIFF
--- a/lib/components/tab.js
+++ b/lib/components/tab.js
@@ -143,7 +143,11 @@ export default class Tab extends Component {
         right: 0,
         top: 0,
         bottom: 0,
-        textAlign: 'center'
+        textAlign: 'center',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+        padding: '0 25px',
+        overflow: 'hidden'
       },
 
       icon: {

--- a/lib/components/tab.js
+++ b/lib/components/tab.js
@@ -67,7 +67,10 @@ export default class Tab extends Component {
         )}
         onClick={this.handleClick}
         >
-        <span className={css('textInner')}>
+        <span
+          title={this.props.text}
+          className={css('textInner')}
+          >
           { this.props.text }
         </span>
       </span>


### PR DESCRIPTION
<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`

Thanks, again! -->

Fixes #1421

Adds better support for narrow tabs by adding ellipsis when text is overflowing instead of cutting it off and additionally adds some padding so that the close button isn't covered by text.

Finally it adds a hover title so that you can see full tab title when it's overflowing.

Before:
<img width="482" alt="skarmavbild 2017-02-16 kl 18 50 15" src="https://cloud.githubusercontent.com/assets/1430576/23033554/cb1c917c-f478-11e6-8046-4a4a3c64ce1b.png">

After:
<img width="482" alt="skarmavbild 2017-02-16 kl 18 49 32" src="https://cloud.githubusercontent.com/assets/1430576/23033555/cc4d8286-f478-11e6-8f5c-41dc85969125.png">
