### PR TITLE
Simplify and correct newlines replacement logic on Windows

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -88,7 +88,7 @@ function exec(str) {
 // to text formatted with DOS line endings. We do this because the default
 // text editor on Windows (notepad) doesn't Deal with LF files. Still. In 2017.
 function crlfify(str) {
-  return str.split('\n').map(x => x.indexOf('\r') < 0 ? x : `${x}\r`).join('\n');
+  return str.replace(/\r?\n/g, '\r\n');
 }
 
 exports.subscribe = function (fn) {


### PR DESCRIPTION
New lines in the `.hyper.js` config file are not replaced correctly on Windows.

There's an error in the replacement logic: `x => x.indexOf('\r') < 0 ? x : '${x}\r'`. The test should actually be `x.indexOf('\r') >= 0`.

However, I've simplyfied the replacement logic to make it more clear what happens.

Should be ready to merge!