### PR TITLE
🌹 Set travis-node version to match electron-node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ language: node_js
 matrix:
   include:
     - os: linux
-      node_js: 8.4.0
+      node_js: 7.9.0
       env: CC=clang CXX=clang++ npm_config_clang=1
       compiler: clang
 


### PR DESCRIPTION
Reason: https://github.com/zeit/hyper/pull/2367#issuecomment-337290759

>The reason why we have locked it is because we run almost all code with "electron's node".
>
>That is, the node that's running in electron. And we lock the travis version to the current version shipped with the version of electron we run.
>
>Better would be if we could fix our tests to run via electron-shipped-node instead of travis node.
>
>example would be:
>
>we had electron 1.x which shipped with node 7.0, but if we then had node 7 in travis, and travis >selected node 7.4+, async/await would be available natively within the tests, making them pass.
>
>but in when the code is run by hyper, it will use electron-node (7.0 in this case) and crash

Also for the future we should make this automatic, i see two solutions for this:

1. Having our tests be run with electron-node (if possible?)
2. Create a test that reads travis config, importinng electron and checks process.version and requires those to match