### PR TITLE
Show actual error message when loading plugin fails

### DIFF
--- a/app/plugins.js
+++ b/app/plugins.js
@@ -291,7 +291,7 @@ function requirePlugins() {
     } catch (err) {
       if (err.code === 'MODULE_NOT_FOUND') {
         //eslint-disable-next-line no-console
-        console.warn(`Plugin "${basename(path_)}" not found: ${path_}`);
+        console.warn(`Plugin error while loading "${basename(path_)}" (${path_}): ${err.message}`);
       } else {
         notify('Plugin error!', `Plugin "${basename(path_)}" failed to load (${err.message})`, {error: err});
       }


### PR DESCRIPTION
<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`
- If your PR changes some API, please make a PR for hyper website too: https://github.com/zeit/hyper-site.

Thanks, again! -->

When attempting to develop a local plugin, I took https://github.com/zeit/hyperpower as a starting point, and cloned it into my local `.hyper_plugins/local`. I then added it to my `localPlugins`, and launched the dev app with `yarn run dev`, however as I didn't have hyperpower's dependencies installed, it could not be `require`d and it errored.

Confusingly, however, the message was

```
Plugin "hyperpower" not found: /Users/razzi/forks/hyper/.hyper_plugins/local/hyperpower
```

which confused me because that directory did exist. Requiring that path, I saw the true error:

```
$ node
> require('/Users/razzi/forks/hyper/.hyper_plugins/local/hyperpower')
Error: Cannot find module 'lodash.throttle'
```

After I ran `npm install` from that directory, the error went away, but since I was confused by the error, I think it'd be helpful to show the actual error rather than handling all MODULE_NOT_FOUND errors with the message "Plugin ... not found."

By applying this update, the true error will be clear: 

```
Plugin error while loading "hyperpower" (/Users/razzi/forks/hyper/.hyper_plugins/local/hyperpower): Cannot find module 'lodash.throttle'
```

I'm not tied to the wording I used - maintainers feel free to edit.