### PR TITLE
Addressing issue #1862 by filtering out Boolean values from the plugins list

### DIFF
--- a/app/config/init.js
+++ b/app/config/init.js
@@ -36,6 +36,8 @@ const _init = function (cfg) {
       notify('Error reading configuration: `config` key is missing');
       return _extractDefault(cfg.defaultCfg);
     }
+    // Ignore undefined values in plugin array Issue #1862
+    _cfg.plugins = _cfg.plugins.filter(Boolean);
     return _cfg;
   }
   return _extractDefault(cfg.defaultCfg);

--- a/app/config/init.js
+++ b/app/config/init.js
@@ -36,8 +36,9 @@ const _init = function (cfg) {
       notify('Error reading configuration: `config` key is missing');
       return _extractDefault(cfg.defaultCfg);
     }
-    // Ignore undefined values in plugin array Issue #1862
-    _cfg.plugins = _cfg.plugins.filter(Boolean);
+    // Ignore undefined values in plugin and localPlugins array Issue #1862
+    _cfg.plugins = (_cfg.plugins && _cfg.plugins.filter(Boolean)) || [];
+    _cfg.localPlugins = (_cfg.localPlugins && _cfg.localPlugins.filter(Boolean)) || [];
     return _cfg;
   }
   return _extractDefault(cfg.defaultCfg);


### PR DESCRIPTION
This adds the `.filter(Boolean)` to filter out the undefined values in the config plugins array.

<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`

Thanks, again! -->
