### PR TITLE
Expose ‘true colour’ support in $COLORTERM

### DIFF
--- a/app/session.js
+++ b/app/session.js
@@ -26,6 +26,7 @@ module.exports = class Session extends EventEmitter {
     const baseEnv = Object.assign({}, process.env, {
       LANG: app.getLocale().replace('-', '_') + '.UTF-8',
       TERM: 'xterm-256color',
+      COLORTERM: 'truecolor',
       TERM_PROGRAM: productName,
       TERM_PROGRAM_VERSION: version
     }, envFromConfig);


### PR DESCRIPTION
Further discussion here: <https://gist.github.com/XVilka/8346728#detection>

This environment variable seems to be becoming standardized-upon. That said, although a single-line change, it *is* increasing the bloat dumped onto the environment by 25%, so feel free to discuss/wait/reject!

`<3`