### PR TITLE
Fix partial TermGroup decoration

### DIFF
--- a/lib/components/term-group.js
+++ b/lib/components/term-group.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import {connect} from 'react-redux';
 import Component from '../component';
-import {decorate, getTermProps} from '../utils/plugins';
+import {decorate, getTermProps, getTermGroupProps} from '../utils/plugins';
 import {resizeTermGroup} from '../actions/term-groups';
 import Term_ from './term';
 import SplitPane_ from './split-pane';
@@ -97,9 +97,9 @@ class TermGroup_ extends Component {
     }
 
     const groups = childGroups.map(child => {
-      const props = Object.assign({}, this.props, {
+      const props = getTermGroupProps(child.uid, this.props.parentProps, Object.assign({}, this.props, {
         termGroup: child
-      });
+      }));
 
       return (<DecoratedTermGroup
         key={child.uid}

--- a/lib/components/term-group.js
+++ b/lib/components/term-group.js
@@ -101,7 +101,7 @@ class TermGroup_ extends Component {
         termGroup: child
       });
 
-      return (<TermGroup
+      return (<DecoratedTermGroup
         key={child.uid}
         {...props}
         />);
@@ -123,5 +123,7 @@ const TermGroup = connect(
     }
   })
 )(TermGroup_);
+
+const DecoratedTermGroup = decorate(TermGroup, 'TermGroup');
 
 export default TermGroup;

--- a/lib/components/terms.js
+++ b/lib/components/terms.js
@@ -101,7 +101,8 @@ export default class Terms extends Component {
             onTitle: this.props.onTitle,
             onData: this.props.onData,
             onURLAbort: this.props.onURLAbort,
-            quickEdit: this.props.quickEdit
+            quickEdit: this.props.quickEdit,
+            parentProps: this.props
           });
 
           return (


### PR DESCRIPTION
First TermGroup of each window is decorated [here](https://github.com/zeit/hyper/blob/master/lib/components/terms.js#L6)

But when a TermGroup add a sub-TermGroup in a SplitPane, it is not decorated.

This PR fix this.