### PR TITLE
add additional sentence To run hyper

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -50,8 +50,9 @@ Regardless of the platform you are working on, you will need to have Yarn instal
 3. Install the dependencies: `yarn`
 4. Build the code and watch for changes: `yarn run dev`
 5. To run `hyper`
-  * `yarn run app` from another terminal tab/window/pane OR press ctrl+c then `yarn run app`
+  * `yarn run app` from another terminal tab/window/pane
   * If you are using **Visual Studio Code**, select `Launch Hyper` in debugger configuration to launch a new Hyper instance with debugger attached.
+  * If you interrupt `yarn run dev`, you'll need to relaunch it each time you want to test something. Webpack will watch changes and will rebuild renderer code when needed (and only what have changed). You'll just have to relaunch electron by using yarn run app or VSCode launch task.
 
 To make sure that your code works in the finished application, you can generate the binaries like this:
 

--- a/readme.md
+++ b/readme.md
@@ -50,7 +50,7 @@ Regardless of the platform you are working on, you will need to have Yarn instal
 3. Install the dependencies: `yarn`
 4. Build the code and watch for changes: `yarn run dev`
 5. To run `hyper`
-  * `yarn run app` from another terminal tab/window/pane
+  * `yarn run app` from another terminal tab/window/pane OR press ctrl+c then `yarn run app`
   * If you are using **Visual Studio Code**, select `Launch Hyper` in debugger configuration to launch a new Hyper instance with debugger attached.
 
 To make sure that your code works in the finished application, you can generate the binaries like this:


### PR DESCRIPTION
5. To run `hyper`
    * `yarn run app` from another terminal tab/window/pane
    * If you are using **Visual Studio Code**, select `Launch Hyper` in debugger configuration to launch a new Hyper instance with debugger attached.
    *** If you interrupt `yarn run dev`, you'll need to relaunch it each time you want to test something. Webpack will watch changes and will rebuild renderer code when needed (and only what have changed). You'll just have to relaunch electron by using yarn run app or VSCode launch task.**
--------------------------------------------------------------------------------------------------------
add additional sentence why you don't need to interrupt `yarn run app`.
Collaborator chabou advice me to change this, but you mean this is right?
If it isn't right, I'm very sorry.