### PR TITLE
Fix Terminal colors hot reloading

### DIFF
--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -240,9 +240,9 @@ export default class Term extends React.PureComponent {
     // Do we need to update theme?
     const shouldUpdateTheme =
       !this.termOptions.theme ||
-      Object.keys(nextTermOptions.theme).some(option => {
-        nextTermOptions.theme[option] !== this.termOptions.theme[option];
-      });
+      Object.keys(nextTermOptions.theme).some(
+        option => nextTermOptions.theme[option] !== this.termOptions.theme[option]
+      );
     if (shouldUpdateTheme) {
       this.term.setOption('theme', nextTermOptions.theme);
     }


### PR DESCRIPTION
Before this PR, Terminal theme colors (background, foreground, selection, ANSI, cursor etc...) were never hot reloaded.