### PR TITLE
Fix config reload after vim edit

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -41,13 +41,19 @@ const _watch = function() {
   // macOS/Linux
   setWatcher();
   function setWatcher() {
-    _watcher = fs.watch(cfgPath, eventType => {
-      if (eventType === 'rename') {
-        _watcher.close();
-        // Ensure that new file has been written
-        setTimeout(() => setWatcher(), 500);
-      }
-    });
+    try {
+      _watcher = fs.watch(cfgPath, eventType => {
+        if (eventType === 'rename') {
+          _watcher.close();
+          // Ensure that new file has been written
+          setTimeout(() => setWatcher(), 500);
+        }
+      });
+    } catch (e) {
+      //eslint-disable-next-line no-console
+      console.error('Failed to watch config file:', cfgPath, e);
+      return;
+    }
     _watcher.on('change', onChange);
     _watcher.on('error', error => {
       //eslint-disable-next-line no-console

--- a/app/config.js
+++ b/app/config.js
@@ -24,6 +24,7 @@ const _watch = function() {
     }, 100);
   };
 
+  // Windows
   if (process.platform === 'win32') {
     // watch for changes on config every 2s on Windows
     // https://github.com/zeit/hyper/pull/1772
@@ -35,8 +36,18 @@ const _watch = function() {
         onChange();
       }
     });
-  } else {
-    _watcher = fs.watch(cfgPath);
+    return;
+  }
+  // macOS/Linux
+  setWatcher();
+  function setWatcher() {
+    _watcher = fs.watch(cfgPath, eventType => {
+      if (eventType === 'rename') {
+        _watcher.close();
+        // Ensure that new file has been written
+        setTimeout(() => setWatcher(), 500);
+      }
+    });
     _watcher.on('change', onChange);
     _watcher.on('error', error => {
       //eslint-disable-next-line no-console


### PR DESCRIPTION
When `vim` edit a file, it write a temp file and move it.
In this case, our watcher didn't work anymore.

This PR rewatch file when file is renamed/mv
