### PR TITLE
Disable Chromium GPU blacklist

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -85,6 +85,10 @@ app.getLastFocusedWindow = () => {
   });
 };
 
+//eslint-disable-next-line no-console
+console.log('Disabling Chromium GPU blacklist');
+app.commandLine.appendSwitch('ignore-gpu-blacklist');
+
 if (isDev) {
   //eslint-disable-next-line no-console
   console.log('running in dev mode');


### PR DESCRIPTION
Fixes #2838 

Context: https://github.com/zeit/hyper/issues/2838#issuecomment-382453354
Fix confirmed here: https://github.com/zeit/hyper/issues/2838#issuecomment-383240324

It maybe needs some more testing, especially it should not prevent using `--disable-gpu` Chromium flag
