### PR TITLE
Fix branch detection when setting the canary icon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,10 @@ install:
   - yarn
 
 after_success:
-  - if [[ "$TRAVIS_BRANCH" == "canary" ]]; then cp build/canary.icns build/icon.icns; fi
+  - git branch --contains $TRAVIS_COMMIT | grep canary >/dev/null && cp build/canary.icns build/icon.icns
   - yarn run dist
 
 branches:
   except:
     - "/^v\\d+\\.\\d+\\.\\d+$/"
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
   - yarn
 
 after_success:
-  - git branch --contains $TRAVIS_COMMIT | grep canary >/dev/null && cp build/canary.icns build/icon.icns
+  - git branch --contains $TRAVIS_COMMIT | grep canary >/dev/null && (cd build; cp canary.icns icon.icns; cp canary.ico icon.ico)
   - yarn run dist
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
   - yarn
 
 after_success:
-  - git branch --contains $TRAVIS_COMMIT | grep canary > /dev/null && (cd build; cp canary.icns icon.icns; cp canary.ico icon.ico)
+  - (git branch --contains $TRAVIS_COMMIT | grep canary > /dev/null || [[ "$TRAVIS_BRANCH" == "canary" ]] ) && (cd build; cp canary.icns icon.icns; cp canary.ico icon.ico)
   - yarn run dist
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
   - yarn
 
 after_success:
-  - git branch --contains $TRAVIS_COMMIT | grep canary >/dev/null && (cd build; cp canary.icns icon.icns; cp canary.ico icon.ico)
+  - git branch --contains $TRAVIS_COMMIT | grep canary > /dev/null && (cd build; cp canary.icns icon.icns; cp canary.ico icon.ico)
   - yarn run dist
 
 branches:


### PR DESCRIPTION
When a tag is being built, `TRAVIS_BRANCH` equals to the tag name. Therefore, the canary icon was never being copied over 😄 

This also copies the Windows (.ico) icon over 👌 