### PR TITLE
Remove 32 bits column

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -72,7 +72,6 @@
         <table id="installation-table" class="offset-header">
           <tr>
             <td style="width: 33.333%" class="invisible-top-left"></td>
-            <td style="width: 33.333%">32-bit</td>
             <td style="width: 33.333%">64-bit</td>
           </tr>
           <tr>
@@ -83,28 +82,24 @@
           </tr>
           <tr>
             <td><b>Windows</b> (.exe)</td>
-            <td class="soon">COMING SOON</td>
             <td id="td-win">
               <a href="https://releases.hyper.is/download/win">DOWNLOAD <img src="static/download-icon.svg"/></a>
             </td>
           </tr>
           <tr>
             <td><b>Debian</b> (.deb)</td>
-            <td class="soon">COMING SOON</td>
             <td id="td-debian">
               <a href="https://releases.hyper.is/download/deb">DOWNLOAD <img src="static/download-icon.svg"/></a>
             </td>
           </tr>
           <tr>
             <td><b>Fedora</b> (.rpm)</td>
-            <td class="soon">COMING SOON</td>
             <td id="td-fedora">
               <a href="https://releases.hyper.is/download/rpm">DOWNLOAD <img src="static/download-icon.svg"/></a>
             </td>
           </tr>
           <tr>
             <td><b>Other Linux distros</b> (.AppImage)</td>
-            <td class="soon">COMING SOON</td>
             <td id="td-appimage" colspan="2">
               <a href="https://releases.hyper.is/download/AppImage">DOWNLOAD <img src="static/download-icon.svg"/></a>
             </td>

--- a/website/style.css
+++ b/website/style.css
@@ -502,15 +502,7 @@ body, html {
     margin-right: 0;
     margin-bottom: 20px;
   }
-
-  #content table td {
-    width: 50% !important;
-  }
-
-  #content table td:nth-child(3) {
-    display: none;
-  }
-
+  
   #content .table-note:after {
     margin: 15px 0;
     content: "Please note: the complete table information is available in bigger resolutions!";


### PR DESCRIPTION
As discussed in https://github.com/zeit/hyper/pull/2638, I'm removing the 32 bits column.

I also included the CSS fix in case you re-add it.

How it looks now:

![screenshot_24-01-2018_20-44-07](https://user-images.githubusercontent.com/11699655/35354027-37f1ecb0-0149-11e8-81c5-a4e01fc3e623.png)

![screenshot_24-01-2018_20-43-50](https://user-images.githubusercontent.com/11699655/35354131-78f4e730-0149-11e8-9fad-64cc14aecad4.png)
