### PR TITLE
Add default keymaps reference to documentation

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -698,6 +698,17 @@
 
 };</code></pre>
 
+        <p>Default keymaps: </p>
+
+        <table>
+          <tbody>
+            <tr>
+              <td><a href="https://github.com/zeit/hyper/blob/master/app/keymaps/win32.json">Windows</a></td>
+              <td><a href="https://github.com/zeit/hyper/blob/master/app/keymaps/linux.json">Linux</a></td>
+              <td><a href="https://github.com/zeit/hyper/blob/master/app/keymaps/darwin.json">macOS</a></td>
+            </tr>
+          </tbody>
+        </table>
 
         <h2 id="cfg"><a href="#cfg">Configuration</a></h2>
 


### PR DESCRIPTION
closes #2167 

This PR just add a table referencing the default keymaps for Windows, Linux and MacOS. It was not in the documentation.