### PR TITLE
Keep Arabic letters without wrapping them with span

### DIFF
--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -31,7 +31,7 @@ hterm.Terminal.prototype.onMouse_ = function (e) {
 };
 
 function containsNonLatinCodepoints(s) {
-  return /[^\u0000-\u00ff]/.test(s);
+  return /[^\u0000-\u00ff]/.test(s) && !/[^\p{Arabic}]/.test(s);
 }
 
 // hterm Unicode patch


### PR DESCRIPTION
Fix the Arabic letter connection where splitting the chars into multiple spans will cause the words to be broken.

Ex. currently when you write مرحبا it will display it as اب ح ر م.

<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`

Thanks, again! -->
