### PR TITLE
line-height customization fix

### DIFF
--- a/lib/components/style-sheet.js
+++ b/lib/components/style-sheet.js
@@ -148,7 +148,7 @@ export default class StyleSheet extends React.PureComponent {
           .terminal .xterm-rows {
             position: absolute;
             left: 0;
-            top: 0;
+            bottom: 0;
           }
 
           .terminal .xterm-rows > div {


### PR DESCRIPTION
Tweaked CSS  `.terminal .xterm-rows` to align with bottom instead of top. Now a margin can be set in .hyper.js such as:

`termCSS: '.terminal .xterm-rows > div {margin: 3px 0}',`

Previously that would mess up the terminal prompt. Yay for better line-height! Should fix https://github.com/zeit/hyper/issues/75 for now