### PR TITLE
Use xterm.js's fit addon when calling fitResize

### DIFF
--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -1,11 +1,14 @@
 /* global Blob,URL,requestAnimationFrame */
 import React from 'react';
 import {Terminal} from 'xterm';
+import * as fit from 'xterm/lib/addons/fit/fit';
 import {clipboard} from 'electron';
 import * as Color from 'color';
 import {PureComponent} from '../base-components';
 import terms from '../terms';
 import processClipboard from '../utils/paste';
+
+Terminal.applyAddon(fit);
 
 // map old hterm constants to xterm.js
 const CURSOR_STYLES = {
@@ -195,10 +198,7 @@ export default class Term extends PureComponent {
     if (!this.termWrapperRef) {
       return;
     }
-    const termRect = this.termWrapperRef.getBoundingClientRect();
-    const cols = Math.floor(termRect.width / this.term.charMeasure.width);
-    const rows = Math.floor(termRect.height / this.term.charMeasure.height);
-    this.resize(cols, rows);
+    this.term.fit();
   }
 
   keyboardHandler(e) {
@@ -286,7 +286,7 @@ export default class Term extends PureComponent {
       >
         {this.props.customChildrenBefore}
         <div ref={this.onTermWrapperRef} className={css('fit', 'wrapper')}>
-          <div ref={this.onTermRef} className={css('term')} />
+          <div ref={this.onTermRef} className={css('fit', 'term')} />
         </div>
         {this.props.customChildren}
       </div>


### PR DESCRIPTION
xterm.js doesn't use `this.term.charMeasure.width` when rendering. It
actually uses:

```
Math.floor(this._terminal.charMeasure.width * window.devicePixelRatio)
```

This is important, because character widths may be non-integer values,
which means that we can end up with an empty space on the right side of
the terminal window.

Instead of trying to match xterm's behavior, it's probably better if we
just use xterm's `fit` addon. This seems to behave better for me.

We might not want to land this as-is, becuase this addon forces an
annoying hard-coded 17px margin on the right side to compensate for a
scrollbar (see xtermjs/xterm.js#400), but at least for my use-cases,
this is still better than it was.

Before:
![workspace 2_020](https://user-images.githubusercontent.com/180404/34863281-652fda50-f723-11e7-8db5-2a2b33462bda.png)

After:
![workspace 2_021](https://user-images.githubusercontent.com/180404/34863285-6b2becbe-f723-11e7-83a6-b3d59092c1ed.png)