### PR TITLE
windows: fix the missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "electron-builder": "13.6.0",
     "electron-devtools-installer": "^2.0.0",
     "electron-rebuild": "1.5.6",
+    "electron-builder-squirrel-windows": "13.6.1",
     "eslint-config-xo-react": "^0.10.0",
     "eslint-plugin-react": "^6.7.1",
     "husky": "^0.11.6",


### PR DESCRIPTION
<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`

Thanks, again! -->

As seen here, the builds brake on Windows due to a missing dependency. https://ci.appveyor.com/project/appveyor-zeit/hyper/build/1.0.564

Adding it will fix the issue. 
