### PR TITLE
Adding ability to send error object to notify()

### DIFF
--- a/app/config/init.js
+++ b/app/config/init.js
@@ -15,9 +15,7 @@ const _syntaxValidation = function(cfg) {
   try {
     return new vm.Script(cfg, {filename: '.hyper.js', displayErrors: true});
   } catch (err) {
-    notify('Error loading config:', `${err.name}, see DevTools for more info`);
-    //eslint-disable-next-line no-console
-    console.error('Error loading config:', err);
+    notify('Error loading config:', `${err.name}, see DevTools for more info`, err);
   }
 };
 

--- a/app/config/init.js
+++ b/app/config/init.js
@@ -15,7 +15,7 @@ const _syntaxValidation = function(cfg) {
   try {
     return new vm.Script(cfg, {filename: '.hyper.js', displayErrors: true});
   } catch (err) {
-    notify('Error loading config:', `${err.name}, see DevTools for more info`, err);
+    notify('Error loading config:', `${err.name}, see DevTools for more info`, {error: err});
   }
 };
 

--- a/app/notify.js
+++ b/app/notify.js
@@ -27,9 +27,13 @@ app.on('ready', () => {
   });
 });
 
-function notify(title, body) {
+function notify(title, body, error) {
   //eslint-disable-next-line no-console
   console.log(`[Notification] ${title}: ${body}`);
+  if (error) {
+    //eslint-disable-next-line no-console
+    console.error(error);
+  }
   if (win) {
     win.webContents.send('notification', {title, body});
   } else {

--- a/app/notify.js
+++ b/app/notify.js
@@ -27,12 +27,12 @@ app.on('ready', () => {
   });
 });
 
-function notify(title, body, error) {
+function notify(title, body, details = {}) {
   //eslint-disable-next-line no-console
   console.log(`[Notification] ${title}: ${body}`);
-  if (error) {
+  if (details.error) {
     //eslint-disable-next-line no-console
-    console.error(error);
+    console.error(details.error);
   }
   if (win) {
     win.webContents.send('notification', {title, body});

--- a/app/plugins.js
+++ b/app/plugins.js
@@ -66,7 +66,7 @@ function updatePlugins({force = false} = {}) {
 
     if (err) {
       //eslint-disable-next-line no-console
-      notify('Error updating plugins.', err, err);
+      notify('Error updating plugins.', err, {error: err});
     } else {
       // flag successful plugin update
       cache.set('hyper.plugins', id_);
@@ -257,7 +257,7 @@ function requirePlugins() {
         //eslint-disable-next-line no-console
         console.warn(`Plugin "${basename(path_)}" not found: ${path_}`);
       } else {
-        notify('Plugin error!', `Plugin "${basename(path_)}" failed to load (${err.message})`, err);
+        notify('Plugin error!', `Plugin "${basename(path_)}" failed to load (${err.message})`, {error: err});
       }
     }
   };
@@ -274,7 +274,9 @@ exports.onApp = app_ => {
       try {
         plugin.onApp(app_);
       } catch (e) {
-        notify('Plugin error!', `"${plugin._name}" has encountered an error. Check Developer Tools for details.`, e);
+        notify('Plugin error!', `"${plugin._name}" has encountered an error. Check Developer Tools for details.`, {
+          error: e
+        });
       }
     }
   });
@@ -286,7 +288,9 @@ exports.onWindow = win => {
       try {
         plugin.onWindow(win);
       } catch (e) {
-        notify('Plugin error!', `"${plugin._name}" has encountered an error. Check Developer Tools for details.`, e);
+        notify('Plugin error!', `"${plugin._name}" has encountered an error. Check Developer Tools for details.`, {
+          error: e
+        });
       }
     }
   });
@@ -302,7 +306,7 @@ function decorateObject(base, key) {
       try {
         res = plugin[key](decorated);
       } catch (e) {
-        notify('Plugin error!', `"${plugin._name}" when decorating ${key}`, e);
+        notify('Plugin error!', `"${plugin._name}" when decorating ${key}`, {error: e});
         return;
       }
       if (res && typeof res === 'object') {
@@ -328,7 +332,9 @@ exports.getDeprecatedConfig = () => {
     try {
       configTmp = plugin.decorateConfig(JSON.parse(JSON.stringify(baseConfig)));
     } catch (e) {
-      notify('Plugin error!', `"${plugin._name}" has encountered an error. Check Developer Tools for details.`, e);
+      notify('Plugin error!', `"${plugin._name}" has encountered an error. Check Developer Tools for details.`, {
+        error: e
+      });
       return;
     }
     const pluginCSSDeprecated = config.getDeprecatedCSS(configTmp);

--- a/app/plugins.js
+++ b/app/plugins.js
@@ -66,7 +66,7 @@ function updatePlugins({force = false} = {}) {
 
     if (err) {
       //eslint-disable-next-line no-console
-      notify('Error updating plugins.', err);
+      notify('Error updating plugins.', err, err);
     } else {
       // flag successful plugin update
       cache.set('hyper.plugins', id_);
@@ -257,9 +257,7 @@ function requirePlugins() {
         //eslint-disable-next-line no-console
         console.warn(`Plugin "${basename(path_)}" not found: ${path_}`);
       } else {
-        //eslint-disable-next-line no-console
-        console.error(err);
-        notify('Plugin error!', `Plugin "${basename(path_)}" failed to load (${err.message})`);
+        notify('Plugin error!', `Plugin "${basename(path_)}" failed to load (${err.message})`, err);
       }
     }
   };
@@ -276,7 +274,7 @@ exports.onApp = app_ => {
       try {
         plugin.onApp(app_);
       } catch (e) {
-        notify('Plugin error!', `"${plugin._name}" has encountered an error. Check Developer Tools for details.`);
+        notify('Plugin error!', `"${plugin._name}" has encountered an error. Check Developer Tools for details.`, e);
       }
     }
   });
@@ -288,7 +286,7 @@ exports.onWindow = win => {
       try {
         plugin.onWindow(win);
       } catch (e) {
-        notify('Plugin error!', `"${plugin._name}" has encountered an error. Check Developer Tools for details.`);
+        notify('Plugin error!', `"${plugin._name}" has encountered an error. Check Developer Tools for details.`, e);
       }
     }
   });
@@ -304,7 +302,7 @@ function decorateObject(base, key) {
       try {
         res = plugin[key](decorated);
       } catch (e) {
-        notify('Plugin error!', `"${plugin._name}" when decorating ${key}`);
+        notify('Plugin error!', `"${plugin._name}" when decorating ${key}`, e);
         return;
       }
       if (res && typeof res === 'object') {
@@ -330,7 +328,7 @@ exports.getDeprecatedConfig = () => {
     try {
       configTmp = plugin.decorateConfig(JSON.parse(JSON.stringify(baseConfig)));
     } catch (e) {
-      notify('Plugin error!', `"${plugin._name}" has encountered an error. Check Developer Tools for details.`);
+      notify('Plugin error!', `"${plugin._name}" has encountered an error. Check Developer Tools for details.`, e);
       return;
     }
     const pluginCSSDeprecated = config.getDeprecatedCSS(configTmp);

--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -258,9 +258,7 @@ export function openFile(path) {
       effect() {
         stat(path, (err, stats) => {
           if (err) {
-            //eslint-disable-next-line no-console
-            console.error(err.stack);
-            notify('Unable to open path', `"${path}" doesn't exist.`);
+            notify('Unable to open path', `"${path}" doesn't exist.`, err);
           } else {
             let command = escapeShellCmd(path).replace(/ /g, '\\ ');
             if (stats.isDirectory()) {

--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -258,7 +258,7 @@ export function openFile(path) {
       effect() {
         stat(path, (err, stats) => {
           if (err) {
-            notify('Unable to open path', `"${path}" doesn't exist.`, err);
+            notify('Unable to open path', `"${path}" doesn't exist.`, {error: err});
           } else {
             let command = escapeShellCmd(path).replace(/ /g, '\\ ');
             if (stats.isDirectory()) {

--- a/lib/utils/notify.js
+++ b/lib/utils/notify.js
@@ -1,7 +1,11 @@
 /* global Notification */
 /* eslint no-new:0 */
-export default function notify(title, body) {
+export default function notify(title, body, error) {
   //eslint-disable-next-line no-console
   console.log(`[Notification] ${title}: ${body}`);
+  if (error) {
+    //eslint-disable-next-line no-console
+    console.error(error);
+  }
   new Notification(title, {body});
 }

--- a/lib/utils/notify.js
+++ b/lib/utils/notify.js
@@ -1,11 +1,11 @@
 /* global Notification */
 /* eslint no-new:0 */
-export default function notify(title, body, error) {
+export default function notify(title, body, details = {}) {
   //eslint-disable-next-line no-console
   console.log(`[Notification] ${title}: ${body}`);
-  if (error) {
+  if (details.error) {
     //eslint-disable-next-line no-console
-    console.error(error);
+    console.error(details.error);
   }
   new Notification(title, {body});
 }

--- a/lib/utils/plugins.js
+++ b/lib/utils/plugins.js
@@ -140,7 +140,7 @@ const loadModules = () => {
         notify(
           'Plugin load error',
           `"${pluginName}" failed to load in the renderer process. Check Developer Tools for details.`,
-          err
+          {error: err}
         );
         return undefined;
       }
@@ -275,11 +275,9 @@ function getProps(name, props, ...fnArgs) {
     try {
       ret_ = fn(...fnArgs, props_);
     } catch (err) {
-      notify(
-        'Plugin error',
-        `${fn._pluginName}: Error occurred in \`${name}\`. Check Developer Tools for details.`,
-        err
-      );
+      notify('Plugin error', `${fn._pluginName}: Error occurred in \`${name}\`. Check Developer Tools for details.`, {
+        error: err
+      });
       return;
     }
 
@@ -327,7 +325,7 @@ export function connect(stateFn, dispatchFn, c, d = {}) {
             notify(
               'Plugin error',
               `${fn._pluginName}: Error occurred in \`map${name}State\`. Check Developer Tools for details.`,
-              err
+              {error: err}
             );
             return;
           }
@@ -352,7 +350,7 @@ export function connect(stateFn, dispatchFn, c, d = {}) {
             notify(
               'Plugin error',
               `${fn._pluginName}: Error occurred in \`map${name}Dispatch\`. Check Developer Tools for details.`,
-              err
+              {error: err}
             );
             return;
           }
@@ -386,11 +384,9 @@ function decorateReducer(name, fn) {
       try {
         state__ = pluginReducer(state_, action);
       } catch (err) {
-        notify(
-          'Plugin error',
-          `${fn._pluginName}: Error occurred in \`${name}\`. Check Developer Tools for details.`,
-          err
-        );
+        notify('Plugin error', `${fn._pluginName}: Error occurred in \`${name}\`. Check Developer Tools for details.`, {
+          error: err
+        });
         return;
       }
 
@@ -437,7 +433,7 @@ function exposeDecorated(Component_) {
         try {
           this.props.onDecorated(decorated_);
         } catch (e) {
-          notify('Plugin error', `Error occurred. Check Developer Tools for details`, e);
+          notify('Plugin error', `Error occurred. Check Developer Tools for details`, {error: e});
         }
       }
     }
@@ -466,7 +462,7 @@ function getDecorated(parent, name) {
           notify(
             'Plugin error',
             `${fn._pluginName}: Error occurred in \`${method}\`. Check Developer Tools for details`,
-            err
+            {error: err}
           );
           return;
         }

--- a/lib/utils/plugins.js
+++ b/lib/utils/plugins.js
@@ -137,11 +137,10 @@ const loadModules = () => {
       try {
         mod = window.require(path);
       } catch (err) {
-        //eslint-disable-next-line no-console
-        console.error(err.stack);
         notify(
           'Plugin load error',
-          `"${pluginName}" failed to load in the renderer process. Check Developer Tools for details.`
+          `"${pluginName}" failed to load in the renderer process. Check Developer Tools for details.`,
+          err
         );
         return undefined;
       }
@@ -276,9 +275,11 @@ function getProps(name, props, ...fnArgs) {
     try {
       ret_ = fn(...fnArgs, props_);
     } catch (err) {
-      //eslint-disable-next-line no-console
-      console.error(err.stack);
-      notify('Plugin error', `${fn._pluginName}: Error occurred in \`${name}\`. Check Developer Tools for details.`);
+      notify(
+        'Plugin error',
+        `${fn._pluginName}: Error occurred in \`${name}\`. Check Developer Tools for details.`,
+        err
+      );
       return;
     }
 
@@ -323,11 +324,10 @@ export function connect(stateFn, dispatchFn, c, d = {}) {
           try {
             ret_ = fn(state, ret);
           } catch (err) {
-            //eslint-disable-next-line no-console
-            console.error(err.stack);
             notify(
               'Plugin error',
-              `${fn._pluginName}: Error occurred in \`map${name}State\`. Check Developer Tools for details.`
+              `${fn._pluginName}: Error occurred in \`map${name}State\`. Check Developer Tools for details.`,
+              err
             );
             return;
           }
@@ -349,11 +349,10 @@ export function connect(stateFn, dispatchFn, c, d = {}) {
           try {
             ret_ = fn(dispatch, ret);
           } catch (err) {
-            //eslint-disable-next-line no-console
-            console.error(err.stack);
             notify(
               'Plugin error',
-              `${fn._pluginName}: Error occurred in \`map${name}Dispatch\`. Check Developer Tools for details.`
+              `${fn._pluginName}: Error occurred in \`map${name}Dispatch\`. Check Developer Tools for details.`,
+              err
             );
             return;
           }
@@ -387,9 +386,11 @@ function decorateReducer(name, fn) {
       try {
         state__ = pluginReducer(state_, action);
       } catch (err) {
-        //eslint-disable-next-line no-console
-        console.error(err.stack);
-        notify('Plugin error', `${fn._pluginName}: Error occurred in \`${name}\`. Check Developer Tools for details.`);
+        notify(
+          'Plugin error',
+          `${fn._pluginName}: Error occurred in \`${name}\`. Check Developer Tools for details.`,
+          err
+        );
         return;
       }
 
@@ -436,7 +437,7 @@ function exposeDecorated(Component_) {
         try {
           this.props.onDecorated(decorated_);
         } catch (e) {
-          notify('Plugin error', `Error occurred. Check Developer Tools for details`);
+          notify('Plugin error', `Error occurred. Check Developer Tools for details`, e);
         }
       }
     }
@@ -462,11 +463,10 @@ function getDecorated(parent, name) {
           class__ = fn(class_, {React, PureComponent, Notification, notify});
           class__.displayName = `${fn._pluginName}(${name})`;
         } catch (err) {
-          //eslint-disable-next-line no-console
-          console.error(err.stack);
           notify(
             'Plugin error',
-            `${fn._pluginName}: Error occurred in \`${method}\`. Check Developer Tools for details`
+            `${fn._pluginName}: Error occurred in \`${method}\`. Check Developer Tools for details`,
+            err
           );
           return;
         }


### PR DESCRIPTION
In short, this pull request is to assist with error reporting, and diagnostics.

After the 2.0 upgrade, a number of plugins I use stopped working. Unfortunately, while I would see the notification message to check 'Developer tools', there was no further output or logs available.

After looking through the source, I found that some catch blocks would output the error to console.error, but others would not. Rather than modifying all the catch blocks, I opted to add an additional parameter 'error', to the notify method. If present, the error is logged to the console. I then just modified the catch block to pass the error reference.

Please do not be bashful with your feedback, and thank you so much for this incredible tool.