### PR TITLE
Disable undo/redo/cut menuItems

### DIFF
--- a/app/menus/menus/edit.js
+++ b/app/menus/menus/edit.js
@@ -1,19 +1,22 @@
 module.exports = (commandKeys, execCommand) => {
   const submenu = [
     {
-      role: 'undo',
-      accelerator: commandKeys['editor:undo']
+      label: 'Undo',
+      accelerator: commandKeys['editor:undo'],
+      enabled: false
     },
     {
-      role: 'redo',
-      accelerator: commandKeys['editor:redo']
+      label: 'Redo',
+      accelerator: commandKeys['editor:redo'],
+      enabled: false
     },
     {
       type: 'separator'
     },
     {
-      role: 'cut',
-      accelerator: commandKeys['editor:cut']
+      label: 'Cut',
+      accelerator: commandKeys['editor:cut'],
+      enabled: false
     },
     {
       role: 'copy',

--- a/app/ui/contextmenu.js
+++ b/app/ui/contextmenu.js
@@ -21,5 +21,5 @@ const filterCutCopy = (selection, menuItem) => {
 module.exports = (createWindow, selection) => {
   const _shell = shellMenu(commandKeys, execCommand).submenu;
   const _edit = editMenu(commandKeys, execCommand).submenu.filter(filterCutCopy.bind(null, selection));
-  return _edit.concat(separator, _shell);
+  return _edit.concat(separator, _shell).filter(menuItem => !menuItem.hasOwnProperty('enabled') || menuItem.enabled);
 };


### PR DESCRIPTION
Undo, Redo and Cut features make no sense for a terminal, for now.
Undo/Redo will be used, one day for Hyper features... Like iTerm, it should be great to cancel a pane closing right after (for 5s).
They are disabled in main menu and removed from contextMenu
