### PR TITLE
Bump electron from 1.8.4 to 1.8.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "repository": "zeit/hyper",
   "scripts": {
-    "start": "echo 'please run `yarn run dev` in one tab and then `yarn run app` in another one'",
+    "start":
+      "echo 'please run `yarn run dev` in one tab and then `yarn run app` in another one'",
     "app": "electron app",
     "dev": "webpack -w",
     "build": "cross-env NODE_ENV=production webpack",
@@ -10,8 +11,10 @@
     "test:unit": "ava test/unit",
     "test:unit:watch": "yarn run test:unit -- --watch",
     "prepush": "yarn test",
-    "postinstall": "electron-builder install-app-deps && yarn run rebuild-node-pty",
-    "rebuild-node-pty": "electron-rebuild -f -w app/node_modules/node-pty -m app",
+    "postinstall":
+      "electron-builder install-app-deps && yarn run rebuild-node-pty",
+    "rebuild-node-pty":
+      "electron-rebuild -f -w app/node_modules/node-pty -m app",
     "dist":
       "yarn run build && cross-env BABEL_ENV=production babel --out-file app/renderer/bundle.js --no-comments --minified app/renderer/bundle.js && build",
     "clean":
@@ -211,7 +214,7 @@
     "babel-preset-react": "6.24.1",
     "copy-webpack-plugin": "4.3.1",
     "cross-env": "5.1.4",
-    "electron": "1.8.7",
+    "electron": "1.8.8",
     "electron-builder": "20.5.1",
     "electron-builder-squirrel-windows": "20.5.0",
     "electron-devtools-installer": "2.2.3",

--- a/package.json
+++ b/package.json
@@ -211,7 +211,7 @@
     "babel-preset-react": "6.24.1",
     "copy-webpack-plugin": "4.3.1",
     "cross-env": "5.1.4",
-    "electron": "1.8.4",
+    "electron": "1.8.7",
     "electron-builder": "20.5.1",
     "electron-builder-squirrel-windows": "20.5.0",
     "electron-devtools-installer": "2.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2329,9 +2329,9 @@ electron-to-chromium@^1.2.7:
   version "1.3.33"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.33.tgz#bf00703d62a7c65238136578c352d6c5c042a545"
 
-electron@1.8.4:
-  version "1.8.4"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-1.8.4.tgz#cca8d0e6889f238f55b414ad224f03e03b226a38"
+electron@1.8.7:
+  version "1.8.7"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-1.8.7.tgz#373c1dc4589d7ab4acd49aff8db4a1c0a6c3bcc1"
   dependencies:
     "@types/node" "^8.0.24"
     electron-download "^3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2329,9 +2329,9 @@ electron-to-chromium@^1.2.7:
   version "1.3.33"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.33.tgz#bf00703d62a7c65238136578c352d6c5c042a545"
 
-electron@1.8.7:
-  version "1.8.7"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-1.8.7.tgz#373c1dc4589d7ab4acd49aff8db4a1c0a6c3bcc1"
+electron@1.8.8:
+  version "1.8.8"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-1.8.8.tgz#a90cddb075291f49576993e6f5c8bb4439301cae"
   dependencies:
     "@types/node" "^8.0.24"
     electron-download "^3.0.1"


### PR DESCRIPTION
Update electron to 1.8.7 from 1.8.4. Also of note we should look into upgrading to electron 2. This PR should be ready to merge, 1.8.7 is just bug fixes as well as a security patch.

<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`
- If your PR changes some API, please make a PR for hyper website too: https://github.com/zeit/hyper-site.

Thanks, again! -->
