### PR TITLE
add note about future config options to default configuration (fixes #1531)

### DIFF
--- a/app/config-default.js
+++ b/app/config-default.js
@@ -1,6 +1,6 @@
 // Future versions of Hyper may add additional config options,
 // which will not automatically be merged into this file.
-// See https://hyper.is/#cfg for all currently supported options.
+// See https://hyper.is#cfg for all currently supported options.
 
 module.exports = {
   config: {

--- a/app/config-default.js
+++ b/app/config-default.js
@@ -1,3 +1,7 @@
+// Future versions of Hyper may add additional config options,
+// which will not automatically be merged into this file.
+// See https://hyper.is/#cfg for all currently supported options.
+
 module.exports = {
   config: {
     // default font size in pixels for all tabs


### PR DESCRIPTION
<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`

Thanks, again! -->

This adds a short explanation and a link to the list of currently available configuration options to the top of the default configuration. Feel free to change the text – I can do so as well, but that seems a pretty roundabout way for such a small change :).