### PR TITLE
Added menu item to to change update channel

### DIFF
--- a/app/commands.js
+++ b/app/commands.js
@@ -1,5 +1,5 @@
 const {app} = require('electron');
-const {openConfig} = require('./config');
+const {openConfig, toggleUpdateChannel} = require('./config');
 const {updatePlugins} = require('./plugins');
 
 const commands = {
@@ -25,6 +25,9 @@ const commands = {
   },
   'window:preferences': () => {
     openConfig();
+  },
+  'prefs:toggleUpdateChannel': () => {
+    toggleUpdateChannel();
   },
   'editor:clearBuffer': focusedWindow => {
     focusedWindow && focusedWindow.rpc.emit('session clear req');

--- a/app/config.js
+++ b/app/config.js
@@ -4,6 +4,7 @@ const {_import, getDefaultConfig} = require('./config/import');
 const _openConfig = require('./config/open');
 const win = require('./config/windows');
 const {cfgPath, cfgDir} = require('./config/paths');
+const {toggleUpdateChannel} = require('./config/edit');
 
 const watchers = [];
 let cfg = {};
@@ -63,6 +64,10 @@ exports.getConfig = () => {
 
 exports.openConfig = () => {
   return _openConfig();
+};
+
+exports.toggleUpdateChannel = () => {
+  return toggleUpdateChannel();
 };
 
 exports.getPlugins = () => {

--- a/app/config/edit.js
+++ b/app/config/edit.js
@@ -3,27 +3,27 @@ const fs = require('fs');
 const recast = require('recast');
 
 function toggleUpdateChannel() {
-  // Get the config file using recast
-  const configFile = recast.parse(getFileContents(cfgPath));
+  let updateChannel = '';
+  let configFile = '';
 
   // Search the config file for the property with the name 'updateChannel'
   try {
     // Get the config file using recast
-    const configFile = recast.parse(getFileContents(cfgPath));
+    configFile = recast.parse(getFileContents(cfgPath));
 
     // Search the config file for the property with the name 'updateChannel'
-    const updateChannel = configFile.program.body[0].expression.right.properties
+    updateChannel = configFile.program.body[0].expression.right.properties
       .find(property => property.key.name === 'config')
       .value.properties.find(property => property.key.name === 'updateChannel').value.value;
   } catch (err) {
-      return;
+    return;
   }
 
   // select the new value for update channel
   updateChannel = updateChannel === 'canary' ? 'stable' : 'canary';
   configFile.program.body[0].expression.right.properties
-    .find(property => property.key.name === 'config').value.properties
-    .find(property => property.key.name === 'updateChannel').value.value = updateChannel;
+    .find(property => property.key.name === 'config')
+    .value.properties.find(property => property.key.name === 'updateChannel').value.value = updateChannel;
 
   // write to the config file
   const output = recast.print(configFile).code;

--- a/app/config/edit.js
+++ b/app/config/edit.js
@@ -1,0 +1,46 @@
+const {cfgPath} = require('./paths');
+const fs = require('fs');
+const recast = require('recast');
+
+function toggleUpdateChannel() {
+  // Get the config file using recast
+  const configFile = recast.parse(getFileContents(cfgPath));
+
+  // Search the config file for the property with the name 'updateChannel'
+  try {
+    // Get the config file using recast
+    const configFile = recast.parse(getFileContents(cfgPath));
+
+    // Search the config file for the property with the name 'updateChannel'
+    const updateChannel = configFile.program.body[0].expression.right.properties
+      .find(property => property.key.name === 'config')
+      .value.properties.find(property => property.key.name === 'updateChannel').value.value;
+  } catch (err) {
+      return;
+  }
+
+  // select the new value for update channel
+  updateChannel = updateChannel === 'canary' ? 'stable' : 'canary';
+  configFile.program.body[0].expression.right.properties
+    .find(property => property.key.name === 'config').value.properties
+    .find(property => property.key.name === 'updateChannel').value.value = updateChannel;
+
+  // write to the config file
+  const output = recast.print(configFile).code;
+  fs.writeFileSync(cfgPath, output, 'utf8');
+}
+
+function getFileContents(fileName) {
+  try {
+    return fs.readFileSync(fileName, 'utf8');
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      throw err;
+    }
+  }
+  return null;
+}
+
+module.exports = {
+  toggleUpdateChannel
+};

--- a/app/config/edit.js
+++ b/app/config/edit.js
@@ -16,6 +16,8 @@ function toggleUpdateChannel() {
       .find(property => property.key.name === 'config')
       .value.properties.find(property => property.key.name === 'updateChannel').value.value;
   } catch (err) {
+    //eslint-disable-next-line no-console
+    console.error("Can't read the config file: ", err);
     return;
   }
 
@@ -27,7 +29,14 @@ function toggleUpdateChannel() {
 
   // write to the config file
   const output = recast.print(configFile).code;
-  fs.writeFileSync(cfgPath, output, 'utf8');
+
+  try {
+    fs.writeFileSync(cfgPath, output, 'utf8');
+  } catch (err) {
+    //eslint-disable-next-line no-console
+    console.error("Can't write to the config file: ", err);
+    return;
+  }
 }
 
 function getFileContents(fileName) {

--- a/app/menus/menu.js
+++ b/app/menus/menu.js
@@ -50,7 +50,7 @@ exports.createMenu = (createWindow, getLoadedPluginVersions) => {
   const menu = [
     ...(process.platform === 'darwin' ? [darwinMenu(commandKeys, execCommand, showAbout)] : []),
     shellMenu(commandKeys, execCommand),
-    editMenu(commandKeys, execCommand),
+    editMenu(commandKeys, execCommand, updateChannel),
     viewMenu(commandKeys, execCommand),
     pluginsMenu(commandKeys, execCommand),
     windowMenu(commandKeys, execCommand),

--- a/app/menus/menus/edit.js
+++ b/app/menus/menus/edit.js
@@ -1,4 +1,4 @@
-module.exports = (commandKeys, execCommand) => {
+module.exports = (commandKeys, execCommand, updateChannel) => {
   const submenu = [
     {
       label: 'Undo',
@@ -118,6 +118,14 @@ module.exports = (commandKeys, execCommand) => {
   if (process.platform !== 'darwin') {
     submenu.push(
       {type: 'separator'},
+      {
+        label: 'Use Canary Version',
+        type: 'checkbox',
+        checked: updateChannel === 'canary',
+        click() {
+          execCommand('prefs:toggleUpdateChannel');
+        }
+      },
       {
         label: 'Preferences...',
         accelerator: commandKeys['window:preferences'],


### PR DESCRIPTION
I added a checkbox to the edit menu that will switch the updateChannel between 'canary' and 'stable'. To do this, I used recast to parse and edit the config file.

Fixes #2708
