### PR TITLE
#1699 - add configurable interval to .hyper.js config file watch.

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -39,7 +39,8 @@ const watchers = [];
 let cfg = {};
 
 function watch() {
-  gaze(path, function (err) {
+  // watch for changes on config every 2s
+  gaze(path, {interval: 2000}, function (err) {
     if (err) {
       throw err;
     }


### PR DESCRIPTION
While looking at another issue related to `gaze` scanning the home folder on Windows, I fixed the following: 
- #1699 - Hyper is reading .hyper.js 40 times a second, constantly.

You can update the following in the `.hyper.js` config file to change the interval:

```
    // number of milliseconds to wait between checking if config file has been updated
    configFileWatchInterval: 5000
```

I have verified with ProcessMonitor on Windows, that the watch() read interval has been altered to the configured value.

This PR should be ready to merge.
