### PR TITLE
Update hterm-umdjs to fix wcnode error

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
   "dependencies": {
     "aphrodite-simple": "0.4.1",
     "color": "0.11.4",
-    "hterm-umdjs": "1.1.3",
+    "hterm-umdjs": "1.2.0",
     "json-loader": "0.5.4",
     "mousetrap": "1.6.0",
     "ms": "0.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3011,9 +3011,9 @@ hosted-git-info@^2.1.4, hosted-git-info@^2.2.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.4.2.tgz#0076b9f46a270506ddbaaea56496897460612a67"
 
-hterm-umdjs@1.1.3:
-  version "1.1.3+1.58.sha.15ed490"
-  resolved "https://registry.yarnpkg.com/hterm-umdjs/-/hterm-umdjs-1.1.3.tgz#8b57bcaded5ba9541d6c8e32a82b34abb93e885e"
+hterm-umdjs@1.2.0:
+  version "1.2.0+1.63.sha.a543c06"
+  resolved "https://registry.yarnpkg.com/hterm-umdjs/-/hterm-umdjs-1.2.0.tgz#c6bb793f60669f17619a06b113db1bc14c2065cd"
 
 http-signature@~1.1.0:
   version "1.1.1"


### PR DESCRIPTION
Hi there!

Hyper seems to break when running `docker-compose logs` in a Vagrant ssh session. (due to the long line of text?)

![screen shot 2017-05-19 at 3 27 02 pm](https://cloud.githubusercontent.com/assets/1763968/26235098/255c1492-3ca8-11e7-9314-a83d7f242cca.png)

Updating the `hterm-umdjs` package seems to fix the issue.
