### PR TITLE
Fix open Preferences when using Powershell

### DIFF
--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -219,7 +219,7 @@ function getEditCommand(shell, isWin) {
   } else if (isWin) {
     return [
       ' echo Attempting to open .hyper.js with notepad',
-      ' start notepad "%userprofile%\\.hyper.js"'
+      ' cmd /c "start notepad \'%userprofile%\\.hyper.js\'"'
     ];
   }
   return [


### PR DESCRIPTION
A more general approach to opening the preferences in Notepad that works from both cmd and Powershell on Windows.

I've tested it locally on Windows 10 when using cmd and Powershell, and I think it should be ready to merge 🤞 😄 