### PR TITLE
Add category option under linux key in root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "appId": "co.zeit.hyper",
     "extraResources": "./bin/yarn-standalone.js",
     "linux": {
+     "category": "TerminalEmulator",
       "target": [
         {
           "target": "deb",


### PR DESCRIPTION
In response to issue entry #2097, a specific category option has been defined under the linux key in the root package.json file. This allows Hyper to take advantage of features that have been added to the most recent version of electron-builder.

Note: I tried to make this commit before, but mistakenly added app/yarn.lock, in addition to the solution of the stated issue, to the branch. Thus, this is a corrected version of my earlier attempt.

<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`

Thanks, again! -->
