### PR TITLE
only show tab title on overflow

### DIFF
--- a/lib/components/tab.js
+++ b/lib/components/tab.js
@@ -10,8 +10,23 @@ export default class Tab extends Component {
     this.handleClick = this.handleClick.bind(this);
 
     this.state = {
-      hovered: false
+      hovered: false,
+      overflowed: false
     };
+  }
+
+  componentDidMount() {
+    this.checkOverflow();
+  }
+
+  componentWillReceiveProps() {
+    this.setState({
+      overflowed: false
+    });
+  }
+
+  componentDidUpdate() {
+    this.checkOverflow();
   }
 
   shouldComponentUpdate() {
@@ -41,9 +56,20 @@ export default class Tab extends Component {
     }
   }
 
+  checkOverflow() {
+    const element = this.textTitle;
+    const overflowed = element.clientWidth < element.scrollWidth;
+
+    if (overflowed !== this.state.overflowed) {
+      this.setState({
+        overflowed
+      });
+    }
+  }
+
   template(css) {
     const {isActive, isFirst, isLast, borderColor, hasActivity} = this.props;
-    const {hovered} = this.state;
+    const {hovered, overflowed} = this.state;
 
     return (<li
       onMouseEnter={this.handleHover}
@@ -68,7 +94,10 @@ export default class Tab extends Component {
         onClick={this.handleClick}
         >
         <span
-          title={this.props.text}
+          ref={component => {
+            this.textTitle = component;
+          }}
+          title={overflowed ? this.props.text : ''}
           className={css('textInner')}
           >
           { this.props.text }


### PR DESCRIPTION
<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`

Thanks, again! -->

Now only shows the tabs titles if the text is actually overflowing.