### PR TITLE
🌹 Update travis node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ language: node_js
 matrix:
   include:
     - os: osx
-      node_js: 6
+      node_js: 7.4
     - os: linux
-      node_js: 6
+      node_js: 7.4
       env: CC=clang CXX=clang++ npm_config_clang=1
       compiler: clang
 


### PR DESCRIPTION
Since electron 1.5 we're running node 7.4, so better to run the tests at that version? 🤔 

As soon as electron 1.7 is released it will be 7.9
https://github.com/electron/electron/pull/9116

Don't know if travis has 7.4, so let's see 😄 