### PR TITLE
View all keyboard shortcuts (#814)

### DIFF
--- a/app/commands.js
+++ b/app/commands.js
@@ -1,5 +1,5 @@
 const {app} = require('electron');
-const {openConfig} = require('./config');
+const {openConfig, openConfigKeymap} = require('./config');
 const {updatePlugins} = require('./plugins');
 
 const commands = {
@@ -25,6 +25,9 @@ const commands = {
   },
   'window:preferences': () => {
     openConfig();
+  },
+  'editor:show': () => {
+    openConfigKeymap();
   },
   'editor:clearBuffer': focusedWindow => {
     focusedWindow && focusedWindow.rpc.emit('session clear req');

--- a/app/commands.js
+++ b/app/commands.js
@@ -26,7 +26,7 @@ const commands = {
   'window:preferences': () => {
     openConfig();
   },
-  'editor:show': () => {
+  'editor:showKeymap': () => {
     openConfigKeymap();
   },
   'editor:clearBuffer': focusedWindow => {

--- a/app/config.js
+++ b/app/config.js
@@ -3,7 +3,7 @@ const notify = require('./notify');
 const {_import, getDefaultConfig} = require('./config/import');
 const _openConfig = require('./config/open');
 const win = require('./config/windows');
-const {cfgPath, cfgDir} = require('./config/paths');
+const {cfgPath, cfgDir, cfgPathKeyPath} = require('./config/paths');
 
 const watchers = [];
 let cfg = {};
@@ -59,7 +59,19 @@ exports.getConfig = () => {
 };
 
 exports.openConfig = () => {
-  return _openConfig();
+  return _openConfig(cfgPath);
+};
+
+exports.openConfigKeymap = () => {
+  let keystring = JSON.stringify(cfg.keymaps, null);
+  let a = keystring.split(/(?!\B"[^"]*),(?![^"]*"\B)/);
+  const {writeFileSync} = require('fs');
+  //write to file
+  writeFileSync(cfgPathKeyPath, a[0]);
+  for (let i = 1; i < a.length; i++) {
+    fs.appendFileSync(cfgPathKeyPath, '\r\n' + a[i]);
+  }
+  return _openConfig(cfgPathKeyPath);
 };
 
 exports.getPlugins = () => {

--- a/app/config/open.js
+++ b/app/config/open.js
@@ -1,7 +1,6 @@
 const {shell} = require('electron');
-const {cfgPath} = require('./paths');
 
-module.exports = () => Promise.resolve(shell.openItem(cfgPath));
+module.exports = path => Promise.resolve(shell.openItem(path));
 
 if (process.platform === 'win32') {
   const Registry = require('winreg');
@@ -68,19 +67,19 @@ if (process.platform === 'win32') {
       });
     });
 
-  module.exports = () =>
+  module.exports = path =>
     hasDefaultSet()
       .then(yes => {
         if (yes) {
-          return shell.openItem(cfgPath);
+          return shell.openItem(path);
         }
         //eslint-disable-next-line no-console
         console.warn('No default app set for .js files, using notepad.exe fallback');
-        return openNotepad(cfgPath);
+        return openNotepad(path);
       })
       .catch(err => {
         //eslint-disable-next-line no-console
         console.error('Open config with default app error:', err);
-        return openNotepad(cfgPath);
+        return openNotepad(path);
       });
 }

--- a/app/config/paths.js
+++ b/app/config/paths.js
@@ -15,6 +15,9 @@ const devDir = resolve(__dirname, '../..');
 const devCfg = join(devDir, cfgFile);
 const defaultCfg = resolve(__dirname, defaultCfgFile);
 
+const cfgFileKeyPath = '.hyperKeyMap.js';
+let cfgPathKeyPath = join(homeDir, cfgFileKeyPath);
+
 if (isDev) {
   // if a local config file exists, use it
   try {
@@ -62,6 +65,7 @@ module.exports = {
   cfgFile,
   defaultCfg,
   icon,
+  cfgPathKeyPath,
   defaultPlatformKeyPath,
   plugs,
   yarn

--- a/app/keymaps/darwin.json
+++ b/app/keymaps/darwin.json
@@ -46,5 +46,6 @@
   "editor:deleteEndLine": "command+delete",
   "editor:clearBuffer": "command+k",
   "editor:emojis": "command+ctrl+space",
-  "plugins:update": "command+shift+u"
+  "plugins:update": "command+shift+u",
+  "editor:show": "command+p"
 }

--- a/app/keymaps/darwin.json
+++ b/app/keymaps/darwin.json
@@ -47,5 +47,5 @@
   "editor:clearBuffer": "command+k",
   "editor:emojis": "command+ctrl+space",
   "plugins:update": "command+shift+u",
-  "editor:show": "command+shift+h"
+  "editor:showKeymap": "command+shift+h"
 }

--- a/app/keymaps/darwin.json
+++ b/app/keymaps/darwin.json
@@ -47,5 +47,5 @@
   "editor:clearBuffer": "command+k",
   "editor:emojis": "command+ctrl+space",
   "plugins:update": "command+shift+u",
-  "editor:show": "command+p"
+  "editor:show": "command+shift+h"
 }

--- a/app/keymaps/linux.json
+++ b/app/keymaps/linux.json
@@ -46,5 +46,5 @@
   "editor:deleteEndLine": "ctrl+end",
   "editor:clearBuffer": "ctrl+shift+k",
   "plugins:update": "ctrl+shift+u",
-  "editor:show": "ctrl+p"
+  "editor:show": "ctrl+shift+h"
 }

--- a/app/keymaps/linux.json
+++ b/app/keymaps/linux.json
@@ -46,5 +46,5 @@
   "editor:deleteEndLine": "ctrl+end",
   "editor:clearBuffer": "ctrl+shift+k",
   "plugins:update": "ctrl+shift+u",
-  "editor:show": "ctrl+shift+h"
+  "editor:showKeymap": "ctrl+shift+h"
 }

--- a/app/keymaps/linux.json
+++ b/app/keymaps/linux.json
@@ -45,5 +45,6 @@
   "editor:deleteBeginningLine": "ctrl+home",
   "editor:deleteEndLine": "ctrl+end",
   "editor:clearBuffer": "ctrl+shift+k",
-  "plugins:update": "ctrl+shift+u"
+  "plugins:update": "ctrl+shift+u",
+  "editor:show": "ctrl+p"
 }

--- a/app/keymaps/win32.json
+++ b/app/keymaps/win32.json
@@ -49,5 +49,5 @@
   "editor:deleteEndLine": "ctrl+end",
   "editor:clearBuffer": "ctrl+shift+k",
   "plugins:update": "ctrl+shift+u",
-  "editor:show": "ctrl+shift+h"
+  "editor:showKeymap": "ctrl+shift+h"
 }

--- a/app/keymaps/win32.json
+++ b/app/keymaps/win32.json
@@ -48,5 +48,6 @@
   "editor:deleteBeginningLine": "ctrl+home",
   "editor:deleteEndLine": "ctrl+end",
   "editor:clearBuffer": "ctrl+shift+k",
-  "plugins:update": "ctrl+shift+u"
+  "plugins:update": "ctrl+shift+u",
+  "editor:show": "ctrl+p"
 }

--- a/app/keymaps/win32.json
+++ b/app/keymaps/win32.json
@@ -49,5 +49,5 @@
   "editor:deleteEndLine": "ctrl+end",
   "editor:clearBuffer": "ctrl+shift+k",
   "plugins:update": "ctrl+shift+u",
-  "editor:show": "ctrl+p"
+  "editor:show": "ctrl+shift+h"
 }


### PR DESCRIPTION
This commit allows hyper to show all keyboard shortcuts as currently configured. 
This is achieved by the command key _ctrl+shift+h_ or _command+shift+h_ in macOS.
Fixes:  [#814](https://github.com/zeit/hyper/issues/814)