### PR TITLE
CMD + R breaks Hyper #2674

### DIFF
--- a/app/commands.js
+++ b/app/commands.js
@@ -36,7 +36,7 @@ const commands = {
     updatePlugins();
   },
   'window:reload': focusedWindow => {
-    focusedWindow && focusedWindow.rpc.emit('reload');
+    focusedWindow && focusedWindow.rpc.emit('session clear req');
   },
   'window:reloadFull': focusedWindow => {
     focusedWindow && focusedWindow.reload();


### PR DESCRIPTION
<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`

Thanks, again! -->

As mentioned in this issue https://github.com/zeit/hyper/issues/2674 the current Reload functionality is broken .
I'm not really sure what the difference should be between Reload ( cmd+R ) and Clear buffer ( cmd+K ) if there is one . Tested it on Terminal.app and iTerm2 and they seem to do the same thing .

