### PR TITLE
Pasting a copied file or dir provides full path to resource

### DIFF
--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -116,6 +116,8 @@ export default class Term extends PureComponent {
     this.fitResize();
   }
 
+  // intercepting paste event for any necessary processing of
+  // clipboard data, if result is falsy, paste event continues
   onWindowPaste(e) {
     if (!this.props.isTermActive) return;
 

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -117,8 +117,10 @@ export default class Term extends PureComponent {
   }
 
   onWindowPaste(e) {
+    if (!this.props.isTermActive) return;
+
     const processed = processClipboard();
-    if (processed && this.props.isTermActive) {
+    if (processed) {
       e.preventDefault();
       e.stopPropagation();
       this.term.send(processed);

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -5,6 +5,7 @@ import {PureComponent} from '../base-components';
 import terms from '../terms';
 import returnKey from '../utils/keymaps';
 import CommandRegistry from '../command-registry';
+import processClipboard from '../utils/paste';
 
 // map old hterm constants to xterm.js
 const CURSOR_STYLES = {
@@ -22,6 +23,7 @@ export default class Term extends PureComponent {
     this.termRect = null;
     this.onOpen = this.onOpen.bind(this);
     this.onWindowResize = this.onWindowResize.bind(this);
+    this.onWindowPaste = this.onWindowPaste.bind(this);
     this.onTermRef = this.onTermRef.bind(this);
     this.onTermWrapperRef = this.onTermWrapperRef.bind(this);
   }
@@ -77,6 +79,10 @@ export default class Term extends PureComponent {
       passive: true
     });
 
+    window.addEventListener('paste', this.onWindowPaste, {
+      capture: true
+    });
+
     terms[this.props.uid] = this;
   }
 
@@ -108,6 +114,15 @@ export default class Term extends PureComponent {
 
   onWindowResize() {
     this.fitResize();
+  }
+
+  onWindowPaste(e) {
+    const processed = processClipboard();
+    if (processed && this.props.isTermActive) {
+      e.preventDefault();
+      e.stopPropagation();
+      this.term.send(processed);
+    }
   }
 
   write(data) {
@@ -197,6 +212,10 @@ export default class Term extends PureComponent {
 
     window.removeEventListener('resize', this.onWindowResize, {
       passive: true
+    });
+
+    window.removeEventListener('paste', this.onWindowPaste, {
+      capture: true
     });
   }
 

--- a/lib/utils/paste.js
+++ b/lib/utils/paste.js
@@ -10,11 +10,9 @@ const getPath = platform => {
       const filepath = clipboard.read('FileNameW');
       return filepath.replace(new RegExp(String.fromCharCode(0), 'g'), '');
     }
-    case 'linux': {
-      return '';
-    }
+    // linux already pastes full path
     default:
-      return '';
+      return null;
   }
 };
 

--- a/lib/utils/paste.js
+++ b/lib/utils/paste.js
@@ -1,0 +1,23 @@
+import {clipboard} from 'electron';
+
+const getPath = platform => {
+  switch (platform) {
+    case 'darwin': {
+      const filepath = clipboard.read('public.file-url');
+      return filepath.replace('file://', '');
+    }
+    case 'win32': {
+      const filepath = clipboard.read('FileNameW');
+      return filepath.replace(new RegExp(String.fromCharCode(0), 'g'), '');
+    }
+    case 'linux': {
+      return '';
+    }
+    default:
+      return '';
+  }
+};
+
+export default function processClipboard() {
+  return getPath(process.platform);
+}


### PR DESCRIPTION
closes #1285 

**ready for merge, tested on windows, linux, and mac**

~not ready for merge because: 
I've tested on linux, and mac, *but not windows* (posted in slack but didn't get a reply), so if someone can test that, that would be great. There is windows specific parsing in there that I haven't tested at all.~

Also, wasn't 100% sure if this is the appropriate spot for this code, but it seemed like it to me (first contrib to `hyper`). Kept clipboard processing in a util file to not clutter the `Term` component. If suggestions for a better place for this, let me know.