### PR TITLE
Add `isWsl` flag to session/action objects

### DIFF
--- a/app/ui/window.js
+++ b/app/ui/window.js
@@ -93,6 +93,7 @@ module.exports = class Window {
           cwd: process.argv[1] && isAbsolute(process.argv[1]) ? process.argv[1] : cfgDir,
           splitDirection: undefined,
           shell: cfg.shell,
+          isWsl: /(?:bash|debian|kali|opensuse|ubuntu|wsl)\.exe$/.test(cfg.shell),
           shellArgs: cfg.shellArgs && Array.from(cfg.shellArgs)
         },
         options
@@ -110,6 +111,7 @@ module.exports = class Window {
           uid,
           splitDirection: sessionOpts.splitDirection,
           shell: session.shell,
+          isWsl: sessionOpts.isWsl,
           pid: session.pty.pid
         });
 

--- a/app/ui/window.js
+++ b/app/ui/window.js
@@ -93,7 +93,7 @@ module.exports = class Window {
           cwd: process.argv[1] && isAbsolute(process.argv[1]) ? process.argv[1] : cfgDir,
           splitDirection: undefined,
           shell: cfg.shell,
-          isWsl: /(?:bash|debian|kali|opensuse|ubuntu|wsl)\.exe$/.test(cfg.shell),
+          isWsl: /(?:bash|debian|kali|opensuse|ubuntu(?:1804)?|wsl)\.exe$/.test(cfg.shell),
           shellArgs: cfg.shellArgs && Array.from(cfg.shellArgs)
         },
         options

--- a/app/ui/window.js
+++ b/app/ui/window.js
@@ -13,6 +13,7 @@ const fetchNotifications = require('../notifications');
 const Session = require('../session');
 const contextMenuTemplate = require('./contextmenu');
 const {execCommand} = require('../commands');
+const {isWslShell} = require('../utils/wsl');
 
 module.exports = class Window {
   constructor(options_, cfg, fn) {
@@ -93,7 +94,7 @@ module.exports = class Window {
           cwd: process.argv[1] && isAbsolute(process.argv[1]) ? process.argv[1] : cfgDir,
           splitDirection: undefined,
           shell: cfg.shell,
-          isWsl: /(bash|debian|kali|opensuse|ubuntu(1804)?|wsl)\.exe$/.test(cfg.shell),
+          isWsl: isWslShell(cfg.shell),
           shellArgs: cfg.shellArgs && Array.from(cfg.shellArgs)
         },
         options

--- a/app/ui/window.js
+++ b/app/ui/window.js
@@ -93,7 +93,7 @@ module.exports = class Window {
           cwd: process.argv[1] && isAbsolute(process.argv[1]) ? process.argv[1] : cfgDir,
           splitDirection: undefined,
           shell: cfg.shell,
-          isWsl: /(?:bash|debian|kali|opensuse|ubuntu(?:1804)?|wsl)\.exe$/.test(cfg.shell),
+          isWsl: /(bash|debian|kali|opensuse|ubuntu(1804)?|wsl)\.exe$/.test(cfg.shell),
           shellArgs: cfg.shellArgs && Array.from(cfg.shellArgs)
         },
         options

--- a/app/utils/wsl.js
+++ b/app/utils/wsl.js
@@ -2,14 +2,14 @@ const path = require('path');
 
 // Valid Windows Subsystem for Linux shell executables
 const WSL_SHELL_EXECUTABLES = [
-	'bash.exe',
-	'wsl.exe',
-	'ubuntu.exe',
-	'ubuntu1804.exe',
-	'kali.exe',
-	'debian.exe',
-	'opensuse-42.exe',
-	'sles-12.exe'
+  'bash.exe',
+  'wsl.exe',
+  'ubuntu.exe',
+  'ubuntu1804.exe',
+  'kali.exe',
+  'debian.exe',
+  'opensuse-42.exe',
+  'sles-12.exe'
 ];
 
 // Returns true if given shell executable is from WSL, false otherwise

--- a/app/utils/wsl.js
+++ b/app/utils/wsl.js
@@ -13,7 +13,7 @@ const WSL_SHELL_EXECUTABLES = [
 ];
 
 // Returns true if given shell executable is from WSL, false otherwise
-function isWslShell(shell) {
+function isWslShell(shell = '') {
   return WSL_SHELL_EXECUTABLES.indexOf(shell.split(path.sep).pop()) !== -1;
 }
 

--- a/app/utils/wsl.js
+++ b/app/utils/wsl.js
@@ -1,0 +1,22 @@
+const path = require('path');
+
+// Valid Windows Subsystem for Linux shell executables
+const WSL_SHELL_EXECUTABLES = [
+	'bash.exe',
+	'wsl.exe',
+	'ubuntu.exe',
+	'ubuntu1804.exe',
+	'kali.exe',
+	'debian.exe',
+	'opensuse-42.exe',
+	'sles-12.exe'
+];
+
+// Returns true if given shell executable is from WSL, false otherwise
+function isWslShell(shell) {
+  return WSL_SHELL_EXECUTABLES.indexOf(shell.split(path.sep).pop()) !== -1;
+}
+
+module.exports = {
+  isWslShell
+};

--- a/lib/actions/sessions.js
+++ b/lib/actions/sessions.js
@@ -18,7 +18,7 @@ import {
   SESSION_SET_XTERM_TITLE
 } from '../constants/sessions';
 
-export function addSession({uid, shell, pid, cols, rows, splitDirection}) {
+export function addSession({uid, shell, isWsl, pid, cols, rows, splitDirection}) {
   return (dispatch, getState) => {
     const {sessions} = getState();
     const now = Date.now();
@@ -26,6 +26,7 @@ export function addSession({uid, shell, pid, cols, rows, splitDirection}) {
       type: SESSION_ADD,
       uid,
       shell,
+      isWsl,
       pid,
       cols,
       rows,

--- a/lib/reducers/sessions.js
+++ b/lib/reducers/sessions.js
@@ -28,6 +28,7 @@ function Session(obj) {
     url: null,
     cleared: false,
     shell: '',
+    isWsl: false,
     pid: null
   }).merge(obj);
 }
@@ -42,6 +43,7 @@ const reducer = (state = initialState, action) => {
           rows: action.rows,
           uid: action.uid,
           shell: action.shell.split('/').pop(),
+          isWsl: action.isWsl,
           pid: action.pid
         })
       );

--- a/lib/reducers/sessions.js
+++ b/lib/reducers/sessions.js
@@ -13,6 +13,7 @@ import {
   SESSION_SET_XTERM_TITLE,
   SESSION_SET_CWD
 } from '../constants/sessions';
+import path from 'path';
 
 const initialState = Immutable({
   sessions: {},
@@ -42,7 +43,7 @@ const reducer = (state = initialState, action) => {
           cols: action.cols,
           rows: action.rows,
           uid: action.uid,
-          shell: action.shell.split('/').pop(),
+          shell: action.shell.split(path.sep).pop(),
           isWsl: action.isWsl,
           pid: action.pid
         })


### PR DESCRIPTION
The `isWsl` flag denotes if the running shell is a Windows Subsystem for Linux (WSL) shell by pattern matching the user configurable `shell` property.

This flag has support for invoking WSL with multiple executables:

- `bash.exe`
- `debian.exe`
- `kali.exe`
- `opensuse.exe`
- `ubuntu.exe`
- `wsl.exe`

I'm not sure if this is something you guys want to add to Hyper core but it's just a small flag to help plugin developers easily know if the running shell is WSL or not, just like they currently need to know if the host OS is Windows and Linux (provided by `process.platform`) to properly do their plugin magic. This will come in handy to better support WSL within plugins.

Let me know if you have any questions or a better idea to implement this.