### PR TITLE
Improve documentation of showHamburguerMenu option

### DIFF
--- a/app/config/config-default.js
+++ b/app/config/config-default.js
@@ -38,7 +38,8 @@ module.exports = {
     // custom css to embed in the terminal window
     termCSS: '',
 
-    // set to `true` (without backticks) if you're using a Linux setup that doesn't show native menus
+    // set to `true` (without backticks and without quotes) if you're using a
+    // Linux setup that doesn't show native menus
     // default: `false` on Linux, `true` on Windows (ignored on macOS)
     showHamburgerMenu: '',
 


### PR DESCRIPTION
**Problem**
A lot of users are confused with documentation of `showHamburgerMenu` option.

**Solution**
Improve documentation.

resolves https://github.com/zeit/hyper/issues/1266