### PR TITLE
Only publish for tags

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -17,7 +17,7 @@ deployment:
     branch: /.*/
     owner: zeit
     commands:
-      - yarn run dist -p 'never'
+      - yarn run dist -- -p 'never'
       - cp dist/*.zip $CIRCLE_ARTIFACTS
   release:
     tag: /.*/

--- a/circle.yml
+++ b/circle.yml
@@ -17,7 +17,7 @@ deployment:
     branch: /.*/
     owner: zeit
     commands:
-      - yarn run dist
+      - yarn run dist -p 'never'
       - cp dist/*.zip $CIRCLE_ARTIFACTS
   release:
     tag: /.*/


### PR DESCRIPTION
This makes Circle CI only publish the macOS builds for tags.