### PR TITLE
Fix flicks after a full reload or when close tab button (dis)appear. (Fix #1490, #1575, #1579)

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -9,6 +9,7 @@
     <style>
       body {
         color: #fff;
+        -webkit-backface-visibility: hidden;
       }
 
       * {

--- a/lib/components/tab.js
+++ b/lib/components/tab.js
@@ -155,7 +155,6 @@ export default class Tab extends Component {
       icon: {
         transition: `opacity .2s ease, color .2s ease,
           transform .25s ease, background-color .1s ease`,
-        WebkitBackfaceVisibility: 'hidden', // Prevent a flick, see https://github.com/zeit/hyper/issues/1490.
         pointerEvents: 'none',
         position: 'absolute',
         right: '7px',

--- a/lib/components/tab.js
+++ b/lib/components/tab.js
@@ -155,6 +155,7 @@ export default class Tab extends Component {
       icon: {
         transition: `opacity .2s ease, color .2s ease,
           transform .25s ease, background-color .1s ease`,
+        WebkitBackfaceVisibility: 'hidden', // Prevent a flick, see https://github.com/zeit/hyper/issues/1490.
         pointerEvents: 'none',
         position: 'absolute',
         right: '7px',


### PR DESCRIPTION
<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`

Thanks, again! -->

This PR fixes #1490.

Adding `-webkit-backface-visibility: hidden` does the trick. I didn't notice any perf issue after adding it.
Adding it to main body or iframe body does the trick too. But I think it is better to colocate the trick with the incriminated transition.