### PR TITLE
add scrollback buffer config option

### DIFF
--- a/lib/components/term-group.js
+++ b/lib/components/term-group.js
@@ -82,6 +82,7 @@ class TermGroup_ extends React.PureComponent {
       copyOnSelect: this.props.copyOnSelect,
       bell: this.props.bell,
       bellSoundURL: this.props.bellSoundURL,
+      scrollback: this.props.scrollback,
       onActive: this.bind(this.props.onActive, null, uid),
       onResize: this.bind(this.props.onResize, null, uid),
       onTitle: this.bind(this.props.onTitle, null, uid),

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -36,6 +36,7 @@ const getTermOptions = props => {
     letterSpacing: props.letterSpacing,
     allowTransparency: needTransparency,
     experimentalCharAtlas: 'dynamic',
+    scrollback: props.scrollback,
     theme: {
       foreground: props.foregroundColor,
       background: backgroundColor,

--- a/lib/components/terms.js
+++ b/lib/components/terms.js
@@ -115,6 +115,7 @@ export default class Terms extends React.Component {
             onURLAbort: this.props.onURLAbort,
             onContextMenu: this.props.onContextMenu,
             quickEdit: this.props.quickEdit,
+            scrollback: this.props.scrollback,
             parentProps: this.props
           });
 

--- a/lib/containers/terms.js
+++ b/lib/containers/terms.js
@@ -44,7 +44,8 @@ const TermsContainer = connect(
       bellSoundURL: state.ui.bellSoundURL,
       copyOnSelect: state.ui.copyOnSelect,
       modifierKeys: state.ui.modifierKeys,
-      quickEdit: state.ui.quickEdit
+      quickEdit: state.ui.quickEdit,
+      scrollback: state.ui.scrollback
     };
   },
   dispatch => {

--- a/lib/reducers/ui.js
+++ b/lib/reducers/ui.js
@@ -214,6 +214,10 @@ const reducer = (state = initial, action) => {
               }
             }
 
+            if (config.scrollback) {
+              ret.scrollback = config.scrollback;
+            }
+
             if (config.modifierKeys) {
               ret.modifierKeys = config.modifierKeys;
             }


### PR DESCRIPTION
As stated. The config option added is called `scollback` and takes a number.
Without the option in config the xterm.js default is used (1000?) I believe.

Discussed in #280  
