### PR TITLE
AppVeyor environment variables are now on the platform

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,8 +3,6 @@
 environment:
   matrix:
     - platform: x64
-  GH_TOKEN:
-    secure: tEHrAaRFMrUzagNJsnU+6Esvaw/FdUXZKWz7a690VAy6zzEThB0lThHLFVKZrQrP
 
 image: Visual Studio 2015
 


### PR DESCRIPTION
This should fix Windows builds not appearing in the GitHub Releases (we're signing now).