### PR TITLE
add always on top in menu

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -145,6 +145,7 @@ app.on('ready', () => installDevExtensions(isDev).then(() => {
       height,
       minHeight: 190,
       minWidth: 370,
+      alwaysOnTop: focusedWindow ? focusedWindow.isAlwaysOnTop() : false,
       titleBarStyle: 'hidden-inset', // macOS only
       title: 'Hyper.app',
       backgroundColor: toElectronBackgroundColor(cfg.backgroundColor || '#000'),

--- a/app/menu.js
+++ b/app/menu.js
@@ -189,6 +189,22 @@ module.exports = ({createWindow, updatePlugins}) => {
     label: 'View',
     submenu: [
       {
+        type: 'checkbox',
+        label: 'Float on Top',
+        click(item, focusedWindow) {
+          if (focusedWindow) {
+            if (focusedWindow.isAlwaysOnTop()) {
+              focusedWindow.setAlwaysOnTop(false);
+            } else {
+              focusedWindow.setAlwaysOnTop(true);
+            }
+          }
+        }
+      },
+      {
+        type: 'separator'
+      },
+      {
         label: 'Reload',
         accelerator: accelerators.reload,
         click(item, focusedWindow) {

--- a/app/menu.js
+++ b/app/menu.js
@@ -1,6 +1,6 @@
 const os = require('os');
 const path = require('path');
-const {app, shell, dialog} = require('electron');
+const {app, BrowserWindow, shell, dialog} = require('electron');
 
 const {accelerators} = require('./accelerators');
 
@@ -191,12 +191,15 @@ module.exports = ({createWindow, updatePlugins}) => {
       {
         type: 'checkbox',
         label: 'Float on Top',
-        click(item, focusedWindow) {
-          if (focusedWindow) {
-            if (focusedWindow.isAlwaysOnTop()) {
-              focusedWindow.setAlwaysOnTop(false);
-            } else {
-              focusedWindow.setAlwaysOnTop(true);
+        click(item) {
+          const allWindows = BrowserWindow.getAllWindows();
+          if (item.checked) {
+            for (const win of allWindows) {
+              win.setAlwaysOnTop(true);
+            }
+          } else {
+            for (const win of allWindows) {
+              win.setAlwaysOnTop(false);
             }
           }
         }


### PR DESCRIPTION
<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`

Thanks, again! -->

Adds a `Float on Top` menu toggle item that makes Hyper stay above every other window when enabled.

<img width="244" alt="skarmavbild 2017-02-20 kl 13 35 29" src="https://cloud.githubusercontent.com/assets/1430576/23125331/7d2ca0b4-f771-11e6-9e84-996bda2109cb.png">

It's a very handy yet simple feature to have. It's the same that can be found in [Quicktime](http://www.iclarified.com/53150/how-to-keep-the-quicktime-video-player-always-on-top)/VLC and other apps.