### PR TITLE
Removing call to undefined function on resize

### DIFF
--- a/lib/components/term-group.js
+++ b/lib/components/term-group.js
@@ -91,7 +91,7 @@ class TermGroup_ extends PureComponent {
 
   componentWillReceiveProps(nextProps) {
     if (this.props.termGroup.sizes != nextProps.termGroup.sizes || nextProps.sizeChanged) {
-      this.term && this.term.measureResize();
+      this.term && this.term.fitResize();
       // Indicate to children that their size has changed even if their ratio hasn't
       this.sizeChanged = true;
     } else {


### PR DESCRIPTION
To Address #2395 

Looks like the `measureResize` function was removed in [2273](https://github.com/zeit/hyper/pull/2273) but this file was never updated. This removes the error. 