### PR TITLE
Subpixel with opaque background color

### DIFF
--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -19,7 +19,8 @@ const CURSOR_STYLES = {
 
 const getTermOptions = props => {
   // Set a background color only if it is opaque
-  const backgroundColor = Color(props.backgroundColor).alpha() < 1 ? 'transparent' : props.backgroundColor;
+  const needTransparency = Color(props.backgroundColor).alpha() < 1;
+  const backgroundColor = needTransparency ? 'transparent' : props.backgroundColor;
   return {
     macOptionIsMeta: props.modifierKeys.altIsMeta,
     cursorStyle: CURSOR_STYLES[props.cursorShape],
@@ -28,7 +29,7 @@ const getTermOptions = props => {
     fontSize: props.fontSize,
     fontWeight: props.fontWeight,
     fontWeightBold: props.fontWeightBold,
-    allowTransparency: true,
+    allowTransparency: needTransparency,
     theme: {
       foreground: props.foregroundColor,
       background: backgroundColor,


### PR DESCRIPTION
Check if background color is non-opaque to set xterm `allowTransparency` option or not.
Without `allowTransparency`, xterm can use sub-pixel calculation because it knows final background color.
