### PR TITLE
add custom inner children

### DIFF
--- a/lib/containers/hyper.js
+++ b/lib/containers/hyper.js
@@ -108,6 +108,7 @@ class Hyper extends Component {
         >
         <HeaderContainer/>
         <TermsContainer ref_={this.onTermsRef}/>
+        { this.props.customInnerChildren }
       </div>
 
       <NotificationsContainer/>


### PR DESCRIPTION
<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`

Thanks, again! -->

Adds `customInnerChildren` prop to `decorateHyper` so that plugins can reside inside the `hyper-main` such as `hyper-statusline` plugin.

It's necessary to easily inherit styles applied to `hyper-main` such as the new `uiFontFamily` ✌️