### PR TITLE
Improve Linux keyboard shortcuts

### DIFF
--- a/app/accelerators.js
+++ b/app/accelerators.js
@@ -27,8 +27,8 @@ const applicationMenu = { // app/menu.js
   emojis: isMac ? 'Ctrl+Cmd+Space' : '',
 
   // View menu
-  reload: 'R',
-  fullReload: 'Shift+R',
+  reload: isMac ? 'R' : 'Alt+R',
+  fullReload: isMac ? 'Shift+R' : 'Alt+Shift+R',
   toggleDevTools: isMac ? 'Alt+I' : 'Shift+I',
   resetZoom: '0',
   zoomIn: 'plus',
@@ -39,8 +39,8 @@ const applicationMenu = { // app/menu.js
 
   // Window menu
   minimize: 'M',
-  showPreviousTab: 'Alt+Left',
-  showNextTab: 'Alt+Right',
+  showPreviousTab: isMac ? 'Alt+Left' : 'PageUp',
+  showNextTab: isMac ? 'Alt+Right' : 'PageDown',
   selectNextPane: 'Ctrl+Alt+Tab',
   selectPreviousPane: 'Ctrl+Shift+Alt+Tab',
   enterFullScreen: isMac ? 'Ctrl+Cmd+F' : 'F11'


### PR DESCRIPTION
This PR makes it a little nicer to use Linux (no idea if these shortcuts work on Windows) but it frees up `ctrl+r` for searching through previous commands and uses what seems to be the linux convention of cycling through tabs: `ctrl+PageUp/Down`. In it's current state I cannot use Hyper on Linux.

Sensitive to other open PRs (like #1509) that change a lot more, but it seems like there's still much to discuss there. Also this closes #1178.

This PR is ready to be merged.
