### PR TITLE
Save and restore window size after restart (Fixes #2249)

### DIFF
--- a/app/config/config-default.js
+++ b/app/config/config-default.js
@@ -54,7 +54,7 @@ module.exports = {
 
     // default window width
     windowWidth: 500,
-    
+
     // default window heigth
     windowHeight: 370,
 

--- a/app/config/config-default.js
+++ b/app/config/config-default.js
@@ -52,6 +52,12 @@ module.exports = {
     // custom padding (CSS format, i.e.: `top right bottom left`)
     padding: '12px 14px',
 
+    // default window width
+    windowWidth: 500,
+    
+    // default window heigth
+    windowHeight: 370,
+
     // the full list. if you're going to provide the full color palette,
     // including the 6 x 6 color cubes and the grayscale map, just provide
     // an array here instead of a color map object

--- a/app/config/import.js
+++ b/app/config/import.js
@@ -60,3 +60,15 @@ exports.getDefaultConfig = () => {
   }
   return defaultConfig;
 };
+
+exports.updateState = function(path, data) {
+  _write(path, data);
+};
+
+exports.importState = function(path) {
+  try {
+    return readFileSync(path, 'utf8');
+  } catch (err) {
+    return 0;
+  }  
+};

--- a/app/config/import.js
+++ b/app/config/import.js
@@ -61,14 +61,14 @@ exports.getDefaultConfig = () => {
   return defaultConfig;
 };
 
-exports.updateState = function(path, data) {
+exports.updateState = (path, data) => {
   _write(path, data);
 };
 
-exports.importState = function(path) {
+exports.importState = path => {
   try {
     return readFileSync(path, 'utf8');
   } catch (err) {
     return 0;
-  }  
+  }
 };

--- a/app/config/paths.js
+++ b/app/config/paths.js
@@ -6,9 +6,11 @@ const isDev = require('electron-is-dev');
 
 const cfgFile = '.hyper.js';
 const defaultCfgFile = 'config-default.js';
+const cfgFileState = '.hyperState.js';
 const homeDir = homedir();
 
 let cfgPath = join(homeDir, cfgFile);
+let cfgPathState = join(homeDir, cfgFileState);
 let cfgDir = homeDir;
 
 const devDir = resolve(__dirname, '../..');
@@ -60,6 +62,7 @@ module.exports = {
   cfgDir,
   cfgPath,
   cfgFile,
+  cfgPathState,
   defaultCfg,
   icon,
   defaultPlatformKeyPath,

--- a/app/ui/window.js
+++ b/app/ui/window.js
@@ -63,7 +63,7 @@ module.exports = class Window {
     rpc.on('init', () => {
       window.show();
 
-      if (importState(cfgPathState)=="true"){
+      if (importState(cfgPathState) == 'true') {
         window.maximize();
       }
 
@@ -137,7 +137,7 @@ module.exports = class Window {
       }
     });
     rpc.on('unmaximize', () => {
-      if (importState(cfgPathState)=="true"){
+      if (importState(cfgPathState) == 'true') {
         window.setSize(cfg.windowWidth, cfg.windowHeight);
         window.center();
       } else {
@@ -188,10 +188,10 @@ module.exports = class Window {
       rpc.emit('move');
     });
     rpc.on('close', () => {
-      if (window.isMaximized()==true){
-        updateState(cfgPathState, "true");
-      }else{
-        updateState(cfgPathState, "false");
+      if (window.isMaximized() == true) {
+        updateState(cfgPathState, 'true');
+      } else {
+        updateState(cfgPathState, 'false');
       }
       window.close();
     });


### PR DESCRIPTION
This commit ensures that hyper is restarted in a maximized state if it is closed in a maximized state. Minimizing a maximized window after restart gives a window with default dimensions.

Fixes: [#2249](https://github.com/zeit/hyper/issues/2249)
This issue is only for windows
