### PR TITLE
Get font color 'glow' functionally

### DIFF
--- a/lib/components/tab.js
+++ b/lib/components/tab.js
@@ -55,7 +55,7 @@ export default class Tab extends Component {
         isFirst && 'first',
         isActive && 'active',
         isFirst && isActive && 'firstActive',
-        hasActivity && 'hasActivity'
+        hasActivity > 0 && 'hasActivity'
       )}
       >
       { this.props.customChildrenBefore }
@@ -124,12 +124,7 @@ export default class Tab extends Component {
         }
       },
 
-      hasActivity: {
-        color: '#50E3C2',
-        ':hover': {
-          color: '#50E3C2'
-        }
-      },
+      hasActivity: getHeaderColor(this.props.hasActivity),
 
       text: {
         transition: 'color .2s ease',
@@ -197,4 +192,15 @@ export default class Tab extends Component {
     };
   }
 
+}
+
+function getHeaderColor(activity = 0) {
+  const color = `hsl(144, ${(73 + (activity * 5)).toFixed()}%, ${(45 + activity).toFixed()}%)`;
+
+  return {
+    color,
+    ':hover': {
+      color
+    }
+  };
 }


### PR DESCRIPTION
This is complete and ready to merge, although I have an open question about specific implementation open within the issue it closes (#536).

I think this is the simplest way to create the glowing affect, and can be more finely tuned without updating the function simply by changing the number reducer (`ui`) counts up to (currently `5`). 

Let me know if you see any updates! I will edit this PR to list other PRs as I see them.

Closes #536 