### PR TITLE
Added yarn install to contribute instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -31,8 +31,9 @@ choco install hyper
 ## Contribute
 
 1. Install the dependencies
-  * If you are running Linux, install `icnsutils`, `graphicsmagick`, `xz-utils` and `rpm`
-  * If you are running Windows, install `windows-build-tools` with `yarn global add windows-build-tools`.
+  * If you are running Linux, install `icnsutils`, `graphicsmagick`, `xz-utils` `rpm` and `yarn`
+  * If you are running Windows, install `yarn` and `windows-build-tools` with `yarn global add windows-build-tools`.
+  * Yarn installation instructions: https://yarnpkg.com/en/docs/install
 2. [Fork](https://help.github.com/articles/fork-a-repo/) this repository to your own GitHub account and then [clone](https://help.github.com/articles/cloning-a-repository/) it to your local device
 3. Install the dependencies: `yarn`
 4. Build the code and watch for changes: `yarn run dev`

--- a/readme.md
+++ b/readme.md
@@ -31,8 +31,8 @@ choco install hyper
 ## Contribute
 
 1. Install the dependencies
-  * If you are running Linux, install `icnsutils`, `graphicsmagick`, `xz-utils` `rpm` and `yarn`
-  * If you are running Windows, install `yarn` and `windows-build-tools` with `yarn global add windows-build-tools`.
+  * If you are running Linux, install `icnsutils`, `graphicsmagick`, `xz-utils`, `npm`, `rpm` and `yarn`
+  * If you are running Windows, install `yarn` (If you use the MSI installer you will need to install npm), and `windows-build-tools` with `yarn global add windows-build-tools`.
   * Yarn installation instructions: https://yarnpkg.com/en/docs/install
 2. [Fork](https://help.github.com/articles/fork-a-repo/) this repository to your own GitHub account and then [clone](https://help.github.com/articles/cloning-a-repository/) it to your local device
 3. Install the dependencies: `yarn`


### PR DESCRIPTION
The contribute instructions don't mention installing yarn ahead of time in case the builder doesn't already have it installed.

<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`

Thanks, again! -->
