### PR TITLE
Proxy ReactDOM for plugins

### DIFF
--- a/lib/utils/plugins.js
+++ b/lib/utils/plugins.js
@@ -1,8 +1,9 @@
 import {remote} from 'electron';
 import {connect as reduxConnect} from 'react-redux';
 
-// we expose these two deps to component decorators
+// we expose these deps to component decorators
 import React from 'react';
+import ReactDOM from 'react-dom';
 import Component from '../component';
 import Notification from '../components/notification';
 import notify from './notify';
@@ -13,6 +14,8 @@ Module._load = function (path) {
   switch (path) {
     case 'react':
       return React;
+    case 'react-dom':
+      return ReactDOM;
     case 'hyper/component':
       return Component;
     case 'hyper/notify':

--- a/lib/utils/plugins.js
+++ b/lib/utils/plugins.js
@@ -1,7 +1,9 @@
 import {remote} from 'electron';
 import {connect as reduxConnect} from 'react-redux';
 
-// we expose these deps to component decorators
+// patching Module._load
+// so plugins can `require` them wihtout needing their own version
+// https://github.com/zeit/hyper/issues/619
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Component from '../component';


### PR DESCRIPTION
We do this for React, etc. But some react components require `react-dom`, to not have duplicate versions of ReactDOM, we proxy the one already in use (as we do for React)