### PR TITLE
Disable VSCode type checking

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "checkJs": true,
     "jsx": "react",
     "target": "es6"
   },


### PR DESCRIPTION
Type checking was introduced here: #2272

But there are some confusing errors.
If someone wants to re-enable this, please fix errors too