### PR TITLE
Zoom Keymap Consistency

### DIFF
--- a/app/keymaps/darwin.json
+++ b/app/keymaps/darwin.json
@@ -5,7 +5,7 @@
   "window:preferences": "cmd+,",
   "zoom:reset": "cmd+0",
   "zoom:in": "cmd+plus",
-  "zoom:out": "cmd+-",
+  "zoom:out": "cmd+minus",
   "window:new": "cmd+n",
   "window:minimize": "cmd+m",
   "window:zoom": "ctrl+alt+cmd+m",

--- a/app/keymaps/linux.json
+++ b/app/keymaps/linux.json
@@ -5,7 +5,7 @@
   "window:preferences": "ctrl+,",
   "zoom:reset": "ctrl+0",
   "zoom:in": "ctrl+plus",
-  "zoom:out": "ctrl+-",
+  "zoom:out": "ctrl+minus",
   "window:new": "ctrl+shift+n",
   "window:minimize": "ctrl+shift+m",
   "window:zoom": "ctrl+shift+alt+m",

--- a/app/keymaps/win32.json
+++ b/app/keymaps/win32.json
@@ -5,7 +5,7 @@
   "window:preferences": "ctrl+,",
   "zoom:reset": "ctrl+0",
   "zoom:in": "ctrl+plus",
-  "zoom:out": "ctrl+-",
+  "zoom:out": "ctrl+minus",
   "window:new": "ctrl+shift+n",
   "window:minimize": "ctrl+m",
   "window:zoom": "ctrl+shift+alt+m",


### PR DESCRIPTION
Hello,

After using Hyper for a little bit, I noticed that zooming with CTRL keys and +/- resulted in erratic behavior. Zooming in would be fine, but then a zoom out would reset to a previous position, then zoom out. I found there was a possible typo for the assignment of zoom:out in the darwin, win32 and linux keymaps.

```cmd+-``` fixed to ```cmd+minus```

This PR is ready to be merged, and there is nothing left to do. It seems there might be changes to the keymap coming later on (?) with #1509, but this fixes the current issue.

Thanks! 