### PR TITLE
Put offscreen terms far far away

### DIFF
--- a/lib/components/terms.js
+++ b/lib/components/terms.js
@@ -155,12 +155,12 @@ export default class Terms extends Component {
         width: '100%',
         height: '100%',
         position: 'absolute',
-        top: '100%', // Offscreen to pause xterm rendering, thanks to IntersectionObserver
-        left: 0
+        top: 0,
+        left: '-9999em' // Offscreen to pause xterm rendering, thanks to IntersectionObserver
       },
 
       termGroupActive: {
-        top: 0
+        left: 0
       }
     };
   }


### PR DESCRIPTION
`top: 100%` is not enough when using `hyper-statusline`:
![image](https://user-images.githubusercontent.com/4137761/35068944-f14be948-fbd8-11e7-8759-40ea9b5cde67.png)


