### PR TITLE
Fix unicode display, third attempt :\

### DIFF
--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -378,7 +378,7 @@ hterm.Screen.prototype.insertString = function (str) {
     }
     reverseOffset = 0;
   }
-  this.wrapUnicode(cursorNode);
+  cursorNode = this.wrapUnicode(cursorNode);
   if (this.textAttributes.matchesContainer(cursorNode)) {
     if (reverseOffset === 0) {
       cursorNode.textContent = cursorNodeText + str;
@@ -390,74 +390,86 @@ hterm.Screen.prototype.insertString = function (str) {
           str + hterm.TextAttributes.nodeSubstr(cursorNode, offset);
     }
     this.cursorOffset_ += strWidth;
-    this.wrapUnicode(cursorNode);
+    cursorNode = this.wrapUnicode(cursorNode);
     return;
   }
   if (offset === 0) {
-    const previousSibling = cursorNode.previousSibling;
+    let previousSibling = cursorNode.previousSibling;
     if (previousSibling &&
         this.textAttributes.matchesContainer(previousSibling)) {
       previousSibling.textContent += str;
       this.cursorNode_ = previousSibling;
       this.cursorOffset_ = lib.wc.strWidth(previousSibling.textContent);
-      this.wrapUnicode(previousSibling);
+      previousSibling = this.wrapUnicode(previousSibling);
       return;
     }
-    const newNode = this.textAttributes.createContainer(str);
+    let newNode = this.textAttributes.createContainer(str);
     this.cursorRowNode_.insertBefore(newNode, cursorNode);
     this.cursorNode_ = newNode;
     this.cursorOffset_ = strWidth;
-    this.wrapUnicode(newNode);
+    newNode = this.wrapUnicode(newNode);
     return;
   }
   if (reverseOffset === 0) {
-    const nextSibling = cursorNode.nextSibling;
+    let nextSibling = cursorNode.nextSibling;
     if (nextSibling &&
         this.textAttributes.matchesContainer(nextSibling)) {
       nextSibling.textContent = str + nextSibling.textContent;
       this.cursorNode_ = nextSibling;
       this.cursorOffset_ = lib.wc.strWidth(str);
-      this.wrapUnicode(nextSibling);
+      nextSibling = this.wrapUnicode(nextSibling);
       return;
     }
-    const newNode = this.textAttributes.createContainer(str);
+    let newNode = this.textAttributes.createContainer(str);
     this.cursorRowNode_.insertBefore(newNode, nextSibling);
     this.cursorNode_ = newNode;
     this.cursorOffset_ = hterm.TextAttributes.nodeWidth(newNode);
-    this.wrapUnicode(newNode);
+    newNode = this.wrapUnicode(newNode);
     return;
   }
-  this.splitNode_(cursorNode, offset);
-  const newNode = this.textAttributes.createContainer(str);
+  cursorNode = this.splitNode_(cursorNode, offset);
+  let newNode = this.textAttributes.createContainer(str);
   this.cursorRowNode_.insertBefore(newNode, cursorNode.nextSibling);
   this.cursorNode_ = newNode;
   this.cursorOffset_ = strWidth;
-  this.wrapUnicode(newNode);
+  newNode = this.wrapUnicode(newNode);
 };
 
 // patch for unicode encapsulation
 hterm.Screen.prototype.splitNode_ = function (node, offset) {
-  const afterNode = node.cloneNode(false);
+  let afterNode = node.cloneNode(false);
   const textContent = node.textContent;
   node.textContent = hterm.TextAttributes.nodeSubstr(node, 0, offset);
   afterNode.textContent = lib.wc.substr(textContent, offset);
-  this.wrapUnicode(node);
-  this.wrapUnicode(afterNode);
+  node = this.wrapUnicode(node);
+  afterNode = this.wrapUnicode(afterNode);
   if (afterNode.textContent) {
     node.parentNode.insertBefore(afterNode, node.nextSibling);
   }
   if (!node.textContent) {
     node.parentNode.removeChild(node);
   }
+  return node;
 };
 
 // encapsulate unicode chars in individual spans
 // keep them in the parent node with the rest of the content
 // maintains styling and overflow display in divs with a background color
+// WARNING: this method may reassign the node and return it, please use as follow:
+// myNode = this.wrapUnicode(myNode);
 hterm.Screen.prototype.wrapUnicode = function (node) {
   const nodeContent = node.textContent;
   if (containsNonLatinCodepoints(nodeContent) && !node.wcNode) {
     const doc = this.terminal.document_;
+    // replace text nodes by span elements to append children
+    if (node.nodeType === 3) {
+      const span = doc.createElement('span');
+      span.textContent = node.textContent;
+      node.parentNode.insertBefore(span, node);
+      node.parentNode.removeChild(node);
+      node = span;
+    }
+    // wrap unicode
     if (!node.unicodeParentNode) {
       node.unicodeParentNode = true;
       node.className += ' unicode-parent-node';
@@ -485,6 +497,7 @@ hterm.Screen.prototype.wrapUnicode = function (node) {
       node.appendChild(stringNode);
     }
   }
+  return node;
 };
 
 // ensure no text node contains unicode

--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -378,7 +378,7 @@ hterm.Screen.prototype.insertString = function (str) {
     }
     reverseOffset = 0;
   }
-  cursorNode = this.wrapUnicode(cursorNode);
+  this.cursorNode_ = cursorNode = this.wrapUnicode(cursorNode);
   if (this.textAttributes.matchesContainer(cursorNode)) {
     if (reverseOffset === 0) {
       cursorNode.textContent = cursorNodeText + str;
@@ -390,7 +390,7 @@ hterm.Screen.prototype.insertString = function (str) {
           str + hterm.TextAttributes.nodeSubstr(cursorNode, offset);
     }
     this.cursorOffset_ += strWidth;
-    cursorNode = this.wrapUnicode(cursorNode);
+    this.cursorNode_ = cursorNode = this.wrapUnicode(cursorNode);
     return;
   }
   if (offset === 0) {
@@ -400,14 +400,14 @@ hterm.Screen.prototype.insertString = function (str) {
       previousSibling.textContent += str;
       this.cursorNode_ = previousSibling;
       this.cursorOffset_ = lib.wc.strWidth(previousSibling.textContent);
-      previousSibling = this.wrapUnicode(previousSibling);
+      this.cursorNode_ = previousSibling = this.wrapUnicode(previousSibling);
       return;
     }
     let newNode = this.textAttributes.createContainer(str);
     this.cursorRowNode_.insertBefore(newNode, cursorNode);
     this.cursorNode_ = newNode;
     this.cursorOffset_ = strWidth;
-    newNode = this.wrapUnicode(newNode);
+    this.cursorNode_ = newNode = this.wrapUnicode(newNode);
     return;
   }
   if (reverseOffset === 0) {
@@ -417,14 +417,14 @@ hterm.Screen.prototype.insertString = function (str) {
       nextSibling.textContent = str + nextSibling.textContent;
       this.cursorNode_ = nextSibling;
       this.cursorOffset_ = lib.wc.strWidth(str);
-      nextSibling = this.wrapUnicode(nextSibling);
+      this.cursorNode_ = nextSibling = this.wrapUnicode(nextSibling);
       return;
     }
     let newNode = this.textAttributes.createContainer(str);
     this.cursorRowNode_.insertBefore(newNode, nextSibling);
     this.cursorNode_ = newNode;
     this.cursorOffset_ = hterm.TextAttributes.nodeWidth(newNode);
-    newNode = this.wrapUnicode(newNode);
+    this.cursorNode_ = newNode = this.wrapUnicode(newNode);
     return;
   }
   cursorNode = this.splitNode_(cursorNode, offset);
@@ -432,7 +432,7 @@ hterm.Screen.prototype.insertString = function (str) {
   this.cursorRowNode_.insertBefore(newNode, cursorNode.nextSibling);
   this.cursorNode_ = newNode;
   this.cursorOffset_ = strWidth;
-  newNode = this.wrapUnicode(newNode);
+  this.cursorNode_ = newNode = this.wrapUnicode(newNode);
 };
 
 // patch for unicode encapsulation
@@ -441,11 +441,11 @@ hterm.Screen.prototype.splitNode_ = function (node, offset) {
   const textContent = node.textContent;
   node.textContent = hterm.TextAttributes.nodeSubstr(node, 0, offset);
   afterNode.textContent = lib.wc.substr(textContent, offset);
-  node = this.wrapUnicode(node);
-  afterNode = this.wrapUnicode(afterNode);
   if (afterNode.textContent) {
     node.parentNode.insertBefore(afterNode, node.nextSibling);
   }
+  node = this.wrapUnicode(node);
+  afterNode = this.wrapUnicode(afterNode);
   if (!node.textContent) {
     node.parentNode.removeChild(node);
   }
@@ -465,8 +465,10 @@ hterm.Screen.prototype.wrapUnicode = function (node) {
     if (node.nodeType === 3) {
       const span = doc.createElement('span');
       span.textContent = node.textContent;
-      node.parentNode.insertBefore(span, node);
-      node.parentNode.removeChild(node);
+      if (node.parentNode) {
+        node.parentNode.insertBefore(span, node);
+        node.parentNode.removeChild(node);
+      }
       node = span;
     }
     // wrap unicode

--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -86,21 +86,17 @@ lib.wc.substr = function (str, start, optWidth) {
   const chars = runes(str);
   let startIndex;
   let endIndex;
-  let width = 0;
+  let width;
 
-  for (let i = 0; i < chars.length; i++) {
-    const codePoint = chars[i].codePointAt(0);
-    const charWidth = lib.wc.charWidth(codePoint);
-    if ((width + charWidth) > start) {
-      startIndex = i;
+  for (startIndex = 0, width = 0; startIndex < chars.length; startIndex++) {
+    width += lib.wc.charWidth(chars[startIndex].codePointAt(0));
+    if (width > start) {
       break;
     }
-    width += charWidth;
   }
 
   if (optWidth) {
-    width = 0;
-    for (endIndex = startIndex; endIndex < chars.length && width < optWidth; endIndex++) {
+    for (endIndex = startIndex, width = 0; endIndex < chars.length && width < optWidth; endIndex++) {
       width += lib.wc.charWidth(chars[endIndex].charCodeAt(0));
     }
 
@@ -120,28 +116,6 @@ hterm.Keyboard.prototype.onTextInput_ = function (e) {
   runes(e.data).forEach(this.terminal.onVTKeystroke.bind(this.terminal));
 };
 
-hterm.Terminal.IO.prototype.writeUTF8 = function (string) {
-  if (this.terminal_.io !== this) {
-    throw new Error('Attempt to print from inactive IO object.');
-  }
-
-  if (!containsNonLatinCodepoints(string)) {
-    this.terminal_.interpret(string);
-    return;
-  }
-
-  runes(string).forEach(rune => {
-    this.terminal_.getTextAttributes().unicodeNode = containsNonLatinCodepoints(rune);
-    this.terminal_.interpret(rune);
-    this.terminal_.getTextAttributes().unicodeNode = false;
-  });
-};
-
-const oldIsDefault = hterm.TextAttributes.prototype.isDefault;
-hterm.TextAttributes.prototype.isDefault = function () {
-  return !this.unicodeNode && oldIsDefault.call(this);
-};
-
 const oldSetFontSize = hterm.Terminal.prototype.setFontSize;
 hterm.Terminal.prototype.setFontSize = function (px) {
   oldSetFontSize.call(this, px);
@@ -153,29 +127,12 @@ hterm.Terminal.prototype.setFontSize = function (px) {
     doc.head.appendChild(unicodeNodeStyle);
   }
   unicodeNodeStyle.innerHTML = `
-    .unicode-node {
+    .unicode-node:not(.wc-node) {
       display: inline-block;
       vertical-align: top;
       width: ${this.scrollPort_.characterSize.width}px;
     }
   `;
-};
-
-const oldCreateContainer = hterm.TextAttributes.prototype.createContainer;
-hterm.TextAttributes.prototype.createContainer = function (text) {
-  const container = oldCreateContainer.call(this, text);
-  if (container.style && runes(text).length === 1 && containsNonLatinCodepoints(text)) {
-    container.className += ' unicode-node';
-  }
-  return container;
-};
-
-// Do not match containers when one of them has unicode text (unicode chars need to be alone in their containers)
-const oldMatchesContainer = hterm.TextAttributes.prototype.matchesContainer;
-hterm.TextAttributes.prototype.matchesContainer = function (obj) {
-  return oldMatchesContainer.call(this, obj) &&
-    !this.unicodeNode &&
-    !containsNonLatinCodepoints(obj.textContent);
 };
 
 // there's no option to turn off the size overlay
@@ -386,6 +343,157 @@ hterm.Terminal.prototype.focusHyperCaret = function () {
     this.cursorNode_.appendChild(this.hyperCaret);
   }
   this.hyperCaret.focus();
+};
+
+// patch for unicode encapsulation
+// see comments in original code
+hterm.Screen.prototype.insertString = function (str) {
+  let cursorNode = this.cursorNode_;
+  let cursorNodeText = cursorNode.textContent;
+  this.cursorRowNode_.removeAttribute('line-overflow');
+  const strWidth = lib.wc.strWidth(str);
+  this.cursorPosition.column += strWidth;
+  let offset = this.cursorOffset_;
+  let reverseOffset = hterm.TextAttributes.nodeWidth(cursorNode) - offset;
+  if (reverseOffset < 0) {
+    const ws = lib.f.getWhitespace(-reverseOffset);
+    if (!(this.textAttributes.underline ||
+          this.textAttributes.strikethrough ||
+          this.textAttributes.background ||
+          this.textAttributes.wcNode ||
+          this.textAttributes.tileData !== null)) {
+      str = ws + str;
+    } else if (cursorNode.nodeType === 3 ||
+               !(cursorNode.wcNode ||
+                 cursorNode.tileNode ||
+                 cursorNode.style.textDecoration ||
+                 cursorNode.style.backgroundColor)) {
+      cursorNode.textContent = (cursorNodeText += ws);
+    } else {
+      const wsNode = cursorNode.ownerDocument.createTextNode(ws);
+      this.cursorRowNode_.insertBefore(wsNode, cursorNode.nextSibling);
+      this.cursorNode_ = cursorNode = wsNode;
+      this.cursorOffset_ = offset = -reverseOffset;
+      cursorNodeText = ws;
+    }
+    reverseOffset = 0;
+  }
+  this.wrapUnicode(cursorNode);
+  if (this.textAttributes.matchesContainer(cursorNode)) {
+    if (reverseOffset === 0) {
+      cursorNode.textContent = cursorNodeText + str;
+    } else if (offset === 0) {
+      cursorNode.textContent = str + cursorNodeText;
+    } else {
+      cursorNode.textContent =
+          hterm.TextAttributes.nodeSubstr(cursorNode, 0, offset) +
+          str + hterm.TextAttributes.nodeSubstr(cursorNode, offset);
+    }
+    this.cursorOffset_ += strWidth;
+    this.wrapUnicode(cursorNode);
+    return;
+  }
+  if (offset === 0) {
+    const previousSibling = cursorNode.previousSibling;
+    if (previousSibling &&
+        this.textAttributes.matchesContainer(previousSibling)) {
+      previousSibling.textContent += str;
+      this.cursorNode_ = previousSibling;
+      this.cursorOffset_ = lib.wc.strWidth(previousSibling.textContent);
+      this.wrapUnicode(previousSibling);
+      return;
+    }
+    const newNode = this.textAttributes.createContainer(str);
+    this.cursorRowNode_.insertBefore(newNode, cursorNode);
+    this.cursorNode_ = newNode;
+    this.cursorOffset_ = strWidth;
+    this.wrapUnicode(newNode);
+    return;
+  }
+  if (reverseOffset === 0) {
+    const nextSibling = cursorNode.nextSibling;
+    if (nextSibling &&
+        this.textAttributes.matchesContainer(nextSibling)) {
+      nextSibling.textContent = str + nextSibling.textContent;
+      this.cursorNode_ = nextSibling;
+      this.cursorOffset_ = lib.wc.strWidth(str);
+      this.wrapUnicode(nextSibling);
+      return;
+    }
+    const newNode = this.textAttributes.createContainer(str);
+    this.cursorRowNode_.insertBefore(newNode, nextSibling);
+    this.cursorNode_ = newNode;
+    this.cursorOffset_ = hterm.TextAttributes.nodeWidth(newNode);
+    this.wrapUnicode(newNode);
+    return;
+  }
+  this.splitNode_(cursorNode, offset);
+  const newNode = this.textAttributes.createContainer(str);
+  this.cursorRowNode_.insertBefore(newNode, cursorNode.nextSibling);
+  this.cursorNode_ = newNode;
+  this.cursorOffset_ = strWidth;
+  this.wrapUnicode(newNode);
+};
+
+// patch for unicode encapsulation
+hterm.Screen.prototype.splitNode_ = function (node, offset) {
+  const afterNode = node.cloneNode(false);
+  const textContent = node.textContent;
+  node.textContent = hterm.TextAttributes.nodeSubstr(node, 0, offset);
+  afterNode.textContent = lib.wc.substr(textContent, offset);
+  this.wrapUnicode(node);
+  this.wrapUnicode(afterNode);
+  if (afterNode.textContent) {
+    node.parentNode.insertBefore(afterNode, node.nextSibling);
+  }
+  if (!node.textContent) {
+    node.parentNode.removeChild(node);
+  }
+};
+
+// encapsulate unicode chars in individual spans
+// keep them in the parent node with the rest of the content
+// maintains styling and overflow display in divs with a background color
+hterm.Screen.prototype.wrapUnicode = function (node) {
+  const nodeContent = node.textContent;
+  if (containsNonLatinCodepoints(nodeContent) && !node.className.includes('wc-node')) {
+    const doc = this.terminal.document_;
+    if (!node.className.includes('unicode-parent-node')) {
+      node.className += ' unicode-parent-node';
+    }
+    node.textContent = null;
+    let strBuffer = '';
+    runes(nodeContent).forEach(rune => {
+      if (containsNonLatinCodepoints(rune)) {
+        if (strBuffer !== '') {
+          const stringNode = doc.createTextNode(strBuffer);
+          node.appendChild(stringNode);
+          strBuffer = '';
+        }
+        const unicodeNode = doc.createElement('span');
+        unicodeNode.className = 'unicode-node';
+        unicodeNode.textContent = rune;
+        node.appendChild(unicodeNode);
+      } else {
+        strBuffer += rune;
+      }
+    });
+    if (strBuffer !== '') {
+      const stringNode = doc.createTextNode(strBuffer);
+      node.appendChild(stringNode);
+    }
+  }
+};
+
+// ensure no text node contains unicode
+const oldCreateContainer = hterm.TextAttributes.prototype.createContainer;
+hterm.TextAttributes.prototype.createContainer = function (text) {
+  if (this.isDefault() && text && containsNonLatinCodepoints(text)) {
+    const span = this.document_.createElement('span');
+    span.textContent = text;
+    return span;
+  }
+  return oldCreateContainer.call(this, text);
 };
 
 hterm.Screen.prototype.syncSelectionCaret = function () {

--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -456,9 +456,10 @@ hterm.Screen.prototype.splitNode_ = function (node, offset) {
 // maintains styling and overflow display in divs with a background color
 hterm.Screen.prototype.wrapUnicode = function (node) {
   const nodeContent = node.textContent;
-  if (containsNonLatinCodepoints(nodeContent) && !node.className.includes('wc-node')) {
+  if (containsNonLatinCodepoints(nodeContent) && !node.wcNode) {
     const doc = this.terminal.document_;
-    if (!node.className.includes('unicode-parent-node')) {
+    if (!node.unicodeParentNode) {
+      node.unicodeParentNode = true;
       node.className += ' unicode-parent-node';
     }
     node.textContent = null;
@@ -470,10 +471,11 @@ hterm.Screen.prototype.wrapUnicode = function (node) {
           node.appendChild(stringNode);
           strBuffer = '';
         }
-        const unicodeNode = doc.createElement('span');
-        unicodeNode.className = 'unicode-node';
-        unicodeNode.textContent = rune;
-        node.appendChild(unicodeNode);
+        const childNode = doc.createElement('span');
+        childNode.unicodeNode = true;
+        childNode.className = 'unicode-node';
+        childNode.textContent = rune;
+        node.appendChild(childNode);
       } else {
         strBuffer += rune;
       }

--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -73,7 +73,7 @@ lib.wc.strWidth = function (str) {
     if (width < 0) {
       return -1;
     }
-    rv += width * ((codePoint <= 0xffff) ? 1 : 2);
+    rv += width;
   }
   if (shouldCache) {
     cache[str] = rv;


### PR DESCRIPTION
This is a follow up PR to #1536. It reverts the revert of the merge, and fixes the "includes of undefined" issue that appeared after running `dist`. Since I cannot reproduce the issue locally, it is a blind fix, please check on your side before merging ;).
Cc @albinekb @rauchg 