### PR TITLE
fix tab text alignment issue

### DIFF
--- a/lib/components/tab.js
+++ b/lib/components/tab.js
@@ -142,14 +142,13 @@ export default class Tab extends Component {
 
       textInner: {
         position: 'absolute',
-        left: 0,
-        right: 0,
+        left: '24px',
+        right: '24px',
         top: 0,
         bottom: 0,
         textAlign: 'center',
         textOverflow: 'ellipsis',
         whiteSpace: 'nowrap',
-        padding: '0 25px',
         overflow: 'hidden'
       },
 


### PR DESCRIPTION
<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`

Thanks, again! -->

Fixes tab text alignment issue where it would get pushed out of the container because the minimum width was forced to `50 px` based on the padding.