### PR TITLE
Update Electron to 1.7.8

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -9,7 +9,6 @@
     "email": "team@zeit.co"
   },
   "repository": "zeit/hyper",
-  "xo": false,
   "dependencies": {
     "async-retry": "1.1.3",
     "color": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
     "babel-preset-react": "6.24.1",
     "copy-webpack-plugin": "4.0.1",
     "cross-env": "5.0.5",
-    "electron": "1.7.6",
+    "electron": "1.7.8",
     "electron-builder": "19.27.3",
     "electron-builder-squirrel-windows": "19.27.3",
     "electron-devtools-installer": "2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2212,9 +2212,9 @@ electron-to-chromium@^1.2.7:
   version "1.3.21"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.21.tgz#a967ebdcfe8ed0083fc244d1894022a8e8113ea2"
 
-electron@1.7.6:
-  version "1.7.6"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-1.7.6.tgz#fb69ea31bd03df0eff247f26f0b538bd29b6ee72"
+electron@1.7.8:
+  version "1.7.8"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-1.7.8.tgz#27b791a6895171a7d52991b99442cdbd10a3539d"
   dependencies:
     "@types/node" "^7.0.18"
     electron-download "^3.0.1"


### PR DESCRIPTION
[SECURITY] Fixed Chromium RCE vulnerability

* https://github.com/electron/electron/releases/tag/v1.7.8
* https://github.com/electron/electron/releases/tag/v1.7.7

<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`

Thanks, again! -->
