### PR TITLE
Add new keymaps to jump between tabs

### DIFF
--- a/app/config/keymaps.js
+++ b/app/config/keymaps.js
@@ -5,10 +5,25 @@ const {defaultPlatformKeyPath} = require('./paths');
 const commands = {};
 const keys = {};
 
+const generatePrefixedCommand = function(command, key) {
+  const baseCmd = command.replace(/:prefix$/, '');
+  for (let i = 1; i <= 9; i++) {
+    // 9 is a special number because it means 'last'
+    const index = i === 9 ? 'last' : i;
+    commands[`${baseCmd}:${index}`] = normalize(`${key}+${i}`);
+  }
+};
+
 const _setKeysForCommands = function(keymap) {
   for (const command in keymap) {
     if (command) {
-      commands[command] = normalize(keymap[command]);
+      // In case of a command finishing by :prefix
+      // we need to generate commands and keys
+      if (command.endsWith(':prefix')) {
+        generatePrefixedCommand(command, keymap[command]);
+      } else {
+        commands[command] = normalize(keymap[command]);
+      }
     }
   }
 };

--- a/app/keymaps/darwin.json
+++ b/app/keymaps/darwin.json
@@ -14,6 +14,7 @@
   "tab:new": "cmd+t",
   "tab:next": "cmd+shift+]",
   "tab:prev": "cmd+shift+[",
+  "tab:jump:prefix": "cmd",
   "pane:next": "cmd+]",
   "pane:prev": "cmd+[",
   "pane:splitVertical": "cmd+d",

--- a/app/keymaps/linux.json
+++ b/app/keymaps/linux.json
@@ -14,6 +14,7 @@
   "tab:new": "ctrl+shift+t",
   "tab:next": "ctrl+tab",
   "tab:prev": "ctrl+shift+tab",
+  "tab:jump:prefix": "ctrl",
   "pane:next": "ctrl+pageup",
   "pane:prev": "ctrl+pagedown",
   "pane:splitVertical": "ctrl+shift+d",

--- a/app/keymaps/win32.json
+++ b/app/keymaps/win32.json
@@ -14,6 +14,7 @@
   "tab:new": "ctrl+shift+t",
   "tab:next": "ctrl+tab",
   "tab:prev": "ctrl+shift+tab",
+  "tab:jump:prefix": "ctrl",
   "pane:next": "ctrl+pageup",
   "pane:prev": "ctrl+pagedown",
   "pane:splitVertical": "ctrl+shift+d",

--- a/app/menus/menus/window.js
+++ b/app/menus/menus/window.js
@@ -1,4 +1,21 @@
 module.exports = commands => {
+  // Generating tab:jump array
+  const tabJump = [];
+  for (let i = 1; i <= 9; i++) {
+    // 9 is a special number because it means 'last'
+    const label = i === 9 ? 'Last' : `${i}`;
+    const tabIndex = i === 9 ? 'last' : i - 1;
+    tabJump.push({
+      label: label,
+      accelerator: commands[`tab:jump:${label.toLowerCase()}`],
+      click(item, focusedWindow) {
+        if (focusedWindow) {
+          focusedWindow.rpc.emit('move jump req', tabIndex);
+        }
+      }
+    });
+  }
+
   return {
     role: 'window',
     submenu: [
@@ -34,7 +51,11 @@ module.exports = commands => {
                 focusedWindow.rpc.emit('move right req');
               }
             }
-          }
+          },
+          {
+            type: 'separator'
+          },
+          ...tabJump
         ]
       },
       {

--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -180,6 +180,14 @@ export function moveRight() {
 
 export function moveTo(i) {
   return (dispatch, getState) => {
+    if (i === 'last') {
+      // Finding last tab index
+      const {termGroups} = getState().termGroups;
+      i =
+        Object.keys(termGroups)
+          .map(uid => termGroups[uid])
+          .filter(({parentUid}) => !parentUid).length - 1;
+    }
     dispatch({
       type: UI_MOVE_TO,
       index: i,

--- a/lib/index.js
+++ b/lib/index.js
@@ -99,6 +99,10 @@ rpc.on('move right req', () => {
   store_.dispatch(uiActions.moveRight());
 });
 
+rpc.on('move jump req', index => {
+  store_.dispatch(uiActions.moveTo(index));
+});
+
 rpc.on('next pane req', () => {
   store_.dispatch(uiActions.moveToNextPane());
 });


### PR DESCRIPTION
I didn't want that users have to change multiple keymaps for this jump feature. It could have been the case if we used action definition like this:
```
'tab:jump:1': 'cmd+1'
'tab:jump:2': 'cmd+2'
...
'tab:jump:last': 'cmd+9'
```

So I decided to introduce a naming convention for this action:
``` 
'tab:jump:prefix': 'cmd"
```
It will automatically generate the 9 actions mentioned above.

This PR adds 9 menu items too:
![capture d ecran 2017-10-04 a 23 39 10](https://user-images.githubusercontent.com/4137761/31200998-569ffeca-a95d-11e7-8609-94b292316427.png)

