### PR TITLE
Windows Keybindings was not correctly setup

### DIFF
--- a/app/config/paths.js
+++ b/app/config/paths.js
@@ -45,18 +45,22 @@ const darwinKeys = join(keymapPath, 'darwin.json');
 const win32Keys = join(keymapPath, 'win32.json');
 const linuxKeys = join(keymapPath, 'linux.json');
 
-const defaultPlatformKeyPath = () => {
-  switch (process.platform) {
-    case 'darwin':
-      return darwinKeys;
-    case 'win32':
-      return win32Keys;
-    case 'linux':
-      return linuxKeys;
-    default:
-      return darwinKeys;
-  }
-};
+var defaultPlatformKeyPath;
+
+switch (process.platform) {
+  case 'darwin':
+    defaultPlatformKeyPath = darwinKeys;
+    break;
+  case 'win32':
+    defaultPlatformKeyPath = win32Keys;
+    break;
+  case 'linux':
+    defaultPlatformKeyPath = linuxKeys;
+    break;
+  default:
+    defaultPlatformKeyPath = darwinKeys;
+    break;
+}
 
 module.exports = {
   cfgDir,


### PR DESCRIPTION
I created https://github.com/zeit/hyper/issues/3025 because on Windows, using Powershell as shell, key's didnt work for fx. move word.

What I saw was, "alt+arrows" worked to some degree, but not the expected keymappings defined in `win32.json`.
So for some reason the beneath didnt work, and if evaluated directly in Paths.js it did. Dont know enough of nodejs to say what are happening. But this fixed it. Could be a Windows specific NodeJs bug.

If you got any better way of doing this let me know.