### PR TITLE
Adjust clickable region of control buttons

### DIFF
--- a/lib/components/header.js
+++ b/lib/components/header.js
@@ -228,6 +228,7 @@ export default class Header extends React.PureComponent {
             height: 34px;
             justify-content: space-between;
             position: fixed;
+            top: 0;
             right: 0;
           }
 


### PR DESCRIPTION
On Windows, the close button (rather than the border) is expected to be hit when someone clicks the top-right corner of the screen if a window is maximized.