### PR TITLE
Using options from default config when not specified in user config

### DIFF
--- a/app/config/init.js
+++ b/app/config/init.js
@@ -36,6 +36,10 @@ const _init = function (cfg) {
       notify('Error reading configuration: `config` key is missing');
       return _extractDefault(cfg.defaultCfg);
     }
+
+    // Use options from default config  when not specified in user config #1588
+    _cfg.config = Object.assign({}, _extractDefault(cfg.defaultCfg).config, _cfg.config);
+
     // Ignore undefined values in plugin and localPlugins array Issue #1862
     _cfg.plugins = (_cfg.plugins && _cfg.plugins.filter(Boolean)) || [];
     _cfg.localPlugins = (_cfg.localPlugins && _cfg.localPlugins.filter(Boolean)) || [];


### PR DESCRIPTION
App uses options from default config when not specified in user config. That's issue #1588. Now if you won't specify an option in your config, it will be automatically added from default config.
