### PR TITLE
Support XDG and other user config dirs

### DIFF
--- a/app/config-paths.js
+++ b/app/config-paths.js
@@ -1,0 +1,48 @@
+const {app} = require('electron');
+const {join} = require('path');
+const {homedir} = require('os');
+const {existsSync} = require('fs');
+const {productName} = require('./package.json');
+
+const xdgDir = process.env.XDG_CONFIG_HOME ?
+  join(process.env.XDG_CONFIG_HOME, productName) : false;
+const userDataDir = app.getPath('userData');
+const legacyDir = homedir();
+
+const xdgConfig = xdgDir ? join(xdgDir, 'init.js') : '';
+const userDataConfig = join(userDataDir, 'init.js');
+const legacyConfig = join(legacyDir, '.hyper.js');
+
+const xdg = existsSync(xdgConfig);
+const userData = existsSync(userDataConfig);
+const legacy = existsSync(legacyConfig);
+
+let paths;
+
+if (xdg || (xdgDir && !userData && !legacy)) {
+  paths = {
+    root: xdgDir,
+    config: xdgConfig,
+    plugins: join(xdgDir, 'plugins'),
+    localPlugins: join(xdgDir, 'plugins', 'local'),
+    joinConfigPath: (...paths) => join(xdgDir, ...paths)
+  };
+} else if (userData || !legacy) {
+  paths = {
+    root: userDataDir,
+    config: userDataConfig,
+    plugins: join(userDataDir, 'plugins'),
+    localPlugins: join(userDataDir, 'plugins', 'local'),
+    joinConfigPath: (...paths) => join(userDataDir, ...paths)
+  };
+} else {
+  paths = {
+    root: legacyDir,
+    config: legacyConfig,
+    plugins: join(legacyDir, '.hyper_plugins'),
+    localPlugins: join(legacyDir, '.hyper_plugins', 'local'),
+    joinConfigPath: (...paths) => join(legacyDir, ...paths)
+  };
+}
+
+module.exports = paths;

--- a/app/config.js
+++ b/app/config.js
@@ -1,12 +1,14 @@
 const {homedir} = require('os');
 const {statSync, renameSync, readFileSync, writeFileSync} = require('fs');
-const {resolve} = require('path');
+const {resolve, dirname} = require('path');
 const vm = require('vm');
 
 const {dialog} = require('electron');
 const isDev = require('electron-is-dev');
 const gaze = require('gaze');
 const Config = require('electron-config');
+const {sync: mkdirpSync} = require('mkdirp');
+const {config: path, root} = require('./config-paths');
 const notify = require('./notify');
 
 // local storage
@@ -17,7 +19,7 @@ const winCfg = new Config({
   }
 });
 
-let configDir = homedir();
+let configDir = root;
 if (isDev) {
   // if a local config file exists, use it
   try {
@@ -31,8 +33,7 @@ if (isDev) {
   }
 }
 
-const path = resolve(configDir, '.hyper.js');
-const pathLegacy = resolve(configDir, '.hyperterm.js');
+const pathLegacy = resolve(homedir(), '.hyperterm.js');
 
 const watchers = [];
 
@@ -118,6 +119,7 @@ exports.init = function () {
       console.log('attempting to write default config to', path);
       exec(defaultConfig);
 
+      mkdirpSync(dirname(path));
       writeFileSync(
         path,
         process.platform === 'win32' ? crlfify(defaultConfig.toString()) : defaultConfig);

--- a/app/plugins.js
+++ b/app/plugins.js
@@ -9,14 +9,17 @@ const ms = require('ms');
 const shellEnv = require('shell-env');
 
 const config = require('./config');
+const {
+  config: configFilePath,
+  plugins: path,
+  localPlugins: localPath
+} = require('./config-paths');
 const notify = require('./notify');
 
 // local storage
 const cache = new Config();
 
 // modules path
-const path = resolve(config.getConfigDir(), '.hyper_plugins');
-const localPath = resolve(path, 'local');
 const availableExtensions = new Set([
   'onApp', 'onWindow', 'onRendererWindow', 'onUnload', 'middleware',
   'reduceUI', 'reduceSessions', 'reduceTermGroups',
@@ -177,7 +180,7 @@ function syncPackageJSON() {
   const dependencies = toDependencies(plugins);
   const pkg = {
     name: 'hyper-plugins',
-    description: 'Auto-generated from `~/.hyper.js`!',
+    description: `Auto-generated from \`${configFilePath}\`!`,
     private: true,
     version: '0.0.1',
     repository: 'zeit/hyper',

--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -211,6 +211,7 @@ export function moveTo(i) {
 }
 
 function getEditCommand(shell, isWin) {
+  const {config: configFile} = remote.require('./config-paths');
   if (isWin && shell.includes('bash')) {
     return [
       ' echo Attempting to open .hyper.js with nano',
@@ -223,9 +224,8 @@ function getEditCommand(shell, isWin) {
     ];
   }
   return [
-    ' echo Attempting to open ~/.hyper.js with your \\$EDITOR',
-    // eslint-disable-next-line no-template-curly-in-string
-    ' bash -c \'exec env ${EDITOR:=nano} ~/.hyper.js\''
+    ` echo Attempting to open ${configFile} with your \\$EDITOR`,
+    ` bash -c 'exec env $\{EDITOR:=nano} ${configFile}'`
   ];
 }
 


### PR DESCRIPTION
Tries to find a config file in the following order:

- `$XDG_CONFIG_HOME`, if it's set
- Electron's `app.getPath('userData')`. This is:
  - `%APPDATA%` on Windows
  - `$XDG_CONFIG_HOME` on Linux
  - `~/Library/Application Support` on macOS
- User's home directory

For all but the home directory, files are in a subfolder of the directory which is named after the `packageName` in app/package.json.

For creation of a new config, again, `$XDG_CONFIG_HOME` is preferred, if set. Otherwise, it will use the `app.getPath('userData')` path.

This is largely a rewrite of #170, since that was too old to make rebasing/patching practical. Accordingly, merging this should close #170.
