### PR TITLE
Use child_process.execFile instead of child_process.exec to prevent unescaped stuff

### DIFF
--- a/app/plugins/install.js
+++ b/app/plugins/install.js
@@ -15,13 +15,13 @@ module.exports = {
         const cmd = [process.execPath, yarn].concat(args).join(' ');
         console.log('Launching yarn:', cmd);
 
-        cp.exec(cmd, {
+        cp.execFile(process.execPath, [yarn].concat(args), {
           cwd: plugs.base,
           env,
-          shell: true,
           timeout: ms('5m'),
-          stdio: ['ignore', 'ignore', 'inherit']
-        }, err => {
+          maxBuffer: 1024 * 1024,
+        }, (err, stdout, stderr) => {
+          console.log(err, stdout, stderr);
           if (err) {
             cb(err);
           } else {

--- a/app/plugins/install.js
+++ b/app/plugins/install.js
@@ -19,9 +19,8 @@ module.exports = {
           cwd: plugs.base,
           env,
           timeout: ms('5m'),
-          maxBuffer: 1024 * 1024,
-        }, (err, stdout, stderr) => {
-          console.log(err, stdout, stderr);
+          maxBuffer: 1024 * 1024
+        }, err => {
           if (err) {
             cb(err);
           } else {


### PR DESCRIPTION
This should fix #2173, I've tested on my Window machine with a space in the user name and it works. Haven't tested on other OS, so I'm not sure if using execFile will break anything.