### PR TITLE
Revert "Fix initial cursor blinking (#2614)"

### DIFF
--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -75,8 +75,6 @@ export default class Term extends PureComponent {
     this.term = props.term || new Terminal(this.termOptions);
     this.term.attachCustomKeyEventHandler(this.keyboardHandler);
     this.term.open(this.termRef);
-    //This is a workaround for https://github.com/xtermjs/xterm.js/issues/1194
-    this.term.setOption('cursorBlink', this.termOptions.cursorBlink);
     if (props.term) {
       //We need to set options again after reattaching an existing term
       Object.keys(this.termOptions).forEach(option => this.term.setOption(option, this.termOptions[option]));

--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
     "semver": "5.4.1",
     "shebang-loader": "false0.0.1",
     "uuid": "3.1.0",
-    "xterm": "chabou/xterm.js#hyper"
+    "xterm": "chabou/xterm.js#a7b9059"
   },
   "devDependencies": {
     "ava": "0.24.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6449,9 +6449,9 @@ xtend@~2.1.1:
   dependencies:
     object-keys "~0.4.0"
 
-xterm@chabou/xterm.js#hyper:
+xterm@chabou/xterm.js#a7b9059:
   version "3.0.0"
-  resolved "https://codeload.github.com/chabou/xterm.js/tar.gz/87b1d5276bb72298210021217165ab847a0886ec"
+  resolved "https://codeload.github.com/chabou/xterm.js/tar.gz/a7b9059050f8f77ca0d9469b77086617ad67e2fa"
 
 y18n@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
This PR use xterm v3.0.2 that has a fix for initial cursor blinking.
Our workaround is not necessarily anymore.
