### PR TITLE
Fix Windows keymap delete typo

### DIFF
--- a/app/keymaps/win32.json
+++ b/app/keymaps/win32.json
@@ -44,7 +44,7 @@
   "editor:moveBeginningLine": "home",
   "editor:moveEndLine": "end",
   "editor:deletePreviousWord": "ctrl+backspace",
-  "editor:deleteNextWord": "cltr+del",
+  "editor:deleteNextWord": "ctrl+del",
   "editor:deleteBeginningLine": "ctrl+home",
   "editor:deleteEndLine": "ctrl+end",
   "editor:clearBuffer": "ctrl+shift+k",


### PR DESCRIPTION
Same as #2539, for Windows (pressing <kbd>Del</kbd> typed the letter d.)

Ref. #2538 

<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`

Thanks, again! -->

  