### PR TITLE
Tell Yarn to cache dependencies

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,10 +1,15 @@
 machine:
   xcode:
     version: 8.2
+  pre:
+    - mkdir ~/.yarn-cache
 
 dependencies:
   pre:
     - npm install -g yarn
+    - yarn config set cache-folder ~/.yarn-cache
+  cache_directories:
+    - ~/.yarn-cache
   override:
     - yarn
 

--- a/license.md
+++ b/license.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2016 Zeit, Inc.
+Copyright (c) 2017 Zeit, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This will hopefully make our macOS builds even faster. 🚀 