### PR TITLE
Doc: fix space between text and table

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -276,7 +276,7 @@
       }
 
       #content p {
-        margin: 20px 0 0 0;
+        margin: 0 0 20px;
         line-height: 18px;
       }
 
@@ -316,6 +316,7 @@
       #content table {
         width: 100%;
         border-collapse: collapse;
+        margin-bottom: 20px;
       }
 
       #content td > table {
@@ -510,6 +511,7 @@
         #content table {
           margin-left: 0;
           margin-right: 0;
+          margin-bottom: 20px;
         }
 
         #content table td {

--- a/website/index.html
+++ b/website/index.html
@@ -276,7 +276,7 @@
       }
 
       #content p {
-        margin: 0 0 20px;
+        margin: 20px 0 0 0;
         line-height: 18px;
       }
 


### PR DESCRIPTION
<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`

Thanks, again! -->
This PR fixes wrong space between paragraph and table.

Before:
<img width="852" alt="capture d ecran 2017-03-28 a 14 40 41" src="https://cloud.githubusercontent.com/assets/4137761/24405591/b6f5e60a-13c5-11e7-9f55-d345f6ede773.png">

After:
<img width="860" alt="capture d ecran 2017-03-28 a 14 40 00" src="https://cloud.githubusercontent.com/assets/4137761/24405597/bcae6752-13c5-11e7-8162-40aef76b5284.png">
