### PR TITLE
Bump xterm.js@3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
     "semver": "5.4.1",
     "shebang-loader": "0.0.1",
     "uuid": "3.1.0",
-    "xterm": "chabou/xterm.js#95178dd"
+    "xterm": "3.1.0"
   },
   "devDependencies": {
     "ava": "0.24.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6589,9 +6589,9 @@ xtend@~2.1.1:
   dependencies:
     object-keys "~0.4.0"
 
-xterm@chabou/xterm.js#95178dd:
-  version "3.0.0-hyper.1"
-  resolved "https://codeload.github.com/chabou/xterm.js/tar.gz/95178dddcb7c9e88b3a9444188789696b41788d1"
+xterm@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/xterm/-/xterm-3.1.0.tgz#7f7e1c8cf4b80bd881a4e8891213b851423e90c9"
 
 y18n@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
This updates [`xterm.js` to version 3.1.0](https://github.com/xtermjs/xterm.js/releases/tag/3.1.0) which includes https://github.com/xtermjs/xterm.js/pull/1236 from @chabou.

This release also supports Alt+click to move cursor:
![alt-click](https://user-images.githubusercontent.com/13285808/36067209-32516cb8-0eb9-11e8-8663-a38a8b5c0b41.gif)
Fixes #316
