### PR TITLE
Restart and upgrade in help menu (#434)

### DIFF
--- a/app/menus/menus/help.js
+++ b/app/menus/menus/help.js
@@ -5,12 +5,18 @@ const {getConfig, getPlugins} = require('../../config');
 const {arch, env, platform, versions} = process;
 const {version} = require('../../package.json');
 
-module.exports = (commands, showAbout) => {
+module.exports = (commands, showAbout, installUpdate) => {
   const submenu = [
     {
       label: `${app.getName()} Website`,
       click() {
         shell.openExternal('https://hyper.is');
+      }
+    },
+    {
+      label: 'Restart and update',
+      click() {
+        installUpdate();
       }
     },
     {


### PR DESCRIPTION
This commit adds an option to hyper's help menu for installing already downloaded updates.

This is useful for when the user wants to dismiss an update notification but still have the option to perform a restart and update later.

If there are no updates to be installed when the command is executed, a notification pops regarding that information. 

It comes as a solution for #434.