### PR TITLE
Set line-height same as font size

### DIFF
--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -253,9 +253,6 @@ export default class Term extends Component {
       .cursor-node[focus="false"] {
          border-width: 1px !important;
       }
-      x-row {
-        line-height: ${this.props.fontSize}px;
-      }
       ${hyperCaret}
       ${scrollBarCss}
       ${selectCss}

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -253,6 +253,9 @@ export default class Term extends Component {
       .cursor-node[focus="false"] {
          border-width: 1px !important;
       }
+      x-row {
+        line-height: 1em;
+      }
       ${hyperCaret}
       ${scrollBarCss}
       ${selectCss}

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -254,7 +254,7 @@ export default class Term extends Component {
          border-width: 1px !important;
       }
       x-row {
-        line-height: 1.2em;
+        line-height: ${this.props.fontSize}px;
       }
       ${hyperCaret}
       ${scrollBarCss}


### PR DESCRIPTION
Set `x-row` `line-height` same as `font-size` to fix issues with some fonts on last line of terminal.

This PR should fix https://github.com/zeit/hyper/issues/628

UPDATE: removed whole css as chabou said line-height is same as font size as default