### PR TITLE
Fixed a bug with installing plugins

### DIFF
--- a/app/plugins.js
+++ b/app/plugins.js
@@ -237,8 +237,8 @@ function install(fn) {
     /* eslint-enable camelcase  */
     // Shell-specific installation commands
     const installCommands = {
-      fish: 'npm prune; and npm install --production',
-      posix: 'npm prune && npm install --production'
+      fish: 'npm prune; and npm install --production --no-shrinkwrap',
+      posix: 'npm prune && npm install --production --no-shrinkwrap'
     };
     // determine the shell we're running in
     const whichShell = (typeof cfgShell === 'string' && cfgShell.match(/fish/)) ? 'fish' : 'posix';


### PR DESCRIPTION
Due to the new `package-lock.json` file generated by NPM 5, new plugins will not be installed automatically anymore. This commit adds `--no-shrinkwrap` to the `npm install` command to make sure the contents of `package-lock.json` are ignored, causing all dependencies listed in `package.json` to be installed correctly.

The parameter `--no-shrinkwrap` is also available in earlier versions of NPM, so no backwards compatibility issues should arise from this change.