### PR TITLE
Fix offscreen term size calculation

### DIFF
--- a/lib/components/terms.js
+++ b/lib/components/terms.js
@@ -151,17 +151,16 @@ export default class Terms extends Component {
       },
 
       termGroup: {
-        opacity: 0,
         display: 'block',
         width: '100%',
         height: '100%',
         position: 'absolute',
-        top: 0,
+        top: '100%', // Offscreen to pause xterm rendering, thanks to IntersectionObserver
         left: 0
       },
 
       termGroupActive: {
-        opacity: 1
+        top: 0
       }
     };
   }

--- a/lib/components/terms.js
+++ b/lib/components/terms.js
@@ -151,13 +151,17 @@ export default class Terms extends Component {
       },
 
       termGroup: {
-        display: 'none',
+        opacity: 0,
+        display: 'block',
         width: '100%',
-        height: '100%'
+        height: '100%',
+        position: 'absolute',
+        top: 0,
+        left: 0
       },
 
       termGroupActive: {
-        display: 'block'
+        opacity: 1
       }
     };
   }


### PR DESCRIPTION
`fit` xterm's addon, use parent size to calculate canvas sizes. But when term is offscreen (another tab), ancestor have a `display:none` and prevents xterm to calculate real size.

Using absolute positioning and offscreen positioning (if unfocused) rather than using `display:none` fixes this.

Thanks to IntersectionObserver, `xterm` pauses rendering when canvas are offscreen: https://github.com/xtermjs/xterm.js/pull/1144