### PR TITLE
Add Travis dep for Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ matrix:
 addons:
   apt:
     packages:
+      - gcc-multilib
+      - g++-multilib
       - libgnome-keyring-dev
       - icnsutils
       - graphicsmagick


### PR DESCRIPTION
`electron-builder` compatibility
See https://github.com/electron-userland/electron-builder/wiki/Multi-Platform-Build#to-build-app-in-32-bit-from-a-machine-with-64-bit

Fixes https://travis-ci.org/zeit/hyper/jobs/246404332

<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`

Thanks, again! -->
