### PR TITLE
wipe contents before \k

### DIFF
--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -177,6 +177,7 @@ export default class Term extends Component {
   }
 
   clear() {
+    this.term.wipeContents();
     this.term.onVTKeystroke('\f');
   }
 


### PR DESCRIPTION
Wipe contents before `\k`.

-> Still input `^L` don't know why. ( `^L` = result of commands clear ) 

FIX: 
#1808