### PR TITLE
Fix open Preferences on Windows

### DIFF
--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -217,9 +217,15 @@ function getEditCommand(shell, isWin) {
       ' nano .hyper.js'
     ];
   } else if (isWin) {
+    if (shell.includes('powershell')) {
+      return [
+        ' echo "Attempting to open .hyper.js with default application"',
+        ' Invoke-Item $env:userprofile/.hyper.js'
+      ];
+    }
     return [
-      ' echo Attempting to open .hyper.js with notepad',
-      ' start notepad "%userprofile%\\.hyper.js"'
+      ' echo Attempting to open .hyper.js with default application',
+      ' start "" "%userprofile%\\.hyper.js"'
     ];
   }
   return [


### PR DESCRIPTION
Able to merge.

This change causes Edit -> Preferences to open ~/.hyper.js with the system's default application. I tested it to work with cmd, git bash, ubuntu bash, and Powershell. Someone may want to check it on their machine in case of differences in my config.
