### PR TITLE
Temporarily hide keymaps from documentation

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -677,7 +677,7 @@
         <p>You can also take a look at
           <a href="https://github.com/bnb/awesome-hyper">Awesome Hyper</a>
           for a curated list of plugins and resources.</p>
-
+<!--
           <h2 id="keymaps"><a href="#keymaps">Keymaps</a></h2>
 
           <P> All command keys can be changed. In order to change them, edit
@@ -692,7 +692,7 @@
     'window:devtools': 'cmd+alt+o'
   }
 
-};</code></pre>
+};</code></pre>-->
 
 
         <h2 id="cfg"><a href="#cfg">Configuration</a></h2>


### PR DESCRIPTION
This PR hides keymap part of documentation.
It will be reverted after v1.4.0 release
