### PR TITLE
Use a string for setting the update channel

### DIFF
--- a/app/auto-updater.js
+++ b/app/auto-updater.js
@@ -17,7 +17,16 @@ function init() {
   });
 
   const config = getConfig();
-  const updatePrefix = config.canaryUpdates ? 'releases-canary' : 'releases';
+
+  // Default to the "stable" update channel
+  let canaryUpdates = false;
+
+  // If defined in the config, switch to the "canary" channel
+  if (config.updateChannel && config.updateChannel === 'canary') {
+    canaryUpdates = true;
+  }
+
+  const updatePrefix = canaryUpdates ? 'releases-canary' : 'releases';
   const feedURL = `https://${updatePrefix}.hyper.is/update/${platform}`;
 
   autoUpdater.setFeedURL(`${feedURL}/${version}`);

--- a/app/config/config-default.js
+++ b/app/config/config-default.js
@@ -4,9 +4,9 @@
 
 module.exports = {
   config: {
-    // Choose either `false` for receiving highly polished,
-    // or `true` for less polished but more frequent updates
-    canaryUpdates: false,
+    // Choose either "stable" for receiving highly polished,
+    // or "canary" for less polished but more frequent updates
+    updateChannel: 'stable',
 
     // default font size in pixels for all tabs
     fontSize: 12,


### PR DESCRIPTION
As discussed with @rauchg, there's a chance that we'll have multiple options for the new config property that allows you to pick the update channel in the future.

In turn, we need to go the right way from the start and use a string instead of a boolean.