### PR TITLE
Add support for Headless Terminal Multiplexer (htm)

### DIFF
--- a/app/commands.js
+++ b/app/commands.js
@@ -9,16 +9,16 @@ const commands = {
   },
   'tab:new': focusedWindow => {
     if (focusedWindow) {
-      focusedWindow.rpc.emit('termgroup add req');
+      focusedWindow.rpc.emit('termgroup add req', {});
     } else {
       setTimeout(app.createWindow, 0);
     }
   },
   'pane:splitVertical': focusedWindow => {
-    focusedWindow && focusedWindow.rpc.emit('split request vertical');
+    focusedWindow && focusedWindow.rpc.emit('split request vertical', {});
   },
   'pane:splitHorizontal': focusedWindow => {
-    focusedWindow && focusedWindow.rpc.emit('split request horizontal');
+    focusedWindow && focusedWindow.rpc.emit('split request horizontal', {});
   },
   'pane:close': focusedWindow => {
     focusedWindow && focusedWindow.rpc.emit('termgroup close req');

--- a/app/ui/window.js
+++ b/app/ui/window.js
@@ -147,6 +147,17 @@ module.exports = class Window {
       session.resize({cols, rows});
     });
     rpc.on('data', ({uid, data, escaped}) => {
+      window.handleSessionInput(uid, data, escaped);
+    });
+    window.initSession = (opts, fn_) => {
+      fn_(uuid.v4(), new Session(opts));
+    };
+
+    window.handleSessionData = (uid, data, handleSessionCallback) => {
+      // By default, just execute the callback.  Plugins can override.
+      return handleSessionCallback(uid, data);
+    };
+    window.handleSessionInput = (uid, data, escaped) => {
       const session = sessions.get(uid);
 
       if (escaped) {
@@ -158,14 +169,6 @@ module.exports = class Window {
       } else {
         session.write(data);
       }
-    });
-    window.initSession = (opts, fn_) => {
-      fn_(uuid.v4(), new Session(opts));
-    };
-
-    window.handleSessionData = (uid, data, handleSessionCallback) => {
-      // By default, just execute the callback.  Plugins can override.
-      return handleSessionCallback(uid, data);
     };
     window.deleteSession = uid => {
       sessions.delete(uid);

--- a/app/ui/window.js
+++ b/app/ui/window.js
@@ -120,7 +120,7 @@ module.exports = class Window {
 
         session.on('exit', () => {
           rpc.emit('session exit', {uid});
-          sessions.delete(uid);
+          window.deleteSession(uid);
         });
       });
     });
@@ -166,6 +166,9 @@ module.exports = class Window {
     window.handleSessionData = (uid, data, handleSessionCallback) => {
       // By default, just execute the callback.  Plugins can override.
       return handleSessionCallback(uid, data);
+    };
+    window.deleteSession = uid => {
+      sessions.delete(uid);
     };
     rpc.on('open external', ({url}) => {
       shell.openExternal(url);

--- a/lib/actions/sessions.js
+++ b/lib/actions/sessions.js
@@ -18,7 +18,7 @@ import {
   SESSION_SET_XTERM_TITLE
 } from '../constants/sessions';
 
-export function addSession({uid, shell, pid, cols, rows, splitDirection}) {
+export function addSession({uid, shell, pid, cols, rows, splitDirection, termGroupUid, activeUid}) {
   return (dispatch, getState) => {
     const {sessions} = getState();
     const now = Date.now();
@@ -30,8 +30,9 @@ export function addSession({uid, shell, pid, cols, rows, splitDirection}) {
       cols,
       rows,
       splitDirection,
-      activeUid: sessions.activeUid,
-      now
+      activeUid: activeUid ? activeUid : sessions.activeUid,
+      now,
+      termGroupUid
     });
   };
 }

--- a/lib/actions/term-groups.js
+++ b/lib/actions/term-groups.js
@@ -12,14 +12,16 @@ import getRootGroups from '../selectors';
 import {setActiveSession, ptyExitSession, userExitSession} from './sessions';
 
 function requestSplit(direction) {
-  return () => (dispatch, getState) => {
+  return (sessionUid, sourceUid) => (dispatch, getState) => {
     dispatch({
       type: SESSION_REQUEST,
       effect: () => {
-        const {ui} = getState();
+        const {ui, sessions} = getState();
         rpc.emit('new', {
           splitDirection: direction,
-          cwd: ui.cwd
+          cwd: ui.cwd,
+          sessionUid,
+          activeUid: sourceUid ? sourceUid : sessions.activeUid
         });
       }
     });
@@ -37,7 +39,7 @@ export function resizeTermGroup(uid, sizes) {
   };
 }
 
-export function requestTermGroup() {
+export function requestTermGroup(termGroupUid, sessionUid) {
   return (dispatch, getState) => {
     dispatch({
       type: TERM_GROUP_REQUEST,
@@ -48,7 +50,9 @@ export function requestTermGroup() {
           isNewGroup: true,
           cols,
           rows,
-          cwd
+          cwd,
+          termGroupUid,
+          sessionUid
         });
       }
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,10 +44,7 @@ rpc.on('session add', data => {
   store_.dispatch(sessionActions.addSession(data));
 });
 
-rpc.on('session data', d => {
-  // the uid is a uuid v4 so it's 36 chars long
-  const uid = d.slice(0, 36);
-  const data = d.slice(36);
+rpc.on('session data', ({uid, data}) => {
   store_.dispatch(sessionActions.addSessionData(uid, data));
 });
 
@@ -103,16 +100,16 @@ rpc.on('session break req', () => {
   store_.dispatch(sessionActions.sendSessionData(null, '\x03'));
 });
 
-rpc.on('termgroup add req', () => {
-  store_.dispatch(termGroupActions.requestTermGroup());
+rpc.on('termgroup add req', ({termGroupUid, sessionUid}) => {
+  store_.dispatch(termGroupActions.requestTermGroup(termGroupUid, sessionUid));
 });
 
-rpc.on('split request horizontal', () => {
-  store_.dispatch(termGroupActions.requestHorizontalSplit());
+rpc.on('split request horizontal', ({sessionUid, sourceUid}) => {
+  store_.dispatch(termGroupActions.requestHorizontalSplit(sessionUid, sourceUid));
 });
 
-rpc.on('split request vertical', () => {
-  store_.dispatch(termGroupActions.requestVerticalSplit());
+rpc.on('split request vertical', ({sessionUid, sourceUid}) => {
+  store_.dispatch(termGroupActions.requestVerticalSplit(sessionUid, sourceUid));
 });
 
 rpc.on('reset fontSize req', () => {

--- a/lib/reducers/term-groups.js
+++ b/lib/reducers/term-groups.js
@@ -192,7 +192,10 @@ const reducer = (state = initialState, action) => {
         return setActiveGroup(state, action);
       }
 
-      const uid = uuid.v4();
+      let uid = uuid.v4();
+      if (action.termGroupUid) {
+        uid = action.termGroupUid;
+      }
       const termGroup = TermGroup({
         uid,
         sessionUid: action.uid


### PR DESCRIPTION
As discussed in https://github.com/zeit/hyper/issues/2406 and  https://github.com/zeit/hyper/issues/2978 , a terminal multiplexer that integrates with the terminal emulator would be a great addition to Hyper.js.  I initially looked into integrating the existing solution, tmux control center, but tmux -CC has no defined spec and is difficult to reverse engineer.  As a result, I wrote my own headless terminal multiplexer called HTM.  HTM will be packaged with the next version of Eternal Terminal ( https://mistertea.github.io/EternalTerminal/ ).

The core idea is that htm runs inside of ssh/et and sends commands to Hyper.js (or any other terminal emulator).  Hyper.js gets a special ANSI escape sequence which puts hyper in HTM mode, and then the current state of the tabs/panes.  As users make tabs, delete tabs, or type in panes, all of this is funneled through htm.  If someone exits hyper.js and comes back, running htm restores the state when the person exited.  To see a demo of how this works, check out https://www.youtube.com/watch?v=Ea6Y08tP-RI&feature=youtu.be

This PR is a WIP because I assume it's a big enough change that it will require more iterations before it's ready to merge.  It's 100% functional and can be tried by following these instructions:

- First, check out the htm branch of eternal terminal and build the source (see https://github.com/MisterTea/EternalTerminal#building-from-source ).
- Then, ensure that htm and htmd are in your path by copying to /usr/local/bin or modifying your .bashrc/.zshrc
- Then, build & run yarn with this PR.
- Inside hyper (can be in an ssh session or not), run htm
- Do some work
- Close hyper.js
- re-open and re-run htm
- your state is preserved.
