### PR TITLE
Fix writing composed characters

### DIFF
--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -256,7 +256,9 @@ hterm.Keyboard.prototype.onKeyDown_ = function (e) {
   ];
   if (!clearBlacklist.includes(e.code.toLowerCase()) &&
       !clearBlacklist.includes(e.key.toLowerCase())) {
-    selection.clear(this.terminal);
+    // Since Electron 1.6.X, there is a race condition with character composition
+    // if this selection clearing is made synchronously. See #2140.
+    setTimeout(() => selection.clear(this.terminal), 0);
   }
 
   // If the `hyperCaret` was removed on `selectAll`, we need to insert it back


### PR DESCRIPTION
Fix #2140

This is a temporary and ugly fix but it is ok because `xterm` will not need this.
