### PR TITLE
Mac: altIsMeta support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ language: node_js
 matrix:
   include:
     - os: linux
-      node_js: 7.9.0
+      node_js: 8.0.0
       env: CC=clang CXX=clang++ npm_config_clang=1
       compiler: clang
 

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -21,6 +21,7 @@ const getTermOptions = props => {
   // Set a background color only if it is opaque
   const backgroundColor = Color(props.backgroundColor).alpha() < 1 ? 'transparent' : props.backgroundColor;
   return {
+    macOptionIsMeta: props.modifierKeys.altIsMeta,
     cursorStyle: CURSOR_STYLES[props.cursorShape],
     cursorBlink: props.cursorBlink,
     fontFamily: props.fontFamily,

--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
     "semver": "5.4.1",
     "shebang-loader": "false0.0.1",
     "uuid": "3.1.0",
-    "xterm": "chabou/xterm.js#7b741fe"
+    "xterm": "chabou/xterm.js#95178dd"
   },
   "devDependencies": {
     "ava": "0.24.0",


### PR DESCRIPTION
* Reimplement altIsMeta supprt with new xterm library

_PR is ready to be merged _when_ underlying xterm.js is updated to this version: https://github.com/xtermjs/xterm.js/commit/616958e2c6c004133e4c5fe728702852bb1d2a5f. We just need to update the hyper xterm version in package.json._

Fixes: https://github.com/zeit/hyper/issues/2578

