### PR TITLE
Update electron to 1.7.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "babel-preset-react": "6.24.1",
     "copy-webpack-plugin": "4.0.1",
     "cross-env": "5.0.5",
-    "electron": "1.7.8",
+    "electron": "1.7.9",
     "electron-builder": "19.33.0",
     "electron-builder-squirrel-windows": "19.33.0",
     "electron-devtools-installer": "2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2231,9 +2231,9 @@ electron-to-chromium@^1.2.7:
   version "1.3.24"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.24.tgz#9b7b88bb05ceb9fa016a177833cc2dde388f21b6"
 
-electron@1.7.8:
-  version "1.7.8"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-1.7.8.tgz#27b791a6895171a7d52991b99442cdbd10a3539d"
+electron@1.7.9:
+  version "1.7.9"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-1.7.9.tgz#add54e9f8f83ed02f6519ec10135f698b19336cf"
   dependencies:
     "@types/node" "^7.0.18"
     electron-download "^3.0.1"


### PR DESCRIPTION
[SECURITY] Update to Chromium RCE vulnerability fix for older versions of Chromium.

Changelog: https://github.com/electron/electron/releases/tag/v1.7.9