### PR TITLE
check for null/undefined session in addSessionData

### DIFF
--- a/lib/actions/sessions.js
+++ b/lib/actions/sessions.js
@@ -54,7 +54,7 @@ export function addSessionData(uid, data) {
       data,
       effect() {
         const session = getState().sessions.sessions[uid];
-        if (session !== null && session !== undefined) {
+        if (session) {
           const enterKey = data.indexOf('\n') > 0;
           const url = enterKey ? isUrl(session.shell, data) : null;
           if (url) {

--- a/lib/actions/sessions.js
+++ b/lib/actions/sessions.js
@@ -53,22 +53,23 @@ export function addSessionData(uid, data) {
       type: SESSION_ADD_DATA,
       data,
       effect() {
-        const {shell} = getState().sessions.sessions[uid];
-        const enterKey = data.indexOf('\n') > 0;
-        const url = enterKey ? isUrl(shell, data) : null;
-        if (url) {
-          dispatch({
-            type: SESSION_URL_SET,
-            uid,
-            url
-          });
-        } else {
-          dispatch({
-            type: SESSION_PTY_DATA,
-            uid,
-            data
-          });
+        const session = getState().sessions.sessions[uid];
+        if (session !== null && session !== undefined) {
+          const enterKey = data.indexOf('\n') > 0;
+          const url = enterKey ? isUrl(session.shell, data) : null;
+          if (url) {
+            return dispatch({
+              type: SESSION_URL_SET,
+              uid,
+              url
+            });
+          }
         }
+        dispatch({
+          type: SESSION_PTY_DATA,
+          uid,
+          data
+        });
       }
     });
   };


### PR DESCRIPTION
Work around incorrect event ordering between `SESSION_PTY_EXIT` and `SESSION_ADD_DATA`. See #1628 for more context.
This is ready to merge. Fixes #1628.
