### PR TITLE
Falls back to default shell to install plugin on win32

### DIFF
--- a/app/plugins.js
+++ b/app/plugins.js
@@ -242,12 +242,20 @@ function install(fn) {
     };
     // determine the shell we're running in
     const whichShell = (typeof cfgShell === 'string' && cfgShell.match(/fish/)) ? 'fish' : 'posix';
-    // Use the install command that is appropriate for our shell
-    exec(installCommands[whichShell], {
+    const execOptions = {
       cwd: path,
-      env,
-      shell
-    }, err => {
+      env
+    };
+
+    // https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback
+    // node.js requires command line parsing should be compatible with cmd.exe on Windows, should able to accept `/d /s /c`
+    // but most custom shell doesn't. Instead, falls back to default shell
+    if (process.platform !== 'win32') {
+      execOptions.shell = shell;
+    }
+
+    // Use the install command that is appropriate for our shell
+    exec(installCommands[whichShell], execOptions, err => {
       if (err) {
         return fn(err);
       }


### PR DESCRIPTION
related to #1480.

This PR try to fix plugin installation fails on windows machine, if user specifies custom shell other than `cmd.exe`. The crux of this issue is due to behavior of `child_process::exec` (https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_child_process_exec_command_options_callback), node.js requires any shell specified in windows should compliant to command line parsing with `cmd.exe` to understand `/s /c` (or `/d /s /c` on later version) and does not provide any way to override it.

There isn't seems stable manner of drop-in replacement to child process supports this , so in this PR simply let `exec` falls back to default shell instead of custom shell when install plugins.

<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`

Thanks, again! -->
