### PR TITLE
Revert "Expose ‘true colour’ support in $COLORTERM"

### DIFF
--- a/app/session.js
+++ b/app/session.js
@@ -26,7 +26,6 @@ module.exports = class Session extends EventEmitter {
     const baseEnv = Object.assign({}, process.env, {
       LANG: app.getLocale().replace('-', '_') + '.UTF-8',
       TERM: 'xterm-256color',
-      COLORTERM: 'truecolor',
       TERM_PROGRAM: productName,
       TERM_PROGRAM_VERSION: version
     }, envFromConfig);


### PR DESCRIPTION
Reverts zeit/hyper#2478

Because it should target canary