### PR TITLE
Update node to v8 on appveyor and add fast_finish

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,11 +12,14 @@ init:
   - yarn config set msvs_version 2015 # we need this to build `pty.js`
 
 install:
-  - ps: Install-Product node 6 x64
+  - ps: Install-Product node 8 x64
   - set CI=true
   - yarn
 
 build: off
+
+matrix:
+  fast_finish: true
 
 shallow_clone: true
 


### PR DESCRIPTION
By default AppVeyor runs all build jobs. If at least one job has failed the entire build is marked as failed.

<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`

Thanks, again! -->
