### PR TITLE
Add .yarnrc

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+save-prefix false


### PR DESCRIPTION
Use a `.yarnrc` file to pin dependencies by default in `package.json`.