### PR TITLE
Added check for startup directory and blank option into default config.

### DIFF
--- a/app/config/config-default.js
+++ b/app/config/config-default.js
@@ -57,6 +57,9 @@ module.exports = {
     // custom CSS to embed in the terminal window
     termCSS: '',
 
+    // set custom startup directory (must be an absolute path)
+    workingDirectory: '',
+
     // if you're using a Linux setup which show native menus, set to false
     // default: `true` on Linux, `true` on Windows, ignored on macOS
     showHamburgerMenu: '',

--- a/app/ui/window.js
+++ b/app/ui/window.js
@@ -41,6 +41,14 @@ module.exports = class Window {
       window.setBackgroundColor(toElectronBackgroundColor(cfg_.backgroundColor || '#000'));
     };
 
+    // set startup directory
+    let workingDirectory = cfgDir;
+    if (process.argv[1] && isAbsolute(process.argv[1])) {
+      workingDirectory = process.argv[1];
+    } else if (cfg.startupDirectory && isAbsolute(cfg.startupDirectory)) {
+      workingDirectory = cfg.startupDirectory;
+    }
+
     // config changes
     const cfgUnsubscribe = app.config.subscribe(() => {
       const cfg_ = app.plugins.getDecoratedConfig();
@@ -90,7 +98,7 @@ module.exports = class Window {
         {
           rows: 40,
           cols: 100,
-          cwd: process.argv[1] && isAbsolute(process.argv[1]) ? process.argv[1] : cfgDir,
+          cwd: workingDirectory,
           splitDirection: undefined,
           shell: cfg.shell,
           shellArgs: cfg.shellArgs && Array.from(cfg.shellArgs)


### PR DESCRIPTION
Opening this to tackle #3000. Added a simple check (expanding the check for an argument being passed to also check for a config option named workingDirectory) and then added that option to the default config. Current priority is command-line argument > config file option > home directory.