### PR TITLE
Doc: Fix mixed-up tags in component hierarchy

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -287,7 +287,7 @@
       #content h3:before {
         content: '### ';
       }
-      
+
       #content h4:before {
         content: '#### ';
       }
@@ -1244,7 +1244,7 @@
         <p>The user can hot-load and hot-reload plugins by pressing
         Command + R (refresh). Please strive to make plugins that don't
         require a complete restart of the application to work.</p>
-        
+
         <h4>Notice</h4>
         <p>Plugins affecting the `BrowserWindow` will the effect on new windows after hot-reload.</p>
 
@@ -1300,8 +1300,8 @@
         &lt;TermGroup&gt;
           &lt;Term /&gt; ...
         &lt;/TermGroup&gt;
-      &lt;/TermGroup&gt;
-    &lt;/SplitPane&gt;
+      &lt;/SplitPane&gt;
+    &lt;/TermGroup&gt;
   &lt;/Terms&gt;
   &lt;Notifications&gt;
     &lt;Notification /&gt; ...


### PR DESCRIPTION
The `TermGroup` and `SplitPane` tags were crossed:

```html
<TermGroup><SplitPane>...</TermGroup></SplitPane>
```

I put `SplitPane` inside `TermGroup`, which seemed right from inspecting the code:

```html
<TermGroup><SplitPane>...</SplitPane></TermGroup>
```

Of course, this is my first PR, so if it should be the other way around let me know. Otherwise this is ready to merge.