### PR TITLE
fix terminal sizing issues

### DIFF
--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -81,17 +81,7 @@ export default class Term extends PureComponent {
   }
 
   onOpen() {
-    // we need to delay one frame so that aphrodite styles
-    // get applied and we can make an accurate measurement
-    // of the container width and height
-    requestAnimationFrame(() => {
-      // at this point it would make sense for character
-      // measurement to have taken place but it seems that
-      // xterm.js might be doing this asynchronously, so
-      // we force it instead
-      this.term.charMeasure.measure();
-      this.measureResize();
-    });
+    this.forceResize();
   }
 
   getTermDocument() {
@@ -102,12 +92,34 @@ export default class Term extends PureComponent {
   // measures the container and makes the decision
   // whether to resize the term to fit the container
   measureResize() {
+    // if this tab isn't actuve, termRect will have no width or height, so don't resize
+    if (!this.props.isTermActive) return;
     const termRect = this.termWrapperRef.getBoundingClientRect();
 
     if (!this.termRect || termRect.width !== this.termRect.width || termRect.height !== this.termRect.height) {
       this.termRect = termRect;
       this.fitResize();
     }
+  }
+
+  // when multiple tabs are open, Redux may already have the same ui cols and rows
+  // as we calculate are necessary for this tab, even though it's wrongly sized,
+  // so we need to resize regardless
+  forceResize() {
+    // we need to delay one frame so that aphrodite styles
+    // get applied and we can make an accurate measurement
+    // of the container width and height
+    requestAnimationFrame(() => {
+      // at this point it would make sense for character
+      // measurement to have taken place but it seems that
+      // xterm.js might be doing this asynchronously, so
+      // we force it instead
+      this.term.charMeasure.measure();
+      const termRect = this.termWrapperRef.getBoundingClientRect();
+      const cols = Math.floor(termRect.width / this.term.charMeasure.width);
+      const rows = Math.floor(termRect.height / this.term.charMeasure.height);
+      this.resize(cols, rows);
+    });
   }
 
   onWindowResize() {
@@ -157,6 +169,10 @@ export default class Term extends PureComponent {
   componentWillReceiveProps(nextProps) {
     if (!this.props.cleared && nextProps.cleared) {
       this.clear();
+    }
+
+    if (!this.props.isTermActive && nextProps.isTermActive) {
+      this.forceResize();
     }
 
     if (this.props.fontSize !== nextProps.fontSize || this.props.fontFamily !== nextProps.fontFamily) {


### PR DESCRIPTION
Fixes https://github.com/zeit/hyper/issues/2252

* Forcibly sizes new tab terminals to prevent a problem where the `cols` and `rows` props which are provided by Redux are correct for the current window size (having been set by the original tab terminal), but these figures are not reflected in the newly created terminal tab.  Currently, the check (cols/rows in props from Redux === required cols/rows) will prevent such a resize from happening.
* Does not attempt to resize tabs which are not active when the window is resized as their bounding rectangle will have no width or height.
* Instead, forcibly resizes tabs when they are made active.