### PR TITLE
Move Date.now() into actions to have pure reducers

### DIFF
--- a/lib/actions/sessions.js
+++ b/lib/actions/sessions.js
@@ -21,6 +21,7 @@ import {
 export function addSession({uid, shell, pid, cols, rows, splitDirection}) {
   return (dispatch, getState) => {
     const {sessions} = getState();
+    const now = Date.now();
     dispatch({
       type: SESSION_ADD,
       uid,
@@ -29,7 +30,8 @@ export function addSession({uid, shell, pid, cols, rows, splitDirection}) {
       cols,
       rows,
       splitDirection,
-      activeUid: sessions.activeUid
+      activeUid: sessions.activeUid,
+      now
     });
   };
 }
@@ -54,6 +56,7 @@ export function addSessionData(uid, data) {
       data,
       effect() {
         const session = getState().sessions.sessions[uid];
+        const now = Date.now();
         if (session) {
           const enterKey = data.indexOf('\n') > 0;
           const url = enterKey ? isUrl(session.shell, data) : null;
@@ -68,7 +71,8 @@ export function addSessionData(uid, data) {
         dispatch({
           type: SESSION_PTY_DATA,
           uid,
-          data
+          data,
+          now
         });
       }
     });
@@ -127,12 +131,14 @@ export function resizeSession(uid, cols, rows) {
     const {termGroups} = getState();
     const group = findBySession(termGroups, uid);
     const isStandaloneTerm = !group.parentUid && !group.children.length;
+    const now = Date.now();
     dispatch({
       type: SESSION_RESIZE,
       uid,
       cols,
       rows,
       isStandaloneTerm,
+      now,
       effect() {
         rpc.emit('resize', {uid, cols, rows});
       }

--- a/lib/reducers/sessions.js
+++ b/lib/reducers/sessions.js
@@ -96,7 +96,7 @@ const reducer = (state = initialState, action) => {
       return state.setIn(['sessions', action.uid], state.sessions[action.uid].merge({
         rows: action.rows,
         cols: action.cols,
-        resizeAt: Date.now()
+        resizeAt: action.now
       }));
 
     case SESSION_SET_CWD:

--- a/lib/reducers/ui.js
+++ b/lib/reducers/ui.js
@@ -216,7 +216,7 @@ const reducer = (state = initial, action) => {
       state_ = state.merge({
         activeUid: action.uid,
         openAt: {
-          [action.uid]: Date.now()
+          [action.uid]: action.now
         }
       }, {deep: true});
       break;
@@ -231,7 +231,7 @@ const reducer = (state = initial, action) => {
       state_ = state.merge({
         rows: action.rows,
         cols: action.cols,
-        resizeAt: Date.now()
+        resizeAt: action.now
       });
       break;
 
@@ -264,11 +264,8 @@ const reducer = (state = initial, action) => {
         break;
       }
 
-      // current time for comparisons
-      const now = Date.now();
-
       // if first data events after open, ignore
-      if (now - state.openAt[action.uid] < 1000) {
+      if (action.now - state.openAt[action.uid] < 1000) {
         break;
       }
 
@@ -276,7 +273,7 @@ const reducer = (state = initial, action) => {
       // proximity of a resize event, since we
       // expect to get data packets from the resize
       // of the ptys as a result
-      if (!state.resizeAt || now - state.resizeAt > 1000) {
+      if (!state.resizeAt || action.now - state.resizeAt > 1000) {
         state_ = state.merge({
           activityMarkers: {
             [action.uid]: true


### PR DESCRIPTION
Reducers shouldn't have side effect. Date.now() is a side effect and should be done in action creators.

<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`

Thanks, again! -->
