### PR TITLE
Making it explicit that opacity is only supported in macOS  

### DIFF
--- a/app/config/config-default.js
+++ b/app/config/config-default.js
@@ -27,6 +27,7 @@ module.exports = {
     foregroundColor: '#fff',
 
     // terminal background color
+    // opacity is only supported on macOS
     backgroundColor: '#000',
 
     // border color (window, tabs)


### PR DESCRIPTION
PR is ready to be merged.
Makes it more explicit that background colour opacity is not supported in windows/linux.
Related to #2451 