### PR TITLE
Normalize shell name before selecting URL-matching regex

### DIFF
--- a/lib/utils/url-command.js
+++ b/lib/utils/url-command.js
@@ -1,7 +1,8 @@
+import path from 'path';
 import * as regex from './url-regex';
 
 export default function isUrlCommand(shell, data) {
-  const matcher = regex[shell]; // eslint-disable-line import/namespace
+  const matcher = regex[path.parse(shell).name]; // eslint-disable-line import/namespace
   if (undefined === matcher || !data) {
     return null;
   }


### PR DESCRIPTION
Ready for merge - no work left. One potential snag is the additional `'path'` import; implementing the logic directly without relying on the import wouldn't be a problem, though.

This fix improves URL/webview support by normalizing shell identifiers prior to attempting to select a respective URL-matching pattern from `lib/utils/url-regex.js`'s (shell-identifier-keyed) exports. This mitigates an issue where setting `config.shell` to an absolute path, and/or a binary name including the file extension would disable the URL/filepath-triggered webview behavior.