### PR TITLE
Add displayName for each plugin HOC (dev-tools)

### DIFF
--- a/lib/utils/plugins.js
+++ b/lib/utils/plugins.js
@@ -391,6 +391,7 @@ function exposeDecorated(Component) {
 function getDecorated(parent, name) {
   if (!decorated[name]) {
     let class_ = exposeDecorated(parent);
+    class_.displayName = `_exposeDecorated(${name})`;
 
     modules.forEach(mod => {
       const method = 'decorate' + name;
@@ -401,6 +402,7 @@ function getDecorated(parent, name) {
 
         try {
           class__ = fn(class_, {React, Component, Notification, notify});
+          class__.displayName = `${fn._pluginName}(${name})`;
         } catch (err) {
           console.error(err.stack);
           notify('Plugin error', `${fn._pluginName}: Error occurred in \`${method}\`. Check Developer Tools for details`);


### PR DESCRIPTION
<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`

Thanks, again! -->
With a lot of plugins it's hard to figure out which HOC is displayed in dev-tools:
![capture d ecran 2017-04-08 a 11 48 38](https://cloud.githubusercontent.com/assets/4137761/24827893/f175981c-1c52-11e7-9af7-e556825bdfe4.png)

With this PR, each HOC is associated with its plugin:
![capture d ecran 2017-04-08 a 11 47 40](https://cloud.githubusercontent.com/assets/4137761/24827901/1a84223c-1c53-11e7-82fa-59f1d5eb993a.png)
