### PR TITLE
Enhance plugin installation

### DIFF
--- a/app/plugins.js
+++ b/app/plugins.js
@@ -57,8 +57,7 @@ function updatePlugins({force = false} = {}) {
 
     if (err) {
       //eslint-disable-next-line no-console
-      console.error(err.stack);
-      notify('Error updating plugins.', err.message);
+      notify('Error updating plugins.', err);
     } else {
       // flag successful plugin update
       cache.set('hyper.plugins', id_);
@@ -135,7 +134,7 @@ if (cache.get('hyper.plugins') !== id || process.env.HYPER_FORCE_UPDATE) {
   console.log('plugins have changed / not init, scheduling plugins installation');
   setTimeout(() => {
     updatePlugins();
-  }, 5000);
+  }, 1000);
 }
 
 // otherwise update plugins every 5 hours
@@ -243,9 +242,14 @@ function requirePlugins() {
 
       return mod;
     } catch (err) {
-      //eslint-disable-next-line no-console
-      console.error(err);
-      notify('Plugin error!', `Plugin "${basename(path_)}" failed to load (${err.message})`);
+      if (err.code === 'MODULE_NOT_FOUND') {
+        //eslint-disable-next-line no-console
+        console.warn(`Plugin "${basename(path_)}" not found: ${path_}`);
+      } else {
+        //eslint-disable-next-line no-console
+        console.error(err);
+        notify('Plugin error!', `Plugin "${basename(path_)}" failed to load (${err.message})`);
+      }
     }
   };
 

--- a/app/plugins/install.js
+++ b/app/plugins/install.js
@@ -25,9 +25,9 @@ module.exports = {
             timeout: ms('5m'),
             maxBuffer: 1024 * 1024
           },
-          err => {
+          (err, stdout, stderr) => {
             if (err) {
-              cb(err);
+              cb(stderr);
             } else {
               cb(null);
             }

--- a/lib/utils/plugins.js
+++ b/lib/utils/plugins.js
@@ -123,8 +123,10 @@ const loadModules = () => {
     reduceTermGroups: termGroupsReducers
   };
 
+  const loadedPlugins = plugins.getLoadedPluginVersions().map(plugin => plugin.name);
   modules = paths.plugins
     .concat(paths.localPlugins)
+    .filter(plugin => loadedPlugins.indexOf(plugin) !== -1)
     .map(path => {
       let mod;
       const pluginName = getPluginName(path);


### PR DESCRIPTION
This PR enhance plugin installation:
* No more double error notification triggered when plugin is added to config before launching Hyper
* Error notification message is better when yarn failed:
  * Before : `Command failed: /Users/chabou/Documents/Projets/hyper/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron /Users/chabou/Documents/Projets/hyper/bin/yarn-standalone.js install --no-emoji --no-lockfile --cache-folder /Users/chabou/.hyper_plugins/cache
error Couldn't find package "lklfdklfkl" on the "npm" registry.`
  * After: `error Couldn't find package "lklfdklfkl" on the "npm" registry.`
* Delay before launching plugin installation is reduced from 5s to 1s