### PR TITLE
on Linux default to "showHamburgerMenu": true

### DIFF
--- a/app/config/config-default.js
+++ b/app/config/config-default.js
@@ -51,9 +51,8 @@ module.exports = {
     // custom CSS to embed in the terminal window
     termCSS: '',
 
-    // set to `true` (without backticks and without quotes) if you're using a
-    // Linux setup that doesn't show native menus
-    // default: `false` on Linux, `true` on Windows, ignored on macOS
+    // if you're using a Linux setup which show native menus, set to false
+    // default: `true` on Linux, `true` on Windows, ignored on macOS
     showHamburgerMenu: '',
 
     // set to `false` (without backticks and without quotes) if you want to hide the minimize, maximize and close buttons

--- a/lib/components/header.js
+++ b/lib/components/header.js
@@ -72,7 +72,7 @@ export default class Header extends PureComponent {
     const {showHamburgerMenu, showWindowControls} = this.props;
 
     const defaults = {
-      hambMenu: process.platform === 'win32', // show by default on windows
+      hambMenu: !this.props.isMac, // show by default on windows and linux
       winCtrls: !this.props.isMac // show by default on Windows and Linux
     };
 


### PR DESCRIPTION
I believe this is ready to merge, but I didn't go through and run from source to check. This is partly to open a discussion and get a better understanding of why this default was selected. Another possible resolution to the underlying issue is figuring out how to get the title menu bar to work consistently on Linux.

If a minimal flow is felt to be super important, then I recommend an in-app onboarding wizard to help users understand how to access their menu bar. But until that's built, a menu should be visible by default.

From the code comment `// show by default on Windows and Linux`, it appears that the author expected the window menu to appear on Linux, but this isn't actually happening. Therefore I think it would be better to default to showing the hamburger menu and letting experienced users configure it away.

When I loaded up hyper on Linux, I couldn't access the menu at all. I saw this - and I didn't have an overall menu bar like macOS on Ubuntu 17.10 running KDE Plasma thru Virtualbox:
![image](https://user-images.githubusercontent.com/5614134/36058566-94a371cc-0dd8-11e8-99db-1eacd229f86b.png)

Issues from this that I found quickly:
* https://github.com/zeit/hyper/issues/1266 (most commonly-cited)
* https://github.com/zeit/hyper/issues/1118
* https://github.com/zeit/hyper/issues/1168
* https://github.com/zeit/hyper/issues/1373
* https://github.com/zeit/hyper/issues/1234
* https://github.com/zeit/hyper/issues/1195

[Blame](https://github.com/jcrben/hyper/blame/887fb5ac1a56d50d2f7ab694b8b1e92a2cebc101/lib/components/header.js#L75) points to https://github.com/zeit/hyper/pull/946 which does not discuss this issue.

There is a mention of the frameless thing which I haven't messed around with (https://github.com/zeit/hyper/issues/795 - maybe that could help with https://github.com/zeit/hyper/issues/1683 and showing the title menu bar).