### PR TITLE
CMD+K: Clear Differently if Command Running

### DIFF
--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -177,7 +177,20 @@ export default class Term extends Component {
   }
 
   clear() {
-    this.term.onVTKeystroke('\f');
+    // Command Running
+    if (this.term.getCursorColumn() === 0) {
+      // Clear Screen and Scrollback Buffer
+      this.term.wipeContents();
+    } else {
+      // Clear Scrollback Buffer
+      this.term.scrollbackRows_.length = 0;
+      // Clear Screen but Leave Prompt
+      this.term.onVTKeystroke('\f');
+      // Reset Cursor Position
+      this.term.syncCursorPosition_();
+      // Fix Scoll Position Bug
+      this.term.scrollPort_.redraw_();
+    }
   }
 
   moveWordLeft() {


### PR DESCRIPTION
Ready to be merged after tested by others! Fixes https://github.com/zeit/hyper/issues/1808. 

Fixed using @stephan281094's comment on https://github.com/zeit/hyper/pull/1811:

> I think the wipeContents function should only be called when there's no prompt active. Likewise, the onVTKeystroke('\f'); function should only be called when there is a prompt active.
