### PR TITLE
Use public API to remove xterm listeners

### DIFF
--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -219,7 +219,7 @@ export default class Term extends PureComponent {
     // instead of invoking `destroy`, since it will make the
     // term insta un-attachable in the future (which we need
     // to do in case of splitting, see `componentDidMount`
-    this.term._events = {};
+    ['title', 'focus', 'data', 'resize'].forEach(type => this.term.removeAllListeners(type));
 
     window.removeEventListener('resize', this.onWindowResize, {
       passive: true


### PR DESCRIPTION
This uses the public API to do the same thing. Note that I didn't verify this but I think it should work.