### PR TITLE
Set session CWD only if there is an active session

### DIFF
--- a/lib/reducers/sessions.js
+++ b/lib/reducers/sessions.js
@@ -100,7 +100,10 @@ const reducer = (state = initialState, action) => {
       }));
 
     case SESSION_SET_CWD:
-      return state.setIn(['sessions', state.activeUid, 'cwd'], action.cwd);
+      if (state.activeUid) {
+        return state.setIn(['sessions', state.activeUid, 'cwd'], action.cwd);
+      }
+      return state;
 
     default:
       return state;


### PR DESCRIPTION
Hey Zeit team 👋 

I got a bug report on the `hypercwd` showing that the window lingers around after `CMD + W` closing all the windows.

https://github.com/hharnisc/hypercwd/issues/28

After digging around a bit, it is because `hypercwd` now dispatches a `SESSION_SET_CWD` before an active session is created at the `CONFIG_LOAD` event (allows for setting an initial working directory on the first session 😄 ). 

So if there is no active session, the reducer catches the `SESSION_SET_CWD` action and creates a session with the key `null`.

This PR checks for an active session and conditionally sets `CWD` on the session if it exists. I've tested this with the `hypercwd` plugin and works as expected now - so this is **ready to go**. 

