### PR TITLE
Fix reading config file concurrency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,10 @@ install:
   - yarn
 
 after_success:
-  - if [[ "$TRAVIS_BRANCH" == "canary" ]]; then cp build/canary.icns build/icon.icns; fi
+  - (git branch --contains $TRAVIS_COMMIT | grep canary > /dev/null || [[ "$TRAVIS_BRANCH" == "canary" ]] ) && (cd build; cp canary.icns icon.icns; cp canary.ico icon.ico)
   - yarn run dist
 
 branches:
   except:
     - "/^v\\d+\\.\\d+\\.\\d+$/"
+

--- a/app/config.js
+++ b/app/config.js
@@ -8,6 +8,7 @@ const {cfgPath, cfgDir} = require('./config/paths');
 const watchers = [];
 let cfg = {};
 let _watcher;
+let _isWatching = false;
 
 const _watch = function() {
   if (_watcher) {
@@ -15,10 +16,14 @@ const _watch = function() {
   }
 
   const onChange = () => {
-    cfg = _import();
-    notify('Configuration updated', 'Hyper configuration reloaded!');
-    watchers.forEach(fn => fn());
-    checkDeprecatedConfig();
+    if (_isWatching == false) {
+      _isWatching = true;
+      cfg = _import();
+      notify('Configuration updated', 'Hyper configuration reloaded!');
+      watchers.forEach(fn => fn());
+      checkDeprecatedConfig();
+      _isWatching = false;
+    }
   };
 
   if (process.platform === 'win32') {

--- a/app/package.json
+++ b/app/package.json
@@ -2,7 +2,7 @@
   "name": "hyper",
   "productName": "Hyper",
   "description": "A terminal built on web technologies",
-  "version": "2.0.0-canary.7",
+  "version": "2.0.0-canary.8",
   "license": "MIT",
   "author": {
     "name": "Zeit, Inc.",

--- a/lib/components/style-sheet.js
+++ b/lib/components/style-sheet.js
@@ -99,7 +99,7 @@ export default class StyleSheet extends React.PureComponent {
             content: "";
             display: block;
             position: absolute;
-            background-color: #fff;
+            background-color: ${cursorColor};
           }
           .terminal.xterm-cursor-style-bar .terminal-cursor::before {
             top: 0;
@@ -119,7 +119,7 @@ export default class StyleSheet extends React.PureComponent {
           }
           .terminal.xterm-cursor-style-bar.focus.xterm-cursor-blink .terminal-cursor::before,
           .terminal.xterm-cursor-style-underline.focus.xterm-cursor-blink .terminal-cursor::before {
-            background-color: #fff;
+            background-color: ${cursorColor};
           }
 
           .terminal .composition-view {

--- a/lib/components/style-sheet.js
+++ b/lib/components/style-sheet.js
@@ -5,6 +5,7 @@ export default class StyleSheet extends React.PureComponent {
     const {
       customCSS,
       colors,
+      backgroundColor,
       cursorColor,
       fontSize,
       fontFamily,
@@ -75,7 +76,7 @@ export default class StyleSheet extends React.PureComponent {
 
           .terminal.focus:not(.xterm-cursor-style-underline):not(.xterm-cursor-style-bar) .terminal-cursor {
             background-color: ${cursorColor};
-            color: #000;
+            color: ${backgroundColor};
           }
 
           .terminal:not(.focus) .terminal-cursor {

--- a/lib/components/terms.js
+++ b/lib/components/terms.js
@@ -89,6 +89,7 @@ export default class Terms extends Component {
             terms: this.terms,
             activeSession: this.props.activeSession,
             sessions: this.props.sessions,
+            backgroundColor: this.props.backgroundColor,
             borderColor: this.props.borderColor,
             cursorShape: this.props.cursorShape,
             cursorBlink: this.props.cursorBlink,
@@ -119,6 +120,7 @@ export default class Terms extends Component {
         {this.props.customChildren}
         <StyleSheet
           colors={this.props.colors}
+          backgroundColor={this.props.backgroundColor}
           customCSS={this.props.customCSS}
           cursorColor={this.props.cursorColor}
           fontSize={this.props.fontSize}


### PR DESCRIPTION
This PR is supposed to correct the issue:
#2243

We discovered it was a concurrency problem and the plugins were giving this error not on the first installation but on the second or third because they were reading the 'not yet written' configuration by the last installed plugin.
It was added a flag to check if the configuration is being modified. If it is, it should bypass new changes until the configuration is completely read and the changes are absolutely done.

The Pull Request is able to be merged. 