### PR TITLE
Remove second Terminal.open arg

### DIFF
--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -47,9 +47,7 @@ export default class Term extends PureComponent {
         });
       this.term.attachCustomKeyEventHandler(this.keyboardHandler);
       this.term.on('open', this.onOpen);
-      this.term.open(this.termRef, {
-        focus: false
-      });
+      this.term.open(this.termRef);
     }
 
     if (props.onTitle) {


### PR DESCRIPTION
This was removed in xterm@3, see xtermjs/xterm.js#646