### PR TITLE
Update website link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,6 @@ to the Terms of Service by running `sudo xcodebuild` after a fresh Xcode install
 ## Related Repositories
 
 - [Art](https://github.com/zeit/art/tree/master/hyper)
-- [Website](https://github.com/zeit/hyper-website)
+- [Website](website/)
 - [Sample Extension](https://github.com/zeit/hyperpower)
 - [Sample Theme](https://github.com/zeit/hyperyellow)


### PR DESCRIPTION
https://github.com/zeit/hyper-website says it's deprecated and redirects to this repository's `website/` folder. This PR actually updates website link in `readme.md`.

As suggested in comments,

- This PR is ready to be merged
- This PR contains a single commit which wraps atomic change: no by-products or side-effects or this repository
- You may be willing to delete the other now-defunct repository or keep it for historical purpose.
- Of course you can rebase it

Cheerio and thanks again for that's an awesome piece of code 😄