### PR TITLE
add unicode text as css class to unicode-node

### DIFF
--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -165,7 +165,7 @@ const oldCreateContainer = hterm.TextAttributes.prototype.createContainer;
 hterm.TextAttributes.prototype.createContainer = function (text) {
   const container = oldCreateContainer.call(this, text);
   if (container.style && runes(text).length === 1 && containsNonLatinCodepoints(text)) {
-    container.className += ' unicode-node';
+    container.className += `unicode-node-${text} unicode-node`;
   }
   return container;
 };


### PR DESCRIPTION
It is frustrating to fix the gap between powerline chars. I tried to fix it with patching the font over and over again, tried to fix the font with a font editor. No luck, the gap is still there. It is still seems like below.

![image](https://cloud.githubusercontent.com/assets/198913/23987164/3f056fc0-0a39-11e7-87fe-d6aa37e59637.png)

Then i come with idea to make this chars with css. I have added a classname to the unicode wrapper and styled it with css like below.
```css

		x-row .unicode-node-,
		x-row .unicode-node- {
			text-indent: -9999px;
		}
		x-row .unicode-node-:after,
		x-row .unicode-node-:after {
			content: ' ';
			text-indent: 0;
			border-top: 10px solid transparent;
			border-bottom: 11px solid transparent;
			width: 0;
			height: 0;
		}
		x-row .unicode-node-:after {
			border-left: 7px solid;
			float: left;
		}
		x-row .unicode-node-:after {
			border-right: 7px solid;
			float: right;
		}
```
Works like a charm! 
![image](https://cloud.githubusercontent.com/assets/198913/23987228/995969cc-0a39-11e7-9547-1267aba72046.png)

