### PR TITLE
Fixing zoom out keymap

### DIFF
--- a/app/keymaps/darwin.json
+++ b/app/keymaps/darwin.json
@@ -5,7 +5,7 @@
   "window:preferences": "command+,",
   "zoom:reset": "command+0",
   "zoom:in": "command+plus",
-  "zoom:out": "command+minus",
+  "zoom:out": "command+-",
   "window:new": "command+n",
   "window:minimize": "command+m",
   "window:zoom": "ctrl+alt+command+m",

--- a/app/keymaps/linux.json
+++ b/app/keymaps/linux.json
@@ -5,7 +5,7 @@
   "window:preferences": "ctrl+,",
   "zoom:reset": "ctrl+0",
   "zoom:in": "ctrl+plus",
-  "zoom:out": "ctrl+minus",
+  "zoom:out": "ctrl+-",
   "window:new": "ctrl+shift+n",
   "window:minimize": "ctrl+shift+m",
   "window:zoom": "ctrl+shift+alt+m",

--- a/app/keymaps/win32.json
+++ b/app/keymaps/win32.json
@@ -5,7 +5,7 @@
   "window:preferences": "ctrl+,",
   "zoom:reset": "ctrl+0",
   "zoom:in": "ctrl+plus",
-  "zoom:out": "ctrl+minus",
+  "zoom:out": "ctrl+-",
   "window:new": "ctrl+shift+n",
   "window:minimize": "ctrl+shift+m",
   "window:zoom": "ctrl+shift+alt+m",


### PR DESCRIPTION
I think I fixed the broken keymap for zoom:out.

I found out that when I replaced command+minus with command+- the keyboard shortcut works again on a Mac. I'm not sure why this suddenly stopped working because I couldn't find a recent commit that changed this keymap – maybe it's an Electron thing? Anyway, it makes sense, since that particular key produces a hyphen-minus and not a minus.

I can't test on Windows or Linux but I took the liberty to change those keymaps as well. Can somebody test them?