### PR TITLE
Add support for platform-specific shell config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,6 +8,15 @@
       "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron",
       "program": "${workspaceRoot}/app/index.js",
       "protocol": "inspector"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Run AVA test",
+      "program": "${workspaceRoot}/node_modules/ava/profile.js",
+      "args": [
+        "${file}"
+      ]
     }
   ]
 }

--- a/app/config/config-default.js
+++ b/app/config/config-default.js
@@ -98,13 +98,17 @@ module.exports = {
     //
     // PowerShell on Windows
     // - Example: `C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`
+    //
+    // supports platform specific configuration: shell.windows|linux|osx: ''
     shell: '',
 
     // for setting shell arguments (i.e. for using interactive shellArgs: `['-i']`)
     // by default `['--login']` will be used
+    // supports platform specific configuration: shellArgs.windows|linux|osx: []
     shellArgs: ['--login'],
 
     // for environment variables
+    // supports platform specific configuration: env.windows|linux|osx:{}
     env: {},
 
     // set to `false` for no bell

--- a/app/config/init.js
+++ b/app/config/init.js
@@ -1,6 +1,7 @@
 const vm = require('vm');
 const notify = require('../notify');
 const mapKeys = require('../utils/map-keys');
+const platformSpecific = require('./platform-specific');
 
 const _extract = function(script) {
   const module = {};
@@ -39,6 +40,10 @@ const _init = function(cfg) {
     // Ignore undefined values in plugin and localPlugins array Issue #1862
     _cfg.plugins = (_cfg.plugins && _cfg.plugins.filter(Boolean)) || [];
     _cfg.localPlugins = (_cfg.localPlugins && _cfg.localPlugins.filter(Boolean)) || [];
+
+    // Extract platform specific config values
+    _cfg.config = platformSpecific(_cfg.config);
+
     return _cfg;
   }
   return cfg.defaultCfg;

--- a/app/config/platform-specific.js
+++ b/app/config/platform-specific.js
@@ -1,0 +1,32 @@
+const platformSpecificConfigs = ['shell', 'shellArgs', 'env'];
+
+const getPlatformKey = () => {
+  switch (process.platform) {
+    case 'darwin':
+      return 'osx';
+    case 'win32':
+      return 'windows';
+    default:
+      return 'linux';
+  }
+};
+
+const getValueForPlatform = (platform, cfg, key) => {
+  const value = cfg[key];
+
+  if (value && typeof value === 'object' && value[platform]) {
+    return value[platform];
+  }
+
+  return value;
+};
+
+module.exports = cfg => {
+  const platform = getPlatformKey();
+
+  for (const config of platformSpecificConfigs) {
+    cfg[config] = getValueForPlatform(platform, cfg, config);
+  }
+
+  return cfg;
+};

--- a/test/unit/config-platform-specific.test.js
+++ b/test/unit/config-platform-specific.test.js
@@ -1,0 +1,41 @@
+import test from 'ava';
+import platformSpecific from '../../app/config/platform-specific';
+
+const defaultCfg = {
+  shell: 'custom-shell',
+  env: {
+    custom: 'env'
+  },
+  shellArgs: ['custom-shell-arg']
+};
+
+const getPlatformConfig = platform => {
+  return {
+    shell: {
+      [platform]: defaultCfg.shell
+    },
+    env: {
+      [platform]: defaultCfg.env
+    },
+    shellArgs: {
+      [platform]: defaultCfg.shellArgs
+    }
+  };
+};
+
+test(`supports platform agnostic config`, t => {
+  const value = platformSpecific(defaultCfg);
+  t.deepEqual(value, defaultCfg);
+});
+
+let platform = 'linux';
+if (process.platform === 'win32') {
+  platform = 'windows';
+} else if (process.platform === 'darwin') {
+  platform = 'osx';
+}
+
+test(`supports ${platform} platform config`, t => {
+  const value = platformSpecific(getPlatformConfig(platform));
+  t.deepEqual(value, defaultCfg);
+});

--- a/website/index.html
+++ b/website/index.html
@@ -268,7 +268,7 @@
               <td>A list of overrides for the color palette. The names of the keys represent the "ANSI 16", which can all be seen <a href="https://github.com/zeit/hyper/blob/aaed99abac97a3d6b1766f194522a69e8a994bcb/lib/utils/colors.js">in the default config</a>.</td>
             </tr>
             <tr>
-              <td>"shell"</td>
+              <td>"shell" <sup>1</sup></td>
               <td>""</td>
               <td>A path to a custom shell to run when Hyper starts a new session</td>
             </tr>
@@ -330,7 +330,10 @@
             </tr>
           </tbody>
         </table>
-        <span class="table-note"></span>
+
+        <span class="table-note">
+          <sup>1</sup> Supports platform specific configuration for windows, linux and osx: <code>shell.windows = 'powershell.exe'</code>. Options inc
+        </span>
 
         <h2 id="extensions-api"><a href="#extensions-api">Extensions API</a></h2>
 


### PR DESCRIPTION
This PR introduces platform-specific config support for `windows`, `osx` and `linux` as discussed in #2584. This has been implemented by transforming / extracting platform specific values at cfg load time if available and promoting them to the root cfg properties. This adds support without the need to modify up-stream consumers of the configuration.

This functionality _could_ be expanded to all config options, but is currently limited to just those options that would need to differ by platform. 

**TODO:**
- [x] Document new functionality (website or config-default.js?)
---
Closes #2584 