### PR TITLE
Fix unicode display: CJK, powerline, tmux

### DIFF
--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -349,6 +349,115 @@ hterm.Terminal.prototype.focusHyperCaret = function () {
   this.hyperCaret.focus();
 };
 
+hterm.Screen.prototype.insertString = function(str) {
+  var cursorNode = this.cursorNode_;
+  var cursorNodeText = cursorNode.textContent;
+  this.cursorRowNode_.removeAttribute('line-overflow');
+  // We may alter the width of the string by prepending some missing
+  // whitespaces, so we need to record the string width ahead of time.
+  var strWidth = lib.wc.strWidth(str);
+  // No matter what, before this function exits the cursor column will have
+  // moved this much.
+  this.cursorPosition.column += strWidth;
+  // Local cache of the cursor offset.
+  var offset = this.cursorOffset_;
+  // Reverse offset is the offset measured from the end of the string.
+  // Zero implies that the cursor is at the end of the cursor node.
+  var reverseOffset = hterm.TextAttributes.nodeWidth(cursorNode) - offset;
+  if (reverseOffset < 0) {
+    // A negative reverse offset means the cursor is positioned past the end
+    // of the characters on this line.  We'll need to insert the missing
+    // whitespace.
+    var ws = lib.f.getWhitespace(-reverseOffset);
+    // This whitespace should be completely unstyled.  Underline, background
+    // color, and strikethrough would be visible on whitespace, so we can't use
+    // one of those spans to hold the text.
+    if (!(this.textAttributes.underline ||
+          this.textAttributes.strikethrough ||
+          this.textAttributes.background ||
+          this.textAttributes.wcNode ||
+          this.textAttributes.tileData != null)) {
+      // Best case scenario, we can just pretend the spaces were part of the
+      // original string.
+      str = ws + str;
+    } else if (cursorNode.nodeType == 3 ||
+               !(cursorNode.wcNode ||
+                 cursorNode.tileNode ||
+                 cursorNode.style.textDecoration ||
+                 cursorNode.style.backgroundColor)) {
+      // Second best case, the current node is able to hold the whitespace.
+      cursorNode.textContent = (cursorNodeText += ws);
+    } else {
+      // Worst case, we have to create a new node to hold the whitespace.
+      var wsNode = cursorNode.ownerDocument.createTextNode(ws);
+      this.cursorRowNode_.insertBefore(wsNode, cursorNode.nextSibling);
+      this.cursorNode_ = cursorNode = wsNode;
+      this.cursorOffset_ = offset = -reverseOffset;
+      cursorNodeText = ws;
+    }
+    // We now know for sure that we're at the last character of the cursor node.
+    reverseOffset = 0;
+  }
+  if (this.textAttributes.matchesContainer(cursorNode)) {
+    // The new text can be placed directly in the cursor node.
+    if (reverseOffset == 0) {
+      cursorNode.textContent = cursorNodeText + str;
+    } else if (offset == 0) {
+      cursorNode.textContent = str + cursorNodeText;
+    } else {
+      cursorNode.textContent =
+          hterm.TextAttributes.nodeSubstr(cursorNode, 0, offset) +
+          str + hterm.TextAttributes.nodeSubstr(cursorNode, offset);
+    }
+    this.cursorOffset_ += strWidth;
+    return;
+  }
+  // The cursor node is the wrong style for the new text.  If we're at the
+  // beginning or end of the cursor node, then the adjacent node is also a
+  // potential candidate.
+  if (offset == 0) {
+    // At the beginning of the cursor node, the check the previous sibling.
+    var previousSibling = cursorNode.previousSibling;
+    if (previousSibling &&
+        this.textAttributes.matchesContainer(previousSibling)) {
+      previousSibling.textContent += str;
+      this.cursorNode_ = previousSibling;
+      this.cursorOffset_ = lib.wc.strWidth(previousSibling.textContent);
+      return;
+    }
+    var newNode = this.textAttributes.createContainer(str);
+    this.cursorRowNode_.insertBefore(newNode, cursorNode);
+    this.cursorNode_ = newNode;
+    this.cursorOffset_ = strWidth;
+    return;
+  }
+  if (reverseOffset == 0) {
+    // At the end of the cursor node, the check the next sibling.
+    var nextSibling = cursorNode.nextSibling;
+    if (nextSibling &&
+        this.textAttributes.matchesContainer(nextSibling)) {
+      nextSibling.textContent = str + nextSibling.textContent;
+      this.cursorNode_ = nextSibling;
+      this.cursorOffset_ = lib.wc.strWidth(str);
+      return;
+    }
+    var newNode = this.textAttributes.createContainer(str);
+    this.cursorRowNode_.insertBefore(newNode, nextSibling);
+    this.cursorNode_ = newNode;
+    // We specifically need to include any missing whitespace here, since it's
+    // going in a new node.
+    this.cursorOffset_ = hterm.TextAttributes.nodeWidth(newNode);
+    return;
+  }
+  // Worst case, we're somewhere in the middle of the cursor node.  We'll
+  // have to split it into two nodes and insert our new container in between.
+  this.splitNode_(cursorNode, offset);
+  var newNode = this.textAttributes.createContainer(str);
+  this.cursorRowNode_.insertBefore(newNode, cursorNode.nextSibling);
+  this.cursorNode_ = newNode;
+  this.cursorOffset_ = strWidth;
+};
+
 hterm.Screen.prototype.syncSelectionCaret = function () {
   const p = this.terminal.hyperCaret;
   const doc = this.terminal.document_;

--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -86,21 +86,17 @@ lib.wc.substr = function (str, start, optWidth) {
   const chars = runes(str);
   let startIndex;
   let endIndex;
-  let width = 0;
+  let width;
 
-  for (let i = 0; i < chars.length; i++) {
-    const codePoint = chars[i].codePointAt(0);
-    const charWidth = lib.wc.charWidth(codePoint);
-    if ((width + charWidth) > start) {
-      startIndex = i;
+  for (startIndex = 0, width = 0; startIndex < chars.length; startIndex++) {
+    width += lib.wc.charWidth(chars[startIndex].codePointAt(0));
+    if (width > start) {
       break;
     }
-    width += charWidth;
   }
 
   if (optWidth) {
-    width = 0;
-    for (endIndex = startIndex; endIndex < chars.length && width < optWidth; endIndex++) {
+    for (endIndex = startIndex, width = 0; endIndex < chars.length && width < optWidth; endIndex++) {
       width += lib.wc.charWidth(chars[endIndex].charCodeAt(0));
     }
 

--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -351,30 +351,30 @@ hterm.Terminal.prototype.focusHyperCaret = function () {
 
 // unmodified hterm's insertString except that it returns the node
 // in which the string was inserted (and removed comments)
-hterm.Screen.prototype._insertString = function(str) {
-  var cursorNode = this.cursorNode_;
-  var cursorNodeText = cursorNode.textContent;
+hterm.Screen.prototype._insertString = function (str) {
+  let cursorNode = this.cursorNode_;
+  let cursorNodeText = cursorNode.textContent;
   this.cursorRowNode_.removeAttribute('line-overflow');
-  var strWidth = lib.wc.strWidth(str);
+  const strWidth = lib.wc.strWidth(str);
   this.cursorPosition.column += strWidth;
-  var offset = this.cursorOffset_;
-  var reverseOffset = hterm.TextAttributes.nodeWidth(cursorNode) - offset;
+  let offset = this.cursorOffset_;
+  let reverseOffset = hterm.TextAttributes.nodeWidth(cursorNode) - offset;
   if (reverseOffset < 0) {
-    var ws = lib.f.getWhitespace(-reverseOffset);
+    const ws = lib.f.getWhitespace(-reverseOffset);
     if (!(this.textAttributes.underline ||
           this.textAttributes.strikethrough ||
           this.textAttributes.background ||
           this.textAttributes.wcNode ||
-          this.textAttributes.tileData != null)) {
+          this.textAttributes.tileData !== null)) {
       str = ws + str;
-    } else if (cursorNode.nodeType == 3 ||
+    } else if (cursorNode.nodeType === 3 ||
                !(cursorNode.wcNode ||
                  cursorNode.tileNode ||
                  cursorNode.style.textDecoration ||
                  cursorNode.style.backgroundColor)) {
       cursorNode.textContent = (cursorNodeText += ws);
     } else {
-      var wsNode = cursorNode.ownerDocument.createTextNode(ws);
+      const wsNode = cursorNode.ownerDocument.createTextNode(ws);
       this.cursorRowNode_.insertBefore(wsNode, cursorNode.nextSibling);
       this.cursorNode_ = cursorNode = wsNode;
       this.cursorOffset_ = offset = -reverseOffset;
@@ -383,9 +383,9 @@ hterm.Screen.prototype._insertString = function(str) {
     reverseOffset = 0;
   }
   if (this.textAttributes.matchesContainer(cursorNode)) {
-    if (reverseOffset == 0) {
+    if (reverseOffset === 0) {
       cursorNode.textContent = cursorNodeText + str;
-    } else if (offset == 0) {
+    } else if (offset === 0) {
       cursorNode.textContent = str + cursorNodeText;
     } else {
       cursorNode.textContent =
@@ -395,8 +395,8 @@ hterm.Screen.prototype._insertString = function(str) {
     this.cursorOffset_ += strWidth;
     return cursorNode;
   }
-  if (offset == 0) {
-    var previousSibling = cursorNode.previousSibling;
+  if (offset === 0) {
+    const previousSibling = cursorNode.previousSibling;
     if (previousSibling &&
         this.textAttributes.matchesContainer(previousSibling)) {
       previousSibling.textContent += str;
@@ -404,14 +404,14 @@ hterm.Screen.prototype._insertString = function(str) {
       this.cursorOffset_ = lib.wc.strWidth(previousSibling.textContent);
       return previousSibling;
     }
-    var newNode = this.textAttributes.createContainer(str);
+    const newNode = this.textAttributes.createContainer(str);
     this.cursorRowNode_.insertBefore(newNode, cursorNode);
     this.cursorNode_ = newNode;
     this.cursorOffset_ = strWidth;
     return newNode;
   }
-  if (reverseOffset == 0) {
-    var nextSibling = cursorNode.nextSibling;
+  if (reverseOffset === 0) {
+    const nextSibling = cursorNode.nextSibling;
     if (nextSibling &&
         this.textAttributes.matchesContainer(nextSibling)) {
       nextSibling.textContent = str + nextSibling.textContent;
@@ -419,14 +419,14 @@ hterm.Screen.prototype._insertString = function(str) {
       this.cursorOffset_ = lib.wc.strWidth(str);
       return nextSibling;
     }
-    var newNode = this.textAttributes.createContainer(str);
+    const newNode = this.textAttributes.createContainer(str);
     this.cursorRowNode_.insertBefore(newNode, nextSibling);
     this.cursorNode_ = newNode;
     this.cursorOffset_ = hterm.TextAttributes.nodeWidth(newNode);
     return newNode;
   }
   this.splitNode_(cursorNode, offset);
-  var newNode = this.textAttributes.createContainer(str);
+  const newNode = this.textAttributes.createContainer(str);
   this.cursorRowNode_.insertBefore(newNode, cursorNode.nextSibling);
   this.cursorNode_ = newNode;
   this.cursorOffset_ = strWidth;
@@ -436,13 +436,13 @@ hterm.Screen.prototype._insertString = function(str) {
 // wrap unicode chars in individual spans
 // keep them in the parent node with the rest of the content
 // maintains styling and overflow display in divs with a background color
-hterm.Screen.prototype.insertString = function(str) {
-  console.log('? '+str);
+hterm.Screen.prototype.insertString = function (str) {
+  console.log('? ' + str);
   const node = this._insertString(str);
   const nodeContent = node.textContent;
   console.log(nodeContent);
   if (containsNonLatinCodepoints(nodeContent) && !node.className.includes('wc-node')) {
-    console.log('> '+nodeContent);
+    console.log('> ' + nodeContent);
     const doc = this.terminal.document_;
     if (!node.className.includes('unicode-node-parent')) {
       node.className += ' unicode-node-parent';
@@ -450,9 +450,7 @@ hterm.Screen.prototype.insertString = function(str) {
     node.textContent = null;
     let strBuffer = '';
     runes(nodeContent).forEach(rune => {
-      if (!containsNonLatinCodepoints(rune)) {
-        strBuffer += rune;
-      } else {
+      if (containsNonLatinCodepoints(rune)) {
         if (strBuffer !== '') {
           const stringNode = doc.createTextNode(strBuffer);
           console.log(stringNode);
@@ -464,6 +462,8 @@ hterm.Screen.prototype.insertString = function(str) {
         unicodeNode.textContent = rune;
         console.log(unicodeNode);
         node.appendChild(unicodeNode);
+      } else {
+        strBuffer += rune;
       }
     });
     if (strBuffer !== '') {
@@ -473,19 +473,18 @@ hterm.Screen.prototype.insertString = function(str) {
     }
     console.log(node);
   }
-}
+};
 
 // ensure no text node contains unicode
 const oldCreateContainer = hterm.TextAttributes.prototype.createContainer;
-hterm.TextAttributes.prototype.createContainer = function(text) {
+hterm.TextAttributes.prototype.createContainer = function (text) {
   if (this.isDefault() && text && containsNonLatinCodepoints(text)) {
-    var span = this.document_.createElement('span');
+    const span = this.document_.createElement('span');
     span.textContent = text;
     return span;
-  } else {
-    return oldCreateContainer.call(this, text);
   }
-}
+  return oldCreateContainer.call(this, text);
+};
 
 hterm.Screen.prototype.syncSelectionCaret = function () {
   const p = this.terminal.hyperCaret;

--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -349,57 +349,40 @@ hterm.Terminal.prototype.focusHyperCaret = function () {
   this.hyperCaret.focus();
 };
 
-hterm.Screen.prototype.insertString = function(str) {
+// unmodified hterm's insertString except that it returns the node
+// in which the string was inserted (and removed comments)
+hterm.Screen.prototype._insertString = function(str) {
   var cursorNode = this.cursorNode_;
   var cursorNodeText = cursorNode.textContent;
   this.cursorRowNode_.removeAttribute('line-overflow');
-  // We may alter the width of the string by prepending some missing
-  // whitespaces, so we need to record the string width ahead of time.
   var strWidth = lib.wc.strWidth(str);
-  // No matter what, before this function exits the cursor column will have
-  // moved this much.
   this.cursorPosition.column += strWidth;
-  // Local cache of the cursor offset.
   var offset = this.cursorOffset_;
-  // Reverse offset is the offset measured from the end of the string.
-  // Zero implies that the cursor is at the end of the cursor node.
   var reverseOffset = hterm.TextAttributes.nodeWidth(cursorNode) - offset;
   if (reverseOffset < 0) {
-    // A negative reverse offset means the cursor is positioned past the end
-    // of the characters on this line.  We'll need to insert the missing
-    // whitespace.
     var ws = lib.f.getWhitespace(-reverseOffset);
-    // This whitespace should be completely unstyled.  Underline, background
-    // color, and strikethrough would be visible on whitespace, so we can't use
-    // one of those spans to hold the text.
     if (!(this.textAttributes.underline ||
           this.textAttributes.strikethrough ||
           this.textAttributes.background ||
           this.textAttributes.wcNode ||
           this.textAttributes.tileData != null)) {
-      // Best case scenario, we can just pretend the spaces were part of the
-      // original string.
       str = ws + str;
     } else if (cursorNode.nodeType == 3 ||
                !(cursorNode.wcNode ||
                  cursorNode.tileNode ||
                  cursorNode.style.textDecoration ||
                  cursorNode.style.backgroundColor)) {
-      // Second best case, the current node is able to hold the whitespace.
       cursorNode.textContent = (cursorNodeText += ws);
     } else {
-      // Worst case, we have to create a new node to hold the whitespace.
       var wsNode = cursorNode.ownerDocument.createTextNode(ws);
       this.cursorRowNode_.insertBefore(wsNode, cursorNode.nextSibling);
       this.cursorNode_ = cursorNode = wsNode;
       this.cursorOffset_ = offset = -reverseOffset;
       cursorNodeText = ws;
     }
-    // We now know for sure that we're at the last character of the cursor node.
     reverseOffset = 0;
   }
   if (this.textAttributes.matchesContainer(cursorNode)) {
-    // The new text can be placed directly in the cursor node.
     if (reverseOffset == 0) {
       cursorNode.textContent = cursorNodeText + str;
     } else if (offset == 0) {
@@ -410,53 +393,99 @@ hterm.Screen.prototype.insertString = function(str) {
           str + hterm.TextAttributes.nodeSubstr(cursorNode, offset);
     }
     this.cursorOffset_ += strWidth;
-    return;
+    return cursorNode;
   }
-  // The cursor node is the wrong style for the new text.  If we're at the
-  // beginning or end of the cursor node, then the adjacent node is also a
-  // potential candidate.
   if (offset == 0) {
-    // At the beginning of the cursor node, the check the previous sibling.
     var previousSibling = cursorNode.previousSibling;
     if (previousSibling &&
         this.textAttributes.matchesContainer(previousSibling)) {
       previousSibling.textContent += str;
       this.cursorNode_ = previousSibling;
       this.cursorOffset_ = lib.wc.strWidth(previousSibling.textContent);
-      return;
+      return previousSibling;
     }
     var newNode = this.textAttributes.createContainer(str);
     this.cursorRowNode_.insertBefore(newNode, cursorNode);
     this.cursorNode_ = newNode;
     this.cursorOffset_ = strWidth;
-    return;
+    return newNode;
   }
   if (reverseOffset == 0) {
-    // At the end of the cursor node, the check the next sibling.
     var nextSibling = cursorNode.nextSibling;
     if (nextSibling &&
         this.textAttributes.matchesContainer(nextSibling)) {
       nextSibling.textContent = str + nextSibling.textContent;
       this.cursorNode_ = nextSibling;
       this.cursorOffset_ = lib.wc.strWidth(str);
-      return;
+      return nextSibling;
     }
     var newNode = this.textAttributes.createContainer(str);
     this.cursorRowNode_.insertBefore(newNode, nextSibling);
     this.cursorNode_ = newNode;
-    // We specifically need to include any missing whitespace here, since it's
-    // going in a new node.
     this.cursorOffset_ = hterm.TextAttributes.nodeWidth(newNode);
-    return;
+    return newNode;
   }
-  // Worst case, we're somewhere in the middle of the cursor node.  We'll
-  // have to split it into two nodes and insert our new container in between.
   this.splitNode_(cursorNode, offset);
   var newNode = this.textAttributes.createContainer(str);
   this.cursorRowNode_.insertBefore(newNode, cursorNode.nextSibling);
   this.cursorNode_ = newNode;
   this.cursorOffset_ = strWidth;
+  return newNode;
 };
+
+// wrap unicode chars in individual spans
+// keep them in the parent node with the rest of the content
+// maintains styling and overflow display in divs with a background color
+hterm.Screen.prototype.insertString = function(str) {
+  console.log('? '+str);
+  const node = this._insertString(str);
+  const nodeContent = node.textContent;
+  console.log(nodeContent);
+  if (containsNonLatinCodepoints(nodeContent) && !node.className.includes('wc-node')) {
+    console.log('> '+nodeContent);
+    const doc = this.terminal.document_;
+    if (!node.className.includes('unicode-node-parent')) {
+      node.className += ' unicode-node-parent';
+    }
+    node.textContent = null;
+    let strBuffer = '';
+    runes(nodeContent).forEach(rune => {
+      if (!containsNonLatinCodepoints(rune)) {
+        strBuffer += rune;
+      } else {
+        if (strBuffer !== '') {
+          const stringNode = doc.createTextNode(strBuffer);
+          console.log(stringNode);
+          node.appendChild(stringNode);
+          strBuffer = '';
+        }
+        const unicodeNode = doc.createElement('span');
+        unicodeNode.className = 'unicode-node';
+        unicodeNode.textContent = rune;
+        console.log(unicodeNode);
+        node.appendChild(unicodeNode);
+      }
+    });
+    if (strBuffer !== '') {
+      const stringNode = doc.createTextNode(strBuffer);
+      console.log(stringNode);
+      node.appendChild(stringNode);
+    }
+    console.log(node);
+  }
+}
+
+// ensure no text node contains unicode
+const oldCreateContainer = hterm.TextAttributes.prototype.createContainer;
+hterm.TextAttributes.prototype.createContainer = function(text) {
+  if (this.isDefault() && text && containsNonLatinCodepoints(text)) {
+    var span = this.document_.createElement('span');
+    span.textContent = text;
+    return span;
+  } else {
+    return oldCreateContainer.call(this, text);
+  }
+}
 
 hterm.Screen.prototype.syncSelectionCaret = function () {
   const p = this.terminal.hyperCaret;

--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -35,10 +35,6 @@ function containsNonLatinCodepoints(s) {
   return /[^\u0000-\u00ff]/.test(s);
 }
 
-function containsBrailleCodepoints(s) {
-  return /[\u2800-\u28ff]/.test(s);
-}
-
 // hterm Unicode patch
 hterm.TextAttributes.splitWidecharString = function (str) {
   const context = runes(str).reduce((ctx, rune) => {
@@ -136,16 +132,14 @@ hterm.Terminal.IO.prototype.writeUTF8 = function (string) {
 
   runes(string).forEach(rune => {
     this.terminal_.getTextAttributes().unicodeNode = containsNonLatinCodepoints(rune);
-    this.terminal_.getTextAttributes().brailleNode = containsBrailleCodepoints(rune);
     this.terminal_.interpret(rune);
     this.terminal_.getTextAttributes().unicodeNode = false;
-    this.terminal_.getTextAttributes().brailleNode = false;
   });
 };
 
 const oldIsDefault = hterm.TextAttributes.prototype.isDefault;
 hterm.TextAttributes.prototype.isDefault = function () {
-  return !this.unicodeNode && !this.brailleNode && oldIsDefault.call(this);
+  return !this.unicodeNode && oldIsDefault.call(this);
 };
 
 const oldSetFontSize = hterm.Terminal.prototype.setFontSize;
@@ -159,19 +153,9 @@ hterm.Terminal.prototype.setFontSize = function (px) {
     doc.head.appendChild(unicodeNodeStyle);
   }
   unicodeNodeStyle.innerHTML = `
-    .unicode-node {
+    .unicode-node:not(.wc-node) {
       display: inline-block;
       vertical-align: top;
-    }
-  `;
-  let brailleNodeStyle = doc.getElementById('hyper-braille-styles');
-  if (!brailleNodeStyle) {
-    brailleNodeStyle = doc.createElement('style');
-    brailleNodeStyle.setAttribute('id', 'hyper-braille-styles');
-    doc.head.appendChild(brailleNodeStyle);
-  }
-  brailleNodeStyle.innerHTML = `
-    .braille-node {
       width: ${this.scrollPort_.characterSize.width}px;
     }
   `;
@@ -182,9 +166,6 @@ hterm.TextAttributes.prototype.createContainer = function (text) {
   const container = oldCreateContainer.call(this, text);
   if (container.style && runes(text).length === 1 && containsNonLatinCodepoints(text)) {
     container.className += ' unicode-node';
-    if (containsBrailleCodepoints(text)) {
-      container.className += ' braille-node';
-    }
   }
   return container;
 };

--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -172,8 +172,6 @@ hterm.Terminal.prototype.setFontSize = function (px) {
   }
   brailleNodeStyle.innerHTML = `
     .braille-node {
-      display: inline-block;
-      vertical-align: top;
       width: ${this.scrollPort_.characterSize.width}px;
     }
   `;

--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -35,6 +35,10 @@ function containsNonLatinCodepoints(s) {
   return /[^\u0000-\u00ff]/.test(s);
 }
 
+function containsBrailleCodepoints(s) {
+  return /[\u2800-\u28ff]/.test(s);
+}
+
 // hterm Unicode patch
 hterm.TextAttributes.splitWidecharString = function (str) {
   const context = runes(str).reduce((ctx, rune) => {
@@ -132,14 +136,16 @@ hterm.Terminal.IO.prototype.writeUTF8 = function (string) {
 
   runes(string).forEach(rune => {
     this.terminal_.getTextAttributes().unicodeNode = containsNonLatinCodepoints(rune);
+    this.terminal_.getTextAttributes().brailleNode = containsBrailleCodepoints(rune);
     this.terminal_.interpret(rune);
     this.terminal_.getTextAttributes().unicodeNode = false;
+    this.terminal_.getTextAttributes().brailleNode = false;
   });
 };
 
 const oldIsDefault = hterm.TextAttributes.prototype.isDefault;
 hterm.TextAttributes.prototype.isDefault = function () {
-  return !this.unicodeNode && oldIsDefault.call(this);
+  return !this.unicodeNode && !this.brailleNode && oldIsDefault.call(this);
 };
 
 const oldSetFontSize = hterm.Terminal.prototype.setFontSize;
@@ -156,6 +162,18 @@ hterm.Terminal.prototype.setFontSize = function (px) {
     .unicode-node {
       display: inline-block;
       vertical-align: top;
+    }
+  `;
+  let brailleNodeStyle = doc.getElementById('hyper-braille-styles');
+  if (!brailleNodeStyle) {
+    brailleNodeStyle = doc.createElement('style');
+    brailleNodeStyle.setAttribute('id', 'hyper-braille-styles');
+    doc.head.appendChild(brailleNodeStyle);
+  }
+  brailleNodeStyle.innerHTML = `
+    .braille-node {
+      display: inline-block;
+      vertical-align: top;
       width: ${this.scrollPort_.characterSize.width}px;
     }
   `;
@@ -166,6 +184,9 @@ hterm.TextAttributes.prototype.createContainer = function (text) {
   const container = oldCreateContainer.call(this, text);
   if (container.style && runes(text).length === 1 && containsNonLatinCodepoints(text)) {
     container.className += ' unicode-node';
+    if (containsBrailleCodepoints(text)) {
+      container.className += ' braille-node';
+    }
   }
   return container;
 };

--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -349,9 +349,9 @@ hterm.Terminal.prototype.focusHyperCaret = function () {
   this.hyperCaret.focus();
 };
 
-// unmodified hterm's insertString except that it returns the node
-// in which the string was inserted (and removed comments)
-hterm.Screen.prototype._insertString = function (str) {
+// patch for unicode encapsulation
+// see comments in original code
+hterm.Screen.prototype.insertString = function (str) {
   let cursorNode = this.cursorNode_;
   let cursorNodeText = cursorNode.textContent;
   this.cursorRowNode_.removeAttribute('line-overflow');
@@ -382,6 +382,7 @@ hterm.Screen.prototype._insertString = function (str) {
     }
     reverseOffset = 0;
   }
+  this.wrapUnicode(cursorNode);
   if (this.textAttributes.matchesContainer(cursorNode)) {
     if (reverseOffset === 0) {
       cursorNode.textContent = cursorNodeText + str;
@@ -393,7 +394,8 @@ hterm.Screen.prototype._insertString = function (str) {
           str + hterm.TextAttributes.nodeSubstr(cursorNode, offset);
     }
     this.cursorOffset_ += strWidth;
-    return cursorNode;
+    this.wrapUnicode(cursorNode);
+    return;
   }
   if (offset === 0) {
     const previousSibling = cursorNode.previousSibling;
@@ -402,13 +404,15 @@ hterm.Screen.prototype._insertString = function (str) {
       previousSibling.textContent += str;
       this.cursorNode_ = previousSibling;
       this.cursorOffset_ = lib.wc.strWidth(previousSibling.textContent);
-      return previousSibling;
+      this.wrapUnicode(previousSibling);
+      return;
     }
     const newNode = this.textAttributes.createContainer(str);
     this.cursorRowNode_.insertBefore(newNode, cursorNode);
     this.cursorNode_ = newNode;
     this.cursorOffset_ = strWidth;
-    return newNode;
+    this.wrapUnicode(newNode);
+    return;
   }
   if (reverseOffset === 0) {
     const nextSibling = cursorNode.nextSibling;
@@ -417,35 +421,49 @@ hterm.Screen.prototype._insertString = function (str) {
       nextSibling.textContent = str + nextSibling.textContent;
       this.cursorNode_ = nextSibling;
       this.cursorOffset_ = lib.wc.strWidth(str);
-      return nextSibling;
+      this.wrapUnicode(nextSibling);
+      return;
     }
     const newNode = this.textAttributes.createContainer(str);
     this.cursorRowNode_.insertBefore(newNode, nextSibling);
     this.cursorNode_ = newNode;
     this.cursorOffset_ = hterm.TextAttributes.nodeWidth(newNode);
-    return newNode;
+    this.wrapUnicode(newNode);
+    return;
   }
   this.splitNode_(cursorNode, offset);
   const newNode = this.textAttributes.createContainer(str);
   this.cursorRowNode_.insertBefore(newNode, cursorNode.nextSibling);
   this.cursorNode_ = newNode;
   this.cursorOffset_ = strWidth;
-  return newNode;
+  this.wrapUnicode(newNode);
 };
 
-// wrap unicode chars in individual spans
+// patch for unicode encapsulation
+hterm.Screen.prototype.splitNode_ = function (node, offset) {
+  const afterNode = node.cloneNode(false);
+  const textContent = node.textContent;
+  node.textContent = hterm.TextAttributes.nodeSubstr(node, 0, offset);
+  afterNode.textContent = lib.wc.substr(textContent, offset);
+  this.wrapUnicode(node);
+  this.wrapUnicode(afterNode);
+  if (afterNode.textContent) {
+    node.parentNode.insertBefore(afterNode, node.nextSibling);
+  }
+  if (!node.textContent) {
+    node.parentNode.removeChild(node);
+  }
+};
+
+// encapsulate unicode chars in individual spans
 // keep them in the parent node with the rest of the content
 // maintains styling and overflow display in divs with a background color
-hterm.Screen.prototype.insertString = function (str) {
-  console.log('? ' + str);
-  const node = this._insertString(str);
+hterm.Screen.prototype.wrapUnicode = function (node) {
   const nodeContent = node.textContent;
-  console.log(nodeContent);
   if (containsNonLatinCodepoints(nodeContent) && !node.className.includes('wc-node')) {
-    console.log('> ' + nodeContent);
     const doc = this.terminal.document_;
-    if (!node.className.includes('unicode-node-parent')) {
-      node.className += ' unicode-node-parent';
+    if (!node.className.includes('unicode-parent-node')) {
+      node.className += ' unicode-parent-node';
     }
     node.textContent = null;
     let strBuffer = '';
@@ -453,14 +471,12 @@ hterm.Screen.prototype.insertString = function (str) {
       if (containsNonLatinCodepoints(rune)) {
         if (strBuffer !== '') {
           const stringNode = doc.createTextNode(strBuffer);
-          console.log(stringNode);
           node.appendChild(stringNode);
           strBuffer = '';
         }
         const unicodeNode = doc.createElement('span');
         unicodeNode.className = 'unicode-node';
         unicodeNode.textContent = rune;
-        console.log(unicodeNode);
         node.appendChild(unicodeNode);
       } else {
         strBuffer += rune;
@@ -468,10 +484,8 @@ hterm.Screen.prototype.insertString = function (str) {
     });
     if (strBuffer !== '') {
       const stringNode = doc.createTextNode(strBuffer);
-      console.log(stringNode);
       node.appendChild(stringNode);
     }
-    console.log(node);
   }
 };
 

--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -120,28 +120,6 @@ hterm.Keyboard.prototype.onTextInput_ = function (e) {
   runes(e.data).forEach(this.terminal.onVTKeystroke.bind(this.terminal));
 };
 
-hterm.Terminal.IO.prototype.writeUTF8 = function (string) {
-  if (this.terminal_.io !== this) {
-    throw new Error('Attempt to print from inactive IO object.');
-  }
-
-  if (!containsNonLatinCodepoints(string)) {
-    this.terminal_.interpret(string);
-    return;
-  }
-
-  runes(string).forEach(rune => {
-    this.terminal_.getTextAttributes().unicodeNode = containsNonLatinCodepoints(rune);
-    this.terminal_.interpret(rune);
-    this.terminal_.getTextAttributes().unicodeNode = false;
-  });
-};
-
-const oldIsDefault = hterm.TextAttributes.prototype.isDefault;
-hterm.TextAttributes.prototype.isDefault = function () {
-  return !this.unicodeNode && oldIsDefault.call(this);
-};
-
 const oldSetFontSize = hterm.Terminal.prototype.setFontSize;
 hterm.Terminal.prototype.setFontSize = function (px) {
   oldSetFontSize.call(this, px);
@@ -159,23 +137,6 @@ hterm.Terminal.prototype.setFontSize = function (px) {
       width: ${this.scrollPort_.characterSize.width}px;
     }
   `;
-};
-
-const oldCreateContainer = hterm.TextAttributes.prototype.createContainer;
-hterm.TextAttributes.prototype.createContainer = function (text) {
-  const container = oldCreateContainer.call(this, text);
-  if (container.style && runes(text).length === 1 && containsNonLatinCodepoints(text)) {
-    container.className += ' unicode-node';
-  }
-  return container;
-};
-
-// Do not match containers when one of them has unicode text (unicode chars need to be alone in their containers)
-const oldMatchesContainer = hterm.TextAttributes.prototype.matchesContainer;
-hterm.TextAttributes.prototype.matchesContainer = function (obj) {
-  return oldMatchesContainer.call(this, obj) &&
-    !this.unicodeNode &&
-    !containsNonLatinCodepoints(obj.textContent);
 };
 
 // there's no option to turn off the size overlay


### PR DESCRIPTION
Hi! This is a follow up PR from #1376, taking 2e58e56 into consideration. I have isolated the issue with braille characters for `vtop` by decorating the corresponding nodes with a `braille-node` class additionally to the existing `unicode-node` class. It is ready to merge to the best of my knowledge.
Cc @rauchg 

**WIP summary:**
- [x] powerline wide unicode glyphs display
- [x] CJK chars display, `wc-node` css
- [x] multiple rendering of CJK in some cases, see  https://github.com/zeit/hyper/pull/1376#issuecomment-271876444 / https://github.com/zeit/hyper/pull/1376#issuecomment-272191734
- [x] tmux empty prompt width, see screenshot below:
![tmux](https://cloud.githubusercontent.com/assets/5635553/23095605/7c65ff7a-f647-11e6-8737-b227c0842cbb.png)