### PR TITLE
Add onDecorated property to decorated components

### DIFF
--- a/lib/utils/plugins.js
+++ b/lib/utils/plugins.js
@@ -370,9 +370,27 @@ export const middleware = store => next => action => {
   nextMiddleware(middlewares)(action);
 };
 
+// expose decorated component instance to the higher-order components
+function exposeDecorated(Component) {
+  return class extends React.Component {
+    constructor(props, context) {
+      super(props, context);
+      this.onRef = this.onRef.bind(this);
+    }
+    onRef(decorated) {
+      if (this.props.onDecorated) {
+        this.props.onDecorated(decorated);
+      }
+    }
+    render() {
+      return React.createElement(Component, Object.assign({}, this.props, {ref: this.onRef}));
+    }
+  };
+}
+
 function getDecorated(parent, name) {
   if (!decorated[name]) {
-    let class_ = parent;
+    let class_ = exposeDecorated(parent);
 
     modules.forEach(mod => {
       const method = 'decorate' + name;


### PR DESCRIPTION
<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`

Thanks, again! -->

Plugins could be more powerful if we give them a way to retrieve a reference to decorated components.

The only reference that a plugin could have is `hterm`by passing a `onTerminal` property.
It could use `ref`property in decorators but if it is not the first in plugin list, it will receive previous plugin HOC.

With this PR, every plugin's `decorate<Component>` functions (decorateTerm, decorateTerms, decorateHeader, decorateTab...) could retrieve a reference to <Component> instance.

Maybe it is a little dangerous/anti-pattern to expose all instances to plugins, but this is the same logic than `onTerminal`property.

If you are ok with this feature, I'll add website documentation.
