### PR TITLE
quickEdit support

### DIFF
--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -137,6 +137,7 @@ export default class Term extends PureComponent {
       clipboard.writeText(this.term.getSelection());
     }
 
+    // handle quickEdit copy/paste with right click
     if (this.props.quickEdit && e.button === 2) {
       if (this.term.hasSelection()) {
         clipboard.writeText(this.term.getSelection());

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -132,12 +132,6 @@ export default class Term extends PureComponent {
   }
 
   onMouseUp(e) {
-    // handle copying selected text
-    if (this.props.copyOnSelect && this.term.hasSelection()) {
-      clipboard.writeText(this.term.getSelection());
-    }
-
-    // handle quickEdit copy/paste with right click
     if (this.props.quickEdit && e.button === 2) {
       if (this.term.hasSelection()) {
         clipboard.writeText(this.term.getSelection());
@@ -145,6 +139,8 @@ export default class Term extends PureComponent {
       } else {
         document.execCommand('paste');
       }
+    } else if (this.props.copyOnSelect && this.term.hasSelection()) {
+      clipboard.writeText(this.term.getSelection());
     }
   }
 

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -131,10 +131,19 @@ export default class Term extends PureComponent {
     }
   }
 
-  onMouseUp() {
+  onMouseUp(e) {
     // handle copying selected text
     if (this.props.copyOnSelect && this.term.hasSelection()) {
       clipboard.writeText(this.term.getSelection());
+    }
+
+    if (this.props.quickEdit && e.button === 2) {
+      if (this.term.hasSelection()) {
+        clipboard.writeText(this.term.getSelection());
+        this.term.clearSelection();
+      } else {
+        document.execCommand('paste');
+      }
     }
   }
 


### PR DESCRIPTION
tested on mac, ubuntu 16.04, windows 10

closes #2260, #2318 

Note that this should close #2348, which is the same functionality, very slightly different implementation. I didn't intend to duplicate their effort, but @chabou asked me to submit this (in https://github.com/zeit/hyper/pull/2390#issuecomment-339148926)

As far as I know, and based on a simple test in windows command prompt, this works as expected:
- Select text
- right click anywhere to copy the selection
- selection clears
- right click anywhere to paste

If there are any nuances to quick-edit beyond that, I'm not aware of them, but even still this is probably enough for a first iteration at the very least.

