### PR TITLE
Fix plugin path in dev mode

### DIFF
--- a/app/config/paths.js
+++ b/app/config/paths.js
@@ -15,6 +15,18 @@ const devDir = resolve(__dirname, '../..');
 const devCfg = join(devDir, cfgFile);
 const defaultCfg = resolve(__dirname, defaultCfgFile);
 
+if (isDev) {
+  // if a local config file exists, use it
+  try {
+    statSync(devCfg);
+    cfgPath = devCfg;
+    cfgDir = devDir;
+    console.log('using config file:', cfgPath);
+  } catch (err) {
+    // ignore
+  }
+}
+
 const plugins = resolve(cfgDir, '.hyper_plugins');
 const plugs = {
   base: plugins,
@@ -38,18 +50,6 @@ const defaultPlatformKeyPath = () => {
     default: return darwinKeys;
   }
 };
-
-if (isDev) {
-  // if a local config file exists, use it
-  try {
-    statSync(devCfg);
-    cfgPath = devCfg;
-    cfgDir = devDir;
-    console.log('using config file:', cfgPath);
-  } catch (err) {
-    // ignore
-  }
-}
 
 module.exports = {
   cfgDir, cfgPath, cfgFile, defaultCfg, icon, defaultPlatformKeyPath, plugs, yarn


### PR DESCRIPTION
When a dev config (`<project_dir>/.hyper.js`) is used, plugins should be searched/installed in `<project_dir>/.hyper_plugins` directory

This is a regression of https://github.com/zeit/hyper/pull/1876

<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`

Thanks, again! -->
