### PR TITLE
🐛 Fix missing comma in default config

### DIFF
--- a/app/config/config-default.js
+++ b/app/config/config-default.js
@@ -97,7 +97,7 @@ module.exports = {
     bell: 'SOUND',
 
     // if true, selected text will automatically be copied to the clipboard
-    copyOnSelect: false
+    copyOnSelect: false,
 
     // if true, on right click selected text will be copied or pasted if no
     // selection is present (true by default on Windows)


### PR DESCRIPTION
Doh, this is a trailing comma, not needed... but let's add it because then you can just comment out the lines under without adding the comma?
____________________
In #2286 we started getting reports of a missing comma in the config, very weird.
So i looked in the default config, and saw the comma there.

Now @peauc reported the same thing but on macOS, then i thought it couldn't be the issue I was originally thinking #2286 was about (sync issue, user problem).

and after double checking master config again i remembered that i forgot to check canary, well here's the issue, finally fixed 🎉  

Don't know when this was introduced but let's not blame anyone, this should have been caught by the linter...! 😱 