### PR TITLE
Open Hyper config in the native desktop's default manner

### DIFF
--- a/app/menu.js
+++ b/app/menu.js
@@ -3,6 +3,7 @@ const path = require('path');
 const {app, shell, dialog} = require('electron');
 
 const {accelerators} = require('./accelerators');
+const {getConfigDir} = require('./config');
 
 const isMac = process.platform === 'darwin';
 const appName = app.getName();
@@ -25,12 +26,9 @@ module.exports = ({createWindow, updatePlugins}) => {
       {
         label: 'Preferences...',
         accelerator: accelerators.preferences,
-        click(item, focusedWindow) {
-          if (focusedWindow) {
-            focusedWindow.rpc.emit('preferences');
-          } else {
-            createWindow(win => win.rpc.emit('preferences'));
-          }
+        click() {
+          const configFile = path.resolve(getConfigDir(), '.hyper.js');
+          shell.openItem(configFile);
         }
       },
       {
@@ -174,12 +172,9 @@ module.exports = ({createWindow, updatePlugins}) => {
       {
         label: 'Preferences...',
         accelerator: accelerators.preferences,
-        click(item, focusedWindow) {
-          if (focusedWindow) {
-            focusedWindow.rpc.emit('preferences');
-          } else {
-            createWindow(win => win.rpc.emit('preferences'));
-          }
+        click() {
+          const configFile = path.resolve(getConfigDir(), '.hyper.js');
+          shell.openItem(configFile);
         }
       }
     );

--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -1,6 +1,3 @@
-import {EOL} from 'os';
-
-import {remote} from 'electron';
 import * as shellEscape from 'php-escape-shell';
 import last from '../utils/array';
 import isExecutable from '../utils/file';
@@ -24,7 +21,6 @@ import {
   UI_MOVE_TO,
   UI_MOVE_NEXT_PANE,
   UI_MOVE_PREV_PANE,
-  UI_SHOW_PREFERENCES,
   UI_WINDOW_GEOMETRY_CHANGED,
   UI_WINDOW_MOVE,
   UI_OPEN_FILE
@@ -205,52 +201,6 @@ export function moveTo(i) {
         } else {
           console.log('ignoring inexistent index', i);
         }
-      }
-    });
-  };
-}
-
-function getEditCommand(shell, isWin) {
-  if (isWin && shell.includes('bash')) {
-    return [
-      ' echo Attempting to open .hyper.js with nano',
-      ' nano .hyper.js'
-    ];
-  } else if (isWin) {
-    return [
-      ' echo Attempting to open .hyper.js with notepad',
-      ' start notepad "%userprofile%\\.hyper.js"'
-    ];
-  }
-  return [
-    ' echo Attempting to open ~/.hyper.js with your \\$EDITOR',
-    // eslint-disable-next-line no-template-curly-in-string
-    ' bash -c \'exec env ${EDITOR:=nano} ~/.hyper.js\''
-  ];
-}
-
-export function showPreferences() {
-  const plugins = remote.require('./plugins');
-  const {shell} = plugins.getDecoratedConfig();
-  const message = getEditCommand(shell, process.platform === 'win32');
-
-  return dispatch => {
-    dispatch({
-      type: UI_SHOW_PREFERENCES,
-      effect() {
-        dispatch(requestSession());
-        // Replace this hack with an async action
-        rpc.once('session add', ({uid}) => {
-          rpc.once('session data', () => {
-            dispatch(sendSessionData(
-              uid,
-              [
-                ...message,
-                ''
-              ].join(EOL)
-            ));
-          });
-        });
       }
     });
   };

--- a/lib/index.js
+++ b/lib/index.js
@@ -126,10 +126,6 @@ rpc.on('prev pane req', () => {
   store_.dispatch(uiActions.moveToPreviousPane());
 });
 
-rpc.on('preferences', () => {
-  store_.dispatch(uiActions.showPreferences());
-});
-
 rpc.on('open file', ({path}) => {
   store_.dispatch(uiActions.openFile(path));
 });


### PR DESCRIPTION
This PR fixes #1529

It uses Electron API to open config file with OS default editor.
Bonus: Dev config file is opened if used.

We should test if no default app is set to open a `.js` file on MacOS/Windows/Linux 
