### PR TITLE
Update node-pty to 0.6.6

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -23,7 +23,7 @@
     "mkdirp": "0.5.1",
     "ms": "0.7.1",
     "node-fetch": "1.6.3",
-    "node-pty": "0.6.4",
+    "node-pty": "0.6.6",
     "semver": "5.3.0",
     "shell-env": "0.2.0",
     "uuid": "3.0.0",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -263,9 +263,9 @@ node-fetch@1.6.3:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
-node-pty@0.6.4:
-  version "0.6.4"
-  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.6.4.tgz#8d90c8bfa18514a3d600e528c87bdd932f10bc57"
+node-pty@0.6.6:
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.6.6.tgz#7f507148f917aa809a714c2864d98f0e6d3afcd6"
   dependencies:
     nan "2.5.0"
 


### PR DESCRIPTION
Comes with winpty 0.4.3 (https://github.com/rprichard/winpty/releases/tag/0.4.3)

<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`

Thanks, again! -->
