### PR TITLE
Fix keyboard event handling

### DIFF
--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -138,6 +138,9 @@ export default class Term extends PureComponent {
   }
 
   keyboardHandler(e) {
+    if (e.type !== 'keydown') {
+      return true;
+    }
     // test key from keymaps before moving forward with actions
     const key = returnKey(e);
     if (key) {

--- a/lib/utils/keymaps.js
+++ b/lib/utils/keymaps.js
@@ -2,7 +2,84 @@ import {remote} from 'electron';
 
 const getCommand = remote.require('./utils/keymaps/get-command');
 
+// Key handling is deeply inspired by Mousetrap
+// https://github.com/ccampbell/mousetrap
+
+const _EXCLUDE = {
+  16: 'shift',
+  17: 'ctrl',
+  18: 'alt',
+  91: 'meta',
+  93: 'meta',
+  224: 'meta'
+};
+
+const _MAP = {
+  8: 'backspace',
+  9: 'tab',
+  13: 'enter',
+  20: 'capslock',
+  27: 'esc',
+  32: 'space',
+  33: 'pageup',
+  34: 'pagedown',
+  35: 'end',
+  36: 'home',
+  37: 'left',
+  38: 'up',
+  39: 'right',
+  40: 'down',
+  45: 'ins',
+  46: 'del'
+};
+
+const _KEYCODE_MAP = {
+  106: '*',
+  107: '+',
+  109: '-',
+  110: '.',
+  111: '/',
+  186: ';',
+  187: '=',
+  188: ',',
+  189: '-',
+  190: '.',
+  191: '/',
+  192: '`',
+  219: '[',
+  220: '\\',
+  221: ']',
+  222: "'"
+};
+
+const characterFromEvent = e => {
+  if (_EXCLUDE[e.which]) {
+    return;
+  }
+
+  if (_MAP[e.which]) {
+    return _MAP[e.which];
+  }
+
+  if (_KEYCODE_MAP[e.which]) {
+    return _KEYCODE_MAP[e.which];
+  }
+
+  // if it is not in the special map
+
+  // with keydown and keyup events the character seems to always
+  // come in as an uppercase character whether you are pressing shift
+  // or not.  we should make sure it is always lowercase for comparisons
+
+  return String.fromCharCode(e.which).toLowerCase();
+};
+
 export default function returnKey(e) {
+  const character = characterFromEvent(e);
+  if (!character) {
+    return false;
+  }
+
   let keys = [];
 
   if (e.metaKey && process.platform === 'darwin') {
@@ -23,12 +100,7 @@ export default function returnKey(e) {
     keys.push('alt');
   }
 
-  if (e.key === ' ') {
-    keys.push('space');
-  } else if (e.key !== 'Meta' && e.key !== 'Control' && e.key !== 'Shift' && e.key !== 'Alt') {
-    keys.push(e.key.replace('Arrow', ''));
-  }
+  keys.push(character);
 
-  keys = keys.join('+');
-  return getCommand(keys);
+  return getCommand(keys.join('+'));
 }


### PR DESCRIPTION
This PR fixes issues with some combinations.

With french keyboard (but maybe US keyboard too), it was impossible to use `ctrl+alt+[a-z]` shortcut because keydown event has a modified `key` property.

For example, `ctrl+alt+e` has `ê` as `key` value and not `e`. Our key comparison was failing.

Another issue with foreign keyboard layouts is with digit. If user defines a `cmd+1` shortcut, he must hit `cmd+shift+1` or `cmd+numpad1`.

This PR is deeply inspired by [Mousetrap](https://github.com/ccampbell/mousetrap) which works really great!   

Bonus: new keys are now compatible for keymaps definition:
```
'backspace',
'tab',
'enter',
'capslock',
'esc',
'pageup',
'pagedown',
'end',
'home',
'ins',
'del'
```