### PR TITLE
Improved context menu

### DIFF
--- a/app/menus/menus/shell.js
+++ b/app/menus/menus/shell.js
@@ -39,7 +39,7 @@ module.exports = (commandKeys, execCommand) => {
         type: 'separator'
       },
       {
-        label: 'Close Pane',
+        label: 'Close',
         accelerator: commandKeys['pane:close'],
         click(item, focusedWindow) {
           execCommand('pane:close', focusedWindow);

--- a/app/menus/menus/shell.js
+++ b/app/menus/menus/shell.js
@@ -39,7 +39,7 @@ module.exports = (commandKeys, execCommand) => {
         type: 'separator'
       },
       {
-        label: 'Close Tab',
+        label: 'Close Pane',
         accelerator: commandKeys['pane:close'],
         click(item, focusedWindow) {
           execCommand('pane:close', focusedWindow);

--- a/app/menus/menus/shell.js
+++ b/app/menus/menus/shell.js
@@ -5,13 +5,6 @@ module.exports = (commandKeys, execCommand) => {
     label: isMac ? 'Shell' : 'File',
     submenu: [
       {
-        label: 'New Window',
-        accelerator: commandKeys['window:new'],
-        click(item, focusedWindow) {
-          execCommand('window:new', focusedWindow);
-        }
-      },
-      {
         label: 'New Tab',
         accelerator: commandKeys['tab:new'],
         click(item, focusedWindow) {
@@ -19,14 +12,14 @@ module.exports = (commandKeys, execCommand) => {
         }
       },
       {
-        type: 'separator'
+        label: 'New Window',
+        accelerator: commandKeys['window:new'],
+        click(item, focusedWindow) {
+          execCommand('window:new', focusedWindow);
+        }
       },
       {
-        label: 'Split Vertically',
-        accelerator: commandKeys['pane:splitVertical'],
-        click(item, focusedWindow) {
-          execCommand('pane:splitVertical', focusedWindow);
-        }
+        type: 'separator'
       },
       {
         label: 'Split Horizontally',
@@ -36,10 +29,17 @@ module.exports = (commandKeys, execCommand) => {
         }
       },
       {
+        label: 'Split Vertically',
+        accelerator: commandKeys['pane:splitVertical'],
+        click(item, focusedWindow) {
+          execCommand('pane:splitVertical', focusedWindow);
+        }
+      },
+      {
         type: 'separator'
       },
       {
-        label: 'Close Session',
+        label: 'Close Tab',
         accelerator: commandKeys['pane:close'],
         click(item, focusedWindow) {
           execCommand('pane:close', focusedWindow);


### PR DESCRIPTION
I changed the order of a few context menu entries to make more sense.

As an example, "horizontal splitting" has to come before "vertical splitting" because "x" always comes before the "y" axis. In addition, I replaced "Close Session" with "Close Tab" since we're saying "New Tab" and not "New Session" above.