### PR TITLE
Use electron's getPath() API to get the user's app data directory

### DIFF
--- a/app/config/paths.js
+++ b/app/config/paths.js
@@ -1,12 +1,12 @@
 // This module exports paths, names, and other metadata that is referenced
-const {homedir} = require('os');
+const {app} = require('electron');
 const {statSync} = require('fs');
 const {resolve, join} = require('path');
 const isDev = require('electron-is-dev');
 
 const cfgFile = '.hyper.js';
 const defaultCfgFile = 'config-default.js';
-const homeDir = homedir();
+const homeDir = app.getPath('userData');
 
 let cfgPath = join(homeDir, cfgFile);
 let cfgDir = homeDir;


### PR DESCRIPTION
Docs: https://github.com/electron/electron/blob/master/docs/api/app.md#appgetpathname
Closes: https://github.com/zeit/hyper/pull/1960
Fixes: https://github.com/zeit/hyper/issues/1944

A comment at https://github.com/zeit/hyper/pull/170/files#r83043056 suggests 

```
(process.env.XDG_CONFIG_HOME !== undefined)
    ? join(process.env.XDG_CONFIG_HOME, 'hyper')
    : app.getPath('userData')
```

but I have no clue how relevant that still is. Detailed discussion at https://github.com/zeit/hyper/pull/1595