### PR TITLE
Prevent build job when releasing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ workflows:
                 - master
                 - canary
             tags:
-              only: /.*/
+              ignore: /.*/
       - release:
           requires:
             - test


### PR DESCRIPTION
Running `build` job on tags because `release` job will do the same
