### PR TITLE
Move syntax error description to notification body

### DIFF
--- a/app/config/init.js
+++ b/app/config/init.js
@@ -14,7 +14,7 @@ const _syntaxValidation = function(cfg) {
   try {
     return new vm.Script(cfg, {filename: '.hyper.js', displayErrors: true});
   } catch (err) {
-    notify(`Error loading config: ${err.name}, see DevTools for more info`);
+    notify('Error loading config:', `${err.name}, see DevTools for more info`);
     //eslint-disable-next-line no-console
     console.error('Error loading config:', err);
   }


### PR DESCRIPTION
<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`

Thanks, again! -->
closes #2346

This is a simple one! Although I only tested it on Windows 10, this should resolve the error on Windows 7... it moves the bulk of the error message for syntax validation to the `body` parameter of `notify`, as suggested.

Thank you @albinekb for marking this as a 'good first issue' and allowing me to contribute!