### PR TITLE
Allow process to be used inside config

### DIFF
--- a/app/config/init.js
+++ b/app/config/init.js
@@ -4,7 +4,7 @@ const mapKeys = require('../utils/map-keys');
 
 const _extract = function(script) {
   const module = {};
-  script.runInNewContext({module});
+  script.runInNewContext({module, process});
   if (!module.exports) {
     throw new Error('Error reading configuration: `module.exports` not set');
   }


### PR DESCRIPTION
As discussed in https://github.com/zeit/hyper/pull/2684 it should be possible to use process.platform and process.env inside your config file so you can do stuff like:

```js
module.exports = {
  config: {
    env: process.platform === 'darwin' ? { THIS_IS_MAC_ONLY: 'test' } : {}
  }
}
```
```js
module.exports = {
  config: {
    shell: { win32: 'powershell.exe', darwin: 'fish', linux: 'bash' }[process.platform]
  }
}
```

```js
module.exports = {
  config: {
    env: { win32: {}, darwin: {}, linux: {} }[process.platform]
  }
}
```
