### PR TITLE
Replace nodejs version 8.4.0 with 8 in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ language: node_js
 matrix:
   include:
     - os: linux
-      node_js: 8.4.0
+      node_js: 8
       env: CC=clang CXX=clang++ npm_config_clang=1
       compiler: clang
 


### PR DESCRIPTION
It's better to specify only 8 in Travis CI so that we don't need to manually update its version especially when there is any security update.