### PR TITLE
CLI: better existence check

### DIFF
--- a/cli/api.js
+++ b/cli/api.js
@@ -64,18 +64,11 @@ function save() {
 
 function existsOnNpm(plugin) {
   const name = plugin.split('#')[0].split('@')[0];
-  return got
-    .get(registryUrl + name.toLowerCase(), {timeout: 10000, json: true})
-    .then(res => {
-      if (!res.body.versions) {
-        throw new Error();
-      }
-    })
-    .catch(() => {
-      const err = new Error(`${plugin} not found on npm`);
-      err.code = 'NOT_FOUND_ON_NPM';
-      throw err;
-    });
+  return got.get(registryUrl + name.toLowerCase(), {timeout: 10000, json: true}).then(res => {
+    if (!res.body.versions) {
+      return Promise.reject(res);
+    }
+  });
 }
 
 function install(plugin, locally) {
@@ -93,11 +86,11 @@ function install(plugin, locally) {
           .catch(err => reject(err));
       })
       .catch(err => {
-        if (err.code === 'NOT_FOUND_ON_NPM') {
-          reject(err.message);
-        } else {
-          reject(err);
+        const {statusCode} = err;
+        if (statusCode && (statusCode === 404 || statusCode === 200)) {
+          return reject(`${plugin} not found on npm`);
         }
+        return reject(`Plugin check failed. Check your internet connection or retry later.`);
       });
   });
 }

--- a/cli/api.js
+++ b/cli/api.js
@@ -90,7 +90,7 @@ function install(plugin, locally) {
         if (statusCode && (statusCode === 404 || statusCode === 200)) {
           return reject(`${plugin} not found on npm`);
         }
-        return reject(`Plugin check failed. Check your internet connection or retry later.`);
+        return reject(`${err.message}\nPlugin check failed. Check your internet connection or retry later.`);
       });
   });
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
   "repository": "zeit/hyper",
   "scripts": {
-    "start":
-      "echo 'please run `yarn run dev` in one tab and then `yarn run app` in another one'",
+    "start": "echo 'please run `yarn run dev` in one tab and then `yarn run app` in another one'",
     "app": "electron app",
     "dev": "webpack -w",
     "build": "cross-env NODE_ENV=production webpack",
@@ -11,18 +10,21 @@
     "test:unit": "ava test/unit",
     "test:unit:watch": "yarn run test:unit -- --watch",
     "prepush": "yarn test",
-    "postinstall":
-      "electron-builder install-app-deps && yarn run rebuild-node-pty && yarn --cwd node_modules/xterm",
-    "rebuild-node-pty":
-      "electron-rebuild -f -w app/node_modules/node-pty -m app",
-    "dist":
-      "yarn run build && cross-env BABEL_ENV=production babel --out-file app/renderer/bundle.js --no-comments --minified app/renderer/bundle.js && build",
-    "clean":
-      "node ./bin/rimraf-standalone.js node_modules && node ./bin/rimraf-standalone.js ./app/node_modules && node ./bin/rimraf-standalone.js ./app/renderer"
+    "postinstall": "electron-builder install-app-deps && yarn run rebuild-node-pty && yarn --cwd node_modules/xterm",
+    "rebuild-node-pty": "electron-rebuild -f -w app/node_modules/node-pty -m app",
+    "dist": "yarn run build && cross-env BABEL_ENV=production babel --out-file app/renderer/bundle.js --no-comments --minified app/renderer/bundle.js && build",
+    "clean": "node ./bin/rimraf-standalone.js node_modules && node ./bin/rimraf-standalone.js ./app/node_modules && node ./bin/rimraf-standalone.js ./app/renderer"
   },
   "eslintConfig": {
-    "plugins": ["react", "prettier"],
-    "extends": ["eslint:recommended", "plugin:react/recommended", "prettier"],
+    "plugins": [
+      "react",
+      "prettier"
+    ],
+    "extends": [
+      "eslint:recommended",
+      "plugin:react/recommended",
+      "prettier"
+    ],
     "parserOptions": {
       "ecmaVersion": 8,
       "sourceType": "module",
@@ -39,7 +41,10 @@
       "node": true
     },
     "rules": {
-      "func-names": ["error", "as-needed"],
+      "func-names": [
+        "error",
+        "as-needed"
+      ],
       "no-shadow": "error",
       "no-extra-semi": 0,
       "react/prop-types": 0,
@@ -85,7 +90,9 @@
     ]
   },
   "babel": {
-    "presets": ["react"],
+    "presets": [
+      "react"
+    ],
     "env": {
       "production": {
         "plugins": [
@@ -122,7 +129,9 @@
       {
         "from": "./build/${os}/",
         "to": "./bin/",
-        "filter": ["hyper*"]
+        "filter": [
+          "hyper*"
+        ]
       }
     ],
     "linux": {
@@ -130,20 +139,28 @@
       "target": [
         {
           "target": "deb",
-          "arch": ["x64"]
+          "arch": [
+            "x64"
+          ]
         },
         {
           "target": "AppImage",
-          "arch": ["x64"]
+          "arch": [
+            "x64"
+          ]
         },
         {
           "target": "rpm",
-          "arch": ["x64"]
+          "arch": [
+            "x64"
+          ]
         }
       ]
     },
     "win": {
-      "target": ["squirrel"]
+      "target": [
+        "squirrel"
+      ]
     },
     "mac": {
       "category": "public.app-category.developer-tools",
@@ -157,7 +174,9 @@
     },
     "protocols": {
       "name": "ssh URL",
-      "schemes": ["ssh"]
+      "schemes": [
+        "ssh"
+      ]
     }
   },
   "license": "MIT",
@@ -176,7 +195,6 @@
     "json-loader": "0.5.7",
     "mousetrap": "chabou/mousetrap#useCapture",
     "ms": "2.1.1",
-    "npm-name": "3.1.0",
     "opn": "5.1.0",
     "ora": "1.3.0",
     "parse-url": "3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3080,7 +3080,7 @@ globule@^1.0.0:
     lodash "~4.17.4"
     minimatch "~3.0.2"
 
-got@7.1.0, got@^7.0.0:
+got@7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/got/-/got-7.1.0.tgz#05450fd84094e6bbea56f451a43a9c289166385a"
   dependencies:
@@ -4018,10 +4018,6 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash.zip@^4.0.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.zip/-/lodash.zip-4.2.0.tgz#ec6662e4896408ed4ab6c542a3990b72cc080020"
-
 lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.8.0, lodash@~4.17.4:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
@@ -4412,14 +4408,6 @@ normalize-url@^1.4.0, normalize-url@^1.9.1:
 npm-install-package@~2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/npm-install-package/-/npm-install-package-2.1.0.tgz#d7efe3cfcd7ab00614b896ea53119dc9ab259125"
-
-npm-name@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/npm-name/-/npm-name-3.1.0.tgz#79789afac52ae335dc3a5aa7f41f59d1b77c756f"
-  dependencies:
-    got "^7.0.0"
-    lodash.zip "^4.0.0"
-    registry-url "^3.0.0"
 
 npm-run-path@^2.0.0:
   version "2.0.2"
@@ -5463,7 +5451,7 @@ registry-auth-token@^3.0.1:
     rc "^1.1.6"
     safe-buffer "^5.0.1"
 
-registry-url@^3.0.0, registry-url@^3.0.3:
+registry-url@^3.0.3:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/registry-url/-/registry-url-3.1.0.tgz#3d4ef870f73dde1d77f0cf9a381432444e174942"
   dependencies:


### PR DESCRIPTION
NPM registry is broken for some (unpublished?) package:
https://registry.npmjs.org/hyper-cwd
https://api.npms.io/v2/package/hyper-cwd (error 500)

Checking headers on npm is not enough.

Now, `versions` key existence is checked in content
