### PR TITLE
Disable pop-up accent window on OS X

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -40,7 +40,7 @@ const {homedir} = require('os');
 
 // Packages
 const {parse: parseUrl} = require('url');
-const {app, BrowserWindow, shell, Menu} = require('electron');
+const {app, BrowserWindow, shell, Menu, systemPreferences} = require('electron');
 const {gitDescribe} = require('git-describe');
 const uuid = require('uuid');
 const fileUriToPath = require('file-uri-to-path');
@@ -214,6 +214,10 @@ app.on('ready', () => installDevExtensions(isDev).then(() => {
         AutoUpdater(win);
       } else {
         console.log('ignoring auto updates during dev');
+      }
+      // Disable accent pop-up
+      if (process.platform === 'darwin') {
+        systemPreferences.setUserDefault('ApplePressAndHoldEnabled', 'boolean', false);
       }
     });
 


### PR DESCRIPTION
Before:
![flickering-popus](https://cloud.githubusercontent.com/assets/189619/23828044/495e7726-06d5-11e7-8e8f-194f97d4b620.gif)

After:
![no-popups](https://cloud.githubusercontent.com/assets/189619/23828045/4ce86398-06d5-11e7-9b74-1e74f43ccb13.gif)

Fix #1137 