### PR TITLE
copyOnSelect support in canary

### DIFF
--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -131,20 +131,10 @@ export default class Term extends PureComponent {
     }
   }
 
-  onMouseUp(e) {
+  onMouseUp() {
     // handle copying selected text
     if (this.props.copyOnSelect && this.term.hasSelection()) {
       clipboard.writeText(this.term.getSelection());
-    }
-
-    // handle quickEdit copy/paste
-    if (this.props.quickEdit && e.button === 2) {
-      if (this.term.hasSelection()) {
-        clipboard.writeText(this.term.getSelection());
-        this.term.clearSelection();
-      } else {
-        document.execCommand('paste');
-      }
     }
   }
 

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -116,6 +116,8 @@ export default class Term extends PureComponent {
     this.fitResize();
   }
 
+  // intercepting paste event for any necessary processing of
+  // clipboard data, if result is falsy, paste event continues
   onWindowPaste(e) {
     if (!this.props.isTermActive) return;
 

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -1,6 +1,7 @@
 /* global Blob,URL,requestAnimationFrame */
 import React from 'react';
 import Terminal from 'xterm';
+import {clipboard} from 'electron';
 import {PureComponent} from '../base-components';
 import terms from '../terms';
 import returnKey from '../utils/keymaps';
@@ -26,6 +27,7 @@ export default class Term extends PureComponent {
     this.onWindowPaste = this.onWindowPaste.bind(this);
     this.onTermRef = this.onTermRef.bind(this);
     this.onTermWrapperRef = this.onTermWrapperRef.bind(this);
+    this.onMouseUp = this.onMouseUp.bind(this);
   }
 
   componentDidMount() {
@@ -129,6 +131,23 @@ export default class Term extends PureComponent {
     }
   }
 
+  onMouseUp(e) {
+    // handle copying selected text
+    if (this.props.copyOnSelect && this.term.hasSelection()) {
+      clipboard.writeText(this.term.getSelection());
+    }
+
+    // handle quickEdit copy/paste
+    if (this.props.quickEdit && e.button === 2) {
+      if (this.term.hasSelection()) {
+        clipboard.writeText(this.term.getSelection());
+        this.term.clearSelection();
+      } else {
+        document.execCommand('paste');
+      }
+    }
+  }
+
   write(data) {
     this.term.write(data);
   }
@@ -225,7 +244,11 @@ export default class Term extends PureComponent {
 
   template(css) {
     return (
-      <div className={css('fit', this.props.isTermActive && 'active')} style={{padding: this.props.padding}}>
+      <div
+        className={css('fit', this.props.isTermActive && 'active')}
+        style={{padding: this.props.padding}}
+        onMouseUp={this.onMouseUp}
+      >
         {this.props.customChildrenBefore}
         <div ref={this.onTermWrapperRef} className={css('fit', 'wrapper')}>
           <div ref={this.onTermRef} className={css('term')} />

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -117,8 +117,10 @@ export default class Term extends PureComponent {
   }
 
   onWindowPaste(e) {
+    if (!this.props.isTermActive) return;
+
     const processed = processClipboard();
-    if (processed && this.props.isTermActive) {
+    if (processed) {
       e.preventDefault();
       e.stopPropagation();
       this.term.send(processed);

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -5,6 +5,7 @@ import {PureComponent} from '../base-components';
 import terms from '../terms';
 import returnKey from '../utils/keymaps';
 import CommandRegistry from '../command-registry';
+import processClipboard from '../utils/paste';
 
 // map old hterm constants to xterm.js
 const CURSOR_STYLES = {
@@ -22,6 +23,7 @@ export default class Term extends PureComponent {
     this.termRect = null;
     this.onOpen = this.onOpen.bind(this);
     this.onWindowResize = this.onWindowResize.bind(this);
+    this.onWindowPaste = this.onWindowPaste.bind(this);
     this.onTermRef = this.onTermRef.bind(this);
     this.onTermWrapperRef = this.onTermWrapperRef.bind(this);
   }
@@ -77,6 +79,10 @@ export default class Term extends PureComponent {
       passive: true
     });
 
+    window.addEventListener('paste', this.onWindowPaste, {
+      capture: true
+    });
+
     terms[this.props.uid] = this;
   }
 
@@ -108,6 +114,15 @@ export default class Term extends PureComponent {
 
   onWindowResize() {
     this.fitResize();
+  }
+
+  onWindowPaste(e) {
+    const processed = processClipboard();
+    if (processed && this.props.isTermActive) {
+      e.preventDefault();
+      e.stopPropagation();
+      this.term.send(processed);
+    }
   }
 
   write(data) {
@@ -197,6 +212,10 @@ export default class Term extends PureComponent {
 
     window.removeEventListener('resize', this.onWindowResize, {
       passive: true
+    });
+
+    window.removeEventListener('paste', this.onWindowPaste, {
+      capture: true
     });
   }
 

--- a/lib/utils/paste.js
+++ b/lib/utils/paste.js
@@ -10,11 +10,9 @@ const getPath = platform => {
       const filepath = clipboard.read('FileNameW');
       return filepath.replace(new RegExp(String.fromCharCode(0), 'g'), '');
     }
-    case 'linux': {
-      return '';
-    }
+    // linux already pastes full path
     default:
-      return '';
+      return null;
   }
 };
 

--- a/lib/utils/paste.js
+++ b/lib/utils/paste.js
@@ -1,0 +1,23 @@
+import {clipboard} from 'electron';
+
+const getPath = platform => {
+  switch (platform) {
+    case 'darwin': {
+      const filepath = clipboard.read('public.file-url');
+      return filepath.replace('file://', '');
+    }
+    case 'win32': {
+      const filepath = clipboard.read('FileNameW');
+      return filepath.replace(new RegExp(String.fromCharCode(0), 'g'), '');
+    }
+    case 'linux': {
+      return '';
+    }
+    default:
+      return '';
+  }
+};
+
+export default function processClipboard() {
+  return getPath(process.platform);
+}


### PR DESCRIPTION
PR is ready to be merged: tested on mac, ubuntu, and windows 10

fixes #2260 (partially)

Fairly straightforward: on mouseUp, if there is a selection and copyOnSelect is true, it'll copy it.

----------

I had also added quickEdit support in before I noticed there was an existing PR. I backed it out though, see commit here: https://github.com/derrickpelletier/hyper/commit/9dd1d27a96c5236ba3a21971186d29a08c0a9778#diff-268710614c2274f611be667a5f72bb13R141

I'll add it back in if we're going to merge it but @albinekb seemed unsure of that functionality at this time. If you'd rather maintain the existing PR for it (#2348), note that it uses a different method for click handling that I did here.