### PR TITLE
Load/Unload theme without restarting

### DIFF
--- a/app/ui/window.js
+++ b/app/ui/window.js
@@ -36,6 +36,11 @@ module.exports = class Window {
     const rpc = createRPC(window);
     const sessions = new Map();
 
+    const updateBackgroundColor = () => {
+      const cfg_ = app.plugins.getDecoratedConfig();
+      window.setBackgroundColor(toElectronBackgroundColor(cfg_.backgroundColor || '#000'));
+    };
+
     // config changes
     const cfgUnsubscribe = app.config.subscribe(() => {
       const cfg_ = app.plugins.getDecoratedConfig();
@@ -49,11 +54,12 @@ module.exports = class Window {
       }
 
       // update background color if necessary
+      updateBackgroundColor();
+
       cfg = cfg_;
     });
 
     rpc.on('init', () => {
-      window.setBackgroundColor(toElectronBackgroundColor(cfg.backgroundColor || '#000'));
       window.show();
 
       // If no callback is passed to createWindow,
@@ -234,6 +240,7 @@ module.exports = class Window {
       if (!err) {
         load();
         window.webContents.send('plugins change');
+        updateBackgroundColor();
       }
     });
 

--- a/lib/reducers/ui.js
+++ b/lib/reducers/ui.js
@@ -155,7 +155,7 @@ const reducer = (state = initial, action) => {
               ret.backgroundColor = config.backgroundColor;
             }
 
-            if (config.css) {
+            if (config.css || config.css === '') {
               ret.css = config.css;
             }
 


### PR DESCRIPTION
This PR fixes 2 things: 
* Background color, especially with transparency was not visible without restarting.
* If `config.css` was empty after removing a plugin, plugin's css was not removed from DOM

To test this PR, add/remove/add a local plugin (For example, this mix between `hyperyellow` and `hyper-simple-transparency`):
```javascript
module.exports.onWindow = browserWindow => {
  browserWindow.setVibrancy("dark");
};

module.exports.decorateConfig = config => {
  return Object.assign({}, config, {
    backgroundColor: "rgba(0,0,0,0.2)",
    borderColor: "yellow",
    cursorColor: "yellow",
    css: `
      ${config.css || ""}
      .tabs_nav .tabs_list .tab_text {
        color: yellow;
      }
      .tabs_nav .tabs_title {
        color: yellow;
      }
    `
  });
};
```

Result:
![hyper-fix-theme-loading](https://user-images.githubusercontent.com/4137761/32810873-42376fb2-c99d-11e7-9a86-bf063d563b0b.gif)
