### PR TITLE
Adjusts home directory path on Windows (fixes #1959)

### DIFF
--- a/app/config/paths.js
+++ b/app/config/paths.js
@@ -6,10 +6,10 @@ const isDev = require('electron-is-dev');
 
 const cfgFile = '.hyper.js';
 const defaultCfgFile = 'config-default.js';
-const homeDir = homedir();
+let homeDir = homedir();
 
 if (process.platform === 'win32') {
-    homeDir = resolve (homeDir, 'AppData\\Roaming\\Hyper');
+    homeDir = resolve(homeDir, 'AppData\\Roaming\\Hyper');
 }
 
 let cfgPath = join(homeDir, cfgFile);

--- a/app/config/paths.js
+++ b/app/config/paths.js
@@ -9,7 +9,7 @@ const defaultCfgFile = 'config-default.js';
 let homeDir = homedir();
 
 if (process.platform === 'win32') {
-    homeDir = resolve(homeDir, 'AppData\\Roaming\\Hyper');
+  homeDir = resolve(homeDir, 'AppData\\Roaming\\Hyper');
 }
 
 let cfgPath = join(homeDir, cfgFile);

--- a/app/config/paths.js
+++ b/app/config/paths.js
@@ -8,6 +8,10 @@ const cfgFile = '.hyper.js';
 const defaultCfgFile = 'config-default.js';
 const homeDir = homedir();
 
+if (process.platform === 'win32') {
+    homeDir = resolve (homeDir, 'AppData\\Roaming\\Hyper');
+}
+
 let cfgPath = join(homeDir, cfgFile);
 let cfgDir = homeDir;
 


### PR DESCRIPTION
Adjusts the home directory path (source of the config file path) on Win32 to the AppData\Roaming\Hyper subfolder of the folder returned by homedir(). This fixes issue #1959 by eliminating the OneDrive subdirectory from those watched by gaze.

(This also puts storage of the Hyper configuration in the Windows design guidelines recommended location, enables it to roam with the user when roaming profiles are in use, and should improve system performance impact by not watching all the potentially many thousands of files under homedir() not relevant to Hyper configuration, but the fix to #1959 is the important thing.)

Should be ready to merge.
