### PR TITLE
Added config switch for update channel

### DIFF
--- a/app/auto-updater.js
+++ b/app/auto-updater.js
@@ -1,11 +1,13 @@
+// Packages
 const {autoUpdater} = require('electron');
 const ms = require('ms');
 
+// Utilities
 const notify = require('./notify'); // eslint-disable-line no-unused-vars
 const {version} = require('./package');
+const {getConfig} = require('./config');
 
 const {platform} = process;
-const FEED_URL = `https://releases.hyper.is/update/${platform}`;
 
 let isInit = false;
 
@@ -14,7 +16,11 @@ function init() {
     console.error('Error fetching updates', msg + ' (' + err.stack + ')');
   });
 
-  autoUpdater.setFeedURL(`${FEED_URL}/${version}`);
+  const config = getConfig();
+  const updatePrefix = config.canaryUpdates ? 'releases-canary' : 'releases';
+  const feedURL = `https://${updatePrefix}.hyper.is/update/${platform}`;
+
+  autoUpdater.setFeedURL(`${feedURL}/${version}`);
 
   setTimeout(() => {
     autoUpdater.checkForUpdates();

--- a/app/config/config-default.js
+++ b/app/config/config-default.js
@@ -4,6 +4,10 @@
 
 module.exports = {
   config: {
+    // Choose either `false` for receiving highly polished,
+    // or `true` for less polished but more frequent updates
+    canaryUpdates: false,
+
     // default font size in pixels for all tabs
     fontSize: 12,
 


### PR DESCRIPTION
As discussed on [zeit.chat](https://zeit.chat) in `#hyper-dev`, we decided to implement a config switch for the new "Canary" update channel (which purpose it is to deliver pre-releases).

We initially thought about using a UI switch for this, but after a few hours of extensive debugging, it stopped making sense. Since we're using a JavaScript file for configuration, updating it would be pretty messy (it is possible though, I know - but messy). In addition, the update channel would be the ONLY UI switch that saves to the config. In turn, to keep it all as straightforward as possible, @chabou and I decided that it makes more sense to make it only a config property for now:

```js
// Choose either `false` for receiving highly polished,
// or `true` for less polished but more frequent updates
canaryUpdates: false
```

The reason why it's a boolean is because we'll most likely only have two release channels forever (or at least for a very long time), because more would also be way too hard to maintain at the current state of the project.