### PR TITLE
Show update channel in About window

### DIFF
--- a/app/menus/menu.js
+++ b/app/menus/menu.js
@@ -17,10 +17,9 @@ const appVersion = app.getVersion();
 
 module.exports = (createWindow, updatePlugins, getLoadedPluginVersions) => {
   const config = getConfig();
-  const keymaps = getKeymaps();
+  const {commands} = getKeymaps();
 
   const updateChannel = config.canaryUpdates ? 'canary' : 'stable';
-  const commands = keymaps.commands;
 
   const showAbout = () => {
     const loadedPlugins = getLoadedPluginVersions();

--- a/app/menus/menu.js
+++ b/app/menus/menu.js
@@ -1,9 +1,9 @@
+// Packages
 const {app, dialog} = require('electron');
 
-const {getKeymaps} = require('../config');
+// Utilities
+const {getKeymaps, getConfig} = require('../config');
 const {icon} = require('../config/paths');
-
-// menus
 const viewMenu = require('./menus/view');
 const shellMenu = require('./menus/shell');
 const editMenu = require('./menus/edit');
@@ -16,15 +16,21 @@ const appName = app.getName();
 const appVersion = app.getVersion();
 
 module.exports = (createWindow, updatePlugins, getLoadedPluginVersions) => {
-  const commands = getKeymaps().commands;
+  const config = getConfig();
+  const keymaps = getKeymaps();
+
+  const updateChannel = config.canaryUpdates ? 'canary' : 'stable';
+  const commands = keymaps.commands;
+
   const showAbout = () => {
     const loadedPlugins = getLoadedPluginVersions();
     const pluginList = loadedPlugins.length === 0 ?
       'none' :
       loadedPlugins.map(plugin => `\n  ${plugin.name} (${plugin.version})`);
+
     dialog.showMessageBox({
       title: `About ${appName}`,
-      message: `${appName} ${appVersion}`,
+      message: `${appName} ${appVersion} (${updateChannel})`,
       detail: `Plugins: ${pluginList}\n\nCreated by Guillermo Rauch\nCopyright © 2017 Zeit, Inc.`,
       buttons: [],
       icon


### PR DESCRIPTION
So that people know which channel they're on without opening the config file.

**STABLE:**

<img width="532" alt="screen shot 2017-08-20 at 12 37 14" src="https://user-images.githubusercontent.com/6170607/29494160-7109a25c-85a4-11e7-8218-5c059bb2d645.png">

**CANARY:**

<img width="532" alt="screen shot 2017-08-20 at 12 36 55" src="https://user-images.githubusercontent.com/6170607/29494164-7966bf34-85a4-11e7-93de-26816e916fb8.png">
