### PR TITLE
Refactor component methods to use arrow functions

### DIFF
--- a/lib/components/header.js
+++ b/lib/components/header.js
@@ -9,15 +9,14 @@ const Tabs = decorate(Tabs_, 'Tabs');
 export default class Header extends React.PureComponent {
   constructor() {
     super();
-    this.onChangeIntent = this.onChangeIntent.bind(this);
-    this.handleHeaderMouseDown = this.handleHeaderMouseDown.bind(this);
-    this.handleHamburgerMenuClick = this.handleHamburgerMenuClick.bind(this);
-    this.handleMaximizeClick = this.handleMaximizeClick.bind(this);
-    this.handleMinimizeClick = this.handleMinimizeClick.bind(this);
-    this.handleCloseClick = this.handleCloseClick.bind(this);
   }
 
-  onChangeIntent(active) {
+  componentWillUnmount = () => {
+    delete this.clicks;
+    clearTimeout(this.clickTimer);
+  };
+
+  onChangeIntent = active => {
     // we ignore clicks if they're a byproduct of a drag
     // motion to move the window
     if (window.screenX !== this.headerMouseDownWindowX || window.screenY !== this.headerMouseDownWindowY) {
@@ -25,9 +24,9 @@ export default class Header extends React.PureComponent {
     }
 
     this.props.onChangeTab(active);
-  }
+  };
 
-  handleHeaderMouseDown(ev) {
+  handleHeaderMouseDown = ev => {
     // the hack of all hacks, this prevents the term
     // iframe from losing focus, for example, when
     // the user drags the nav around
@@ -37,37 +36,32 @@ export default class Header extends React.PureComponent {
     // to differentiate dragging from clicking
     this.headerMouseDownWindowX = window.screenX;
     this.headerMouseDownWindowY = window.screenY;
-  }
+  };
 
-  handleHamburgerMenuClick(event) {
+  handleHamburgerMenuClick = event => {
     let {right: x, bottom: y} = event.currentTarget.getBoundingClientRect();
     x -= 15; // to compensate padding
     y -= 12; // ^ same
     this.props.openHamburgerMenu({x, y});
-  }
+  };
 
-  handleMaximizeClick() {
+  handleMaximizeClick = () => {
     if (this.props.maximized) {
       this.props.unmaximize();
     } else {
       this.props.maximize();
     }
-  }
+  };
 
-  handleMinimizeClick() {
+  handleMinimizeClick = () => {
     this.props.minimize();
-  }
+  };
 
-  handleCloseClick() {
+  handleCloseClick = () => {
     this.props.close();
-  }
+  };
 
-  componentWillUnmount() {
-    delete this.clicks;
-    clearTimeout(this.clickTimer);
-  }
-
-  getWindowHeaderConfig() {
+  getWindowHeaderConfig = () => {
     const {showHamburgerMenu, showWindowControls} = this.props;
 
     const defaults = {
@@ -84,9 +78,9 @@ export default class Header extends React.PureComponent {
       hambMenu: showHamburgerMenu === '' ? defaults.hambMenu : showHamburgerMenu,
       winCtrls: showWindowControls === '' ? defaults.winCtrls : showWindowControls
     };
-  }
+  };
 
-  render() {
+  render = () => {
     const {isMac} = this.props;
     const props = getTabsProps(this.props, {
       tabs: this.props.tabs,
@@ -258,5 +252,5 @@ export default class Header extends React.PureComponent {
         `}</style>
       </header>
     );
-  }
+  };
 }

--- a/lib/components/notification.js
+++ b/lib/components/notification.js
@@ -6,17 +6,15 @@ export default class Notification extends React.PureComponent {
     this.state = {
       dismissing: false
     };
-    this.handleDismiss = this.handleDismiss.bind(this);
-    this.onElement = this.onElement.bind(this);
   }
 
-  componentDidMount() {
+  componentDidMount = () => {
     if (this.props.dismissAfter) {
       this.setDismissTimer();
     }
-  }
+  };
 
-  componentWillReceiveProps(next) {
+  componentWillReceiveProps = next => {
     // if we have a timer going and the notification text
     // changed we reset the timer
     if (next.text !== this.props.text) {
@@ -27,13 +25,17 @@ export default class Notification extends React.PureComponent {
         this.setState({dismissing: false});
       }
     }
-  }
+  };
 
-  handleDismiss() {
+  componentWillUnmount = () => {
+    clearTimeout(this.dismissTimer);
+  };
+
+  handleDismiss = () => {
     this.setState({dismissing: true});
-  }
+  };
 
-  onElement(el) {
+  onElement = el => {
     if (el) {
       el.addEventListener('webkitTransitionEnd', () => {
         if (this.state.dismissing) {
@@ -45,24 +47,20 @@ export default class Notification extends React.PureComponent {
         el.style.setProperty('background-color', backgroundColor, 'important');
       }
     }
-  }
+  };
 
-  setDismissTimer() {
+  setDismissTimer = () => {
     this.dismissTimer = setTimeout(() => {
       this.handleDismiss();
     }, this.props.dismissAfter);
-  }
+  };
 
-  resetDismissTimer() {
+  resetDismissTimer = () => {
     clearTimeout(this.dismissTimer);
     this.setDismissTimer();
-  }
+  };
 
-  componentWillUnmount() {
-    clearTimeout(this.dismissTimer);
-  }
-
-  render() {
+  render = () => {
     const {backgroundColor, color} = this.props;
     const opacity = this.state.dismissing ? 0 : 1;
     return (
@@ -111,5 +109,5 @@ export default class Notification extends React.PureComponent {
         `}</style>
       </div>
     );
-  }
+  };
 }

--- a/lib/components/notifications.js
+++ b/lib/components/notifications.js
@@ -7,7 +7,7 @@ import Notification_ from './notification';
 const Notification = decorate(Notification_, 'Notification');
 
 export default class Notifications extends React.PureComponent {
-  render() {
+  render = () => {
     return (
       <div className="notifications_view">
         {this.props.customChildrenBefore}
@@ -124,5 +124,5 @@ export default class Notifications extends React.PureComponent {
         `}</style>
       </div>
     );
-  }
+  };
 }

--- a/lib/components/split-pane.js
+++ b/lib/components/split-pane.js
@@ -5,27 +5,30 @@ import _ from 'lodash';
 export default class SplitPane extends React.PureComponent {
   constructor(props) {
     super(props);
-    this.handleDragStart = this.handleDragStart.bind(this);
-    this.handleAutoResize = this.handleAutoResize.bind(this);
-    this.onDrag = this.onDrag.bind(this);
-    this.onDragEnd = this.onDragEnd.bind(this);
     this.state = {dragging: false};
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate = prevProps => {
     if (this.state.dragging && prevProps.sizes !== this.props.sizes) {
       // recompute positions for ongoing dragging
       this.dragPanePosition = this.dragTarget.getBoundingClientRect()[this.d2];
     }
-  }
+  };
 
-  setupPanes(ev) {
+  componentWillUnmount = () => {
+    // ensure drag end
+    if (this.dragging) {
+      this.onDragEnd();
+    }
+  };
+
+  setupPanes = ev => {
     this.panes = Array.from(ev.target.parentNode.childNodes);
     this.paneIndex = this.panes.indexOf(ev.target);
     this.paneIndex -= Math.ceil(this.paneIndex / 2);
-  }
+  };
 
-  handleAutoResize(ev) {
+  handleAutoResize = ev => {
     ev.preventDefault();
 
     this.setupPanes(ev);
@@ -39,9 +42,9 @@ export default class SplitPane extends React.PureComponent {
     sizes_[this.paneIndex + 1] = availableWidth / 2;
 
     this.props.onResize(sizes_);
-  }
+  };
 
-  handleDragStart(ev) {
+  handleDragStart = ev => {
     ev.preventDefault();
     this.setState({dragging: true});
     window.addEventListener('mousemove', this.onDrag);
@@ -62,9 +65,9 @@ export default class SplitPane extends React.PureComponent {
     this.dragPanePosition = this.dragTarget.getBoundingClientRect()[this.d2];
     this.panesSize = ev.target.parentNode.getBoundingClientRect()[this.d1];
     this.setupPanes(ev);
-  }
+  };
 
-  getSizes() {
+  getSizes = () => {
     const {sizes} = this.props;
     let sizes_;
 
@@ -77,9 +80,9 @@ export default class SplitPane extends React.PureComponent {
       sizes_ = count;
     }
     return sizes_;
-  }
+  };
 
-  onDrag(ev) {
+  onDrag = ev => {
     const sizes_ = this.getSizes();
 
     const i = this.paneIndex;
@@ -93,17 +96,17 @@ export default class SplitPane extends React.PureComponent {
       sizes_[i + 1] += d;
     }
     this.props.onResize(sizes_);
-  }
+  };
 
-  onDragEnd() {
+  onDragEnd = () => {
     if (this.state.dragging) {
       window.removeEventListener('mousemove', this.onDrag);
       window.removeEventListener('mouseup', this.onDragEnd);
       this.setState({dragging: false});
     }
-  }
+  };
 
-  render() {
+  render = () => {
     const children = this.props.children;
     const {direction, borderColor} = this.props;
     const sizeProperty = direction === 'horizontal' ? 'height' : 'width';
@@ -204,12 +207,5 @@ export default class SplitPane extends React.PureComponent {
         `}</style>
       </div>
     );
-  }
-
-  componentWillUnmount() {
-    // ensure drag end
-    if (this.dragging) {
-      this.onDragEnd();
-    }
-  }
+  };
 }

--- a/lib/components/style-sheet.js
+++ b/lib/components/style-sheet.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 export default class StyleSheet extends React.PureComponent {
-  render() {
+  render = () => {
     const {backgroundColor, fontFamily, foregroundColor, borderColor} = this.props;
 
     return (
@@ -140,5 +140,5 @@ export default class StyleSheet extends React.PureComponent {
         }
       `}</style>
     );
-  }
+  };
 }

--- a/lib/components/tab.js
+++ b/lib/components/tab.js
@@ -3,29 +3,24 @@ import React from 'react';
 export default class Tab extends React.PureComponent {
   constructor() {
     super();
-
-    this.handleHover = this.handleHover.bind(this);
-    this.handleBlur = this.handleBlur.bind(this);
-    this.handleClick = this.handleClick.bind(this);
-
     this.state = {
       hovered: false
     };
   }
 
-  handleHover() {
+  handleHover = () => {
     this.setState({
       hovered: true
     });
-  }
+  };
 
-  handleBlur() {
+  handleBlur = () => {
     this.setState({
       hovered: false
     });
-  }
+  };
 
-  handleClick(event) {
+  handleClick = event => {
     const isLeftClick = event.nativeEvent.which === 1;
     const isMiddleClick = event.nativeEvent.which === 2;
 
@@ -34,9 +29,9 @@ export default class Tab extends React.PureComponent {
     } else if (isMiddleClick) {
       this.props.onClose();
     }
-  }
+  };
 
-  render() {
+  render = () => {
     const {isActive, isFirst, isLast, borderColor, hasActivity} = this.props;
     const {hovered} = this.state;
 
@@ -176,5 +171,5 @@ export default class Tab extends React.PureComponent {
         `}</style>
       </React.Fragment>
     );
-  }
+  };
 }

--- a/lib/components/tabs.js
+++ b/lib/components/tabs.js
@@ -8,7 +8,7 @@ const Tab = decorate(Tab_, 'Tab');
 const isMac = /Mac/.test(navigator.userAgent);
 
 export default class Tabs extends React.PureComponent {
-  render() {
+  render = () => {
     const {tabs = [], borderColor, onChange, onClose} = this.props;
 
     const hide = !isMac && tabs.length === 1;
@@ -86,5 +86,5 @@ export default class Tabs extends React.PureComponent {
         `}</style>
       </nav>
     );
-  }
+  };
 }

--- a/lib/components/term-group.js
+++ b/lib/components/term-group.js
@@ -14,10 +14,19 @@ class TermGroup_ extends React.PureComponent {
     this.bound = new WeakMap();
     this.termRefs = {};
     this.sizeChanged = false;
-    this.onTermRef = this.onTermRef.bind(this);
   }
 
-  bind(fn, thisObj, uid) {
+  componentWillReceiveProps = nextProps => {
+    if (this.props.termGroup.sizes != nextProps.termGroup.sizes || nextProps.sizeChanged) {
+      this.term && this.term.fitResize();
+      // Indicate to children that their size has changed even if their ratio hasn't
+      this.sizeChanged = true;
+    } else {
+      this.sizeChanged = false;
+    }
+  };
+
+  bind = (fn, thisObj, uid) => {
     if (!this.bound.has(fn)) {
       this.bound.set(fn, {});
     }
@@ -26,9 +35,9 @@ class TermGroup_ extends React.PureComponent {
       map[uid] = fn.bind(thisObj, uid);
     }
     return map[uid];
-  }
+  };
 
-  renderSplit(groups) {
+  renderSplit = groups => {
     const [first, ...rest] = groups;
     if (rest.length === 0) {
       return first;
@@ -45,14 +54,14 @@ class TermGroup_ extends React.PureComponent {
         {groups}
       </SplitPane>
     );
-  }
+  };
 
-  onTermRef(uid, term) {
+  onTermRef = (uid, term) => {
     this.term = term;
     this.props.ref_(uid, term);
-  }
+  };
 
-  renderTerm(uid) {
+  renderTerm = uid => {
     const session = this.props.sessions[uid];
     const termRef = this.props.terms[uid];
     const props = getTermProps(uid, this.props, {
@@ -99,19 +108,9 @@ class TermGroup_ extends React.PureComponent {
     // which is inefficient. Should maybe do something similar
     // to this.bind.
     return <Term ref_={this.onTermRef} key={uid} {...props} />;
-  }
+  };
 
-  componentWillReceiveProps(nextProps) {
-    if (this.props.termGroup.sizes != nextProps.termGroup.sizes || nextProps.sizeChanged) {
-      this.term && this.term.fitResize();
-      // Indicate to children that their size has changed even if their ratio hasn't
-      this.sizeChanged = true;
-    } else {
-      this.sizeChanged = false;
-    }
-  }
-
-  render() {
+  render = () => {
     const {childGroups, termGroup} = this.props;
     if (termGroup.sessionUid) {
       return this.renderTerm(termGroup.sessionUid);
@@ -131,7 +130,7 @@ class TermGroup_ extends React.PureComponent {
     });
 
     return this.renderSplit(groups);
-  }
+  };
 }
 
 const TermGroup = connect(

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -70,16 +70,10 @@ export default class Term extends React.PureComponent {
     this.termRef = null;
     this.termWrapperRef = null;
     this.termRect = null;
-    this.onOpen = this.onOpen.bind(this);
-    this.onWindowResize = this.onWindowResize.bind(this);
-    this.onWindowPaste = this.onWindowPaste.bind(this);
-    this.onTermRef = this.onTermRef.bind(this);
-    this.onTermWrapperRef = this.onTermWrapperRef.bind(this);
-    this.onMouseUp = this.onMouseUp.bind(this);
     this.termOptions = {};
   }
 
-  componentDidMount() {
+  componentDidMount = () => {
     const {props} = this;
 
     this.termOptions = getTermOptions(props);
@@ -140,103 +134,9 @@ export default class Term extends React.PureComponent {
     });
 
     terms[this.props.uid] = this;
-  }
+  };
 
-  onOpen(termOptions) {
-    // we need to delay one frame so that styles
-    // get applied and we can make an accurate measurement
-    // of the container width and height
-    requestAnimationFrame(() => {
-      // at this point it would make sense for character
-      // measurement to have taken place but it seems that
-      // xterm.js might be doing this asynchronously, so
-      // we force it instead
-      // eslint-disable-next-line no-debugger
-      //debugger;
-      this.term.charMeasure.measure(termOptions);
-      this.fitResize();
-    });
-  }
-
-  getTermDocument() {
-    // eslint-disable-next-line no-console
-    console.warn(
-      'The underlying terminal engine of Hyper no longer ' +
-        'uses iframes with individual `document` objects for each ' +
-        'terminal instance. This method call is retained for ' +
-        "backwards compatibility reasons. It's ok to attach directly" +
-        'to the `document` object of the main `window`.'
-    );
-    return document;
-  }
-
-  onWindowResize() {
-    this.fitResize();
-  }
-
-  // intercepting paste event for any necessary processing of
-  // clipboard data, if result is falsy, paste event continues
-  onWindowPaste(e) {
-    if (!this.props.isTermActive) return;
-
-    const processed = processClipboard();
-    if (processed) {
-      e.preventDefault();
-      e.stopPropagation();
-      this.term.send(processed);
-    }
-  }
-
-  onMouseUp(e) {
-    if (this.props.quickEdit && e.button === 2) {
-      if (this.term.hasSelection()) {
-        clipboard.writeText(this.term.getSelection());
-        this.term.clearSelection();
-      } else {
-        document.execCommand('paste');
-      }
-    } else if (this.props.copyOnSelect && this.term.hasSelection()) {
-      clipboard.writeText(this.term.getSelection());
-    }
-  }
-
-  write(data) {
-    this.term.write(data);
-  }
-
-  focus() {
-    this.term.focus();
-  }
-
-  clear() {
-    this.term.clear();
-  }
-
-  reset() {
-    this.term.reset();
-  }
-
-  resize(cols, rows) {
-    this.term.resize(cols, rows);
-  }
-
-  selectAll() {
-    this.term.selectAll();
-  }
-
-  fitResize() {
-    if (!this.termWrapperRef) {
-      return;
-    }
-    this.term.fit();
-  }
-
-  keyboardHandler(e) {
-    // Has Mousetrap flagged this event as a command?
-    return !e.catched;
-  }
-
-  componentWillReceiveProps(nextProps) {
+  componentWillReceiveProps = nextProps => {
     if (!this.props.cleared && nextProps.cleared) {
       this.clear();
     }
@@ -283,17 +183,9 @@ export default class Term extends React.PureComponent {
     if (nextProps.rows !== this.props.rows || nextProps.cols !== this.props.cols) {
       this.resize(nextProps.cols, nextProps.rows);
     }
-  }
+  };
 
-  onTermWrapperRef(component) {
-    this.termWrapperRef = component;
-  }
-
-  onTermRef(component) {
-    this.termRef = component;
-  }
-
-  componentWillUnmount() {
+  componentWillUnmount = () => {
     terms[this.props.uid] = null;
     this.props.ref_(this.props.uid, null);
 
@@ -310,9 +202,111 @@ export default class Term extends React.PureComponent {
     window.removeEventListener('paste', this.onWindowPaste, {
       capture: true
     });
-  }
+  };
 
-  render() {
+  onOpen = termOptions => {
+    // we need to delay one frame so that styles
+    // get applied and we can make an accurate measurement
+    // of the container width and height
+    requestAnimationFrame(() => {
+      // at this point it would make sense for character
+      // measurement to have taken place but it seems that
+      // xterm.js might be doing this asynchronously, so
+      // we force it instead
+      // eslint-disable-next-line no-debugger
+      //debugger;
+      this.term.charMeasure.measure(termOptions);
+      this.fitResize();
+    });
+  };
+
+  getTermDocument = () => {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'The underlying terminal engine of Hyper no longer ' +
+        'uses iframes with individual `document` objects for each ' +
+        'terminal instance. This method call is retained for ' +
+        "backwards compatibility reasons. It's ok to attach directly" +
+        'to the `document` object of the main `window`.'
+    );
+    return document;
+  };
+
+  onWindowResize = () => {
+    this.fitResize();
+  };
+
+  // intercepting paste event for any necessary processing of
+  // clipboard data, if result is falsy, paste event continues
+  onWindowPaste = e => {
+    if (!this.props.isTermActive) return;
+
+    const processed = processClipboard();
+    if (processed) {
+      e.preventDefault();
+      e.stopPropagation();
+      this.term.send(processed);
+    }
+  };
+
+  onMouseUp = e => {
+    if (this.props.quickEdit && e.button === 2) {
+      if (this.term.hasSelection()) {
+        clipboard.writeText(this.term.getSelection());
+        this.term.clearSelection();
+      } else {
+        document.execCommand('paste');
+      }
+    } else if (this.props.copyOnSelect && this.term.hasSelection()) {
+      clipboard.writeText(this.term.getSelection());
+    }
+  };
+
+  write = data => {
+    this.term.write(data);
+  };
+
+  focus = () => {
+    this.term.focus();
+  };
+
+  clear = () => {
+    this.term.clear();
+  };
+
+  reset = () => {
+    this.term.reset();
+  };
+
+  resize = (cols, rows) => {
+    this.term.resize(cols, rows);
+  };
+
+  selectAll = () => {
+    this.term.selectAll();
+  };
+
+  fitResize = () => {
+    if (!this.termWrapperRef) {
+      return;
+    }
+    this.term.fit();
+  };
+
+  keyboardHandler = e => {
+    // Has Mousetrap flagged this event as a command?
+    return !e.catched;
+  };
+
+  onTermWrapperRef = component => {
+    this.termWrapperRef = component;
+  };
+
+  onTermRef = component => {
+    this.termRef = component;
+  };
+
+  render = () => {
     return (
       <div
         className={`term_fit ${this.props.isTermActive ? 'term_active' : ''}`}
@@ -339,5 +333,5 @@ export default class Term extends React.PureComponent {
         `}</style>
       </div>
     );
-  }
+  };
 }

--- a/lib/components/terms.js
+++ b/lib/components/terms.js
@@ -14,12 +14,11 @@ export default class Terms extends React.Component {
     super(props, context);
     this.terms = {};
     this.bound = new WeakMap();
-    this.onRef = this.onRef.bind(this);
     this.registerCommands = registerCommandHandlers;
     props.ref_(this);
   }
 
-  shouldComponentUpdate(nextProps) {
+  shouldComponentUpdate = nextProps => {
     for (const i in nextProps) {
       if (i === 'write') {
         continue;
@@ -37,45 +36,45 @@ export default class Terms extends React.Component {
       }
     }
     return false;
-  }
+  };
 
-  onRef(uid, term) {
-    if (term) {
-      this.terms[uid] = term;
-    } else if (!this.props.sessions[uid]) {
-      delete this.terms[uid];
-    }
-  }
-
-  getTermByUid(uid) {
-    return this.terms[uid];
-  }
-
-  getActiveTerm() {
-    return this.getTermByUid(this.props.activeSession);
-  }
-
-  getLastTermIndex() {
-    return this.props.sessions.length - 1;
-  }
-
-  onTerminal(uid, term) {
-    this.terms[uid] = term;
-  }
-
-  componentDidMount() {
+  componentDidMount = () => {
     window.addEventListener('contextmenu', () => {
       const selection = window.getSelection().toString();
       const {props: {uid}} = this.getActiveTerm();
       this.props.onContextMenu(uid, selection);
     });
-  }
+  };
 
-  componentWillUnmount() {
+  componentWillUnmount = () => {
     this.props.ref_(null);
-  }
+  };
 
-  render() {
+  onRef = (uid, term) => {
+    if (term) {
+      this.terms[uid] = term;
+    } else if (!this.props.sessions[uid]) {
+      delete this.terms[uid];
+    }
+  };
+
+  getTermByUid = uid => {
+    return this.terms[uid];
+  };
+
+  getActiveTerm = () => {
+    return this.getTermByUid(this.props.activeSession);
+  };
+
+  getLastTermIndex = () => {
+    return this.props.sessions.length - 1;
+  };
+
+  onTerminal = (uid, term) => {
+    this.terms[uid] = term;
+  };
+
+  render = () => {
     const shift = !isMac && this.props.termGroups.length > 1;
     return (
       <div className={`terms_terms ${shift ? 'terms_termsShifted' : ''}`}>
@@ -165,5 +164,5 @@ export default class Terms extends React.Component {
         `}</style>
       </div>
     );
-  }
+  };
 }

--- a/package.json
+++ b/package.json
@@ -231,6 +231,7 @@
     "babel-core": "6.26.0",
     "babel-eslint": "8.2.6",
     "babel-loader": "7.1.2",
+    "babel-plugin-transform-class-properties": "6.24.1",
     "babel-preset-babili": "0.1.4",
     "babel-preset-react": "6.24.1",
     "copy-webpack-plugin": "4.3.1",

--- a/package.json
+++ b/package.json
@@ -12,14 +12,20 @@
     "prepush": "yarn test",
     "postinstall": "electron-builder install-app-deps && yarn run rebuild-node-pty",
     "rebuild-node-pty": "electron-rebuild -f -w app/node_modules/node-pty -m app",
-    "dist":
-      "yarn run build && cross-env BABEL_ENV=production babel --out-file app/renderer/bundle.js --no-comments --minified app/renderer/bundle.js && build",
-    "clean":
-      "node ./bin/rimraf-standalone.js node_modules && node ./bin/rimraf-standalone.js ./app/node_modules && node ./bin/rimraf-standalone.js ./app/renderer"
+    "dist": "yarn run build && cross-env BABEL_ENV=production babel --out-file app/renderer/bundle.js --no-comments --minified app/renderer/bundle.js && build",
+    "clean": "node ./bin/rimraf-standalone.js node_modules && node ./bin/rimraf-standalone.js ./app/node_modules && node ./bin/rimraf-standalone.js ./app/renderer"
   },
   "eslintConfig": {
-    "plugins": ["react", "prettier"],
-    "extends": ["eslint:recommended", "plugin:react/recommended", "prettier"],
+    "plugins": [
+      "react",
+      "prettier"
+    ],
+    "extends": [
+      "eslint:recommended",
+      "plugin:react/recommended",
+      "prettier"
+    ],
+    "parser": "babel-eslint",
     "parserOptions": {
       "ecmaVersion": 8,
       "sourceType": "module",
@@ -36,7 +42,10 @@
       "node": true
     },
     "rules": {
-      "func-names": ["error", "as-needed"],
+      "func-names": [
+        "error",
+        "as-needed"
+      ],
       "no-shadow": "error",
       "no-extra-semi": 0,
       "react/prop-types": 0,
@@ -82,7 +91,9 @@
     ]
   },
   "babel": {
-    "presets": ["react"],
+    "presets": [
+      "react"
+    ],
     "plugins": [
       [
         "styled-jsx/babel",
@@ -127,7 +138,9 @@
       {
         "from": "./build/${os}/",
         "to": "./bin/",
-        "filter": ["hyper*"]
+        "filter": [
+          "hyper*"
+        ]
       }
     ],
     "linux": {
@@ -135,20 +148,28 @@
       "target": [
         {
           "target": "deb",
-          "arch": ["x64"]
+          "arch": [
+            "x64"
+          ]
         },
         {
           "target": "AppImage",
-          "arch": ["x64"]
+          "arch": [
+            "x64"
+          ]
         },
         {
           "target": "rpm",
-          "arch": ["x64"]
+          "arch": [
+            "x64"
+          ]
         }
       ]
     },
     "win": {
-      "target": ["squirrel"],
+      "target": [
+        "squirrel"
+      ],
       "rfc3161TimeStampServer": "http://timestamp.comodoca.com"
     },
     "mac": {
@@ -163,7 +184,9 @@
     },
     "protocols": {
       "name": "ssh URL",
-      "schemes": ["ssh"]
+      "schemes": [
+        "ssh"
+      ]
     }
   },
   "license": "MIT",
@@ -206,6 +229,7 @@
     "ava": "0.25.0",
     "babel-cli": "6.26.0",
     "babel-core": "6.26.0",
+    "babel-eslint": "8.2.6",
     "babel-loader": "7.1.2",
     "babel-preset-babili": "0.1.4",
     "babel-preset-react": "6.24.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,7 +23,10 @@ module.exports = [
         {
           test: /\.(js|jsx)$/,
           exclude: /node_modules/,
-          loader: 'babel-loader'
+          loader: 'babel-loader',
+          query: {
+            plugins: ['transform-class-properties']
+          }
         },
         {
           test: /\.json/,

--- a/yarn.lock
+++ b/yarn.lock
@@ -62,6 +62,82 @@
     imurmurhash "^0.1.4"
     slide "^1.1.5"
 
+"@babel/code-frame@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz#2a02643368de80916162be70865c97774f3adbd9"
+  dependencies:
+    "@babel/highlight" "7.0.0-beta.44"
+
+"@babel/generator@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.0.0-beta.44.tgz#c7e67b9b5284afcf69b309b50d7d37f3e5033d42"
+  dependencies:
+    "@babel/types" "7.0.0-beta.44"
+    jsesc "^2.5.1"
+    lodash "^4.2.0"
+    source-map "^0.5.0"
+    trim-right "^1.0.1"
+
+"@babel/helper-function-name@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz#e18552aaae2231100a6e485e03854bc3532d44dd"
+  dependencies:
+    "@babel/helper-get-function-arity" "7.0.0-beta.44"
+    "@babel/template" "7.0.0-beta.44"
+    "@babel/types" "7.0.0-beta.44"
+
+"@babel/helper-get-function-arity@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz#d03ca6dd2b9f7b0b1e6b32c56c72836140db3a15"
+  dependencies:
+    "@babel/types" "7.0.0-beta.44"
+
+"@babel/helper-split-export-declaration@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz#c0b351735e0fbcb3822c8ad8db4e583b05ebd9dc"
+  dependencies:
+    "@babel/types" "7.0.0-beta.44"
+
+"@babel/highlight@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0-beta.44.tgz#18c94ce543916a80553edcdcf681890b200747d5"
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^3.0.0"
+
+"@babel/template@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.44.tgz#f8832f4fdcee5d59bf515e595fc5106c529b394f"
+  dependencies:
+    "@babel/code-frame" "7.0.0-beta.44"
+    "@babel/types" "7.0.0-beta.44"
+    babylon "7.0.0-beta.44"
+    lodash "^4.2.0"
+
+"@babel/traverse@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.0.0-beta.44.tgz#a970a2c45477ad18017e2e465a0606feee0d2966"
+  dependencies:
+    "@babel/code-frame" "7.0.0-beta.44"
+    "@babel/generator" "7.0.0-beta.44"
+    "@babel/helper-function-name" "7.0.0-beta.44"
+    "@babel/helper-split-export-declaration" "7.0.0-beta.44"
+    "@babel/types" "7.0.0-beta.44"
+    babylon "7.0.0-beta.44"
+    debug "^3.1.0"
+    globals "^11.1.0"
+    invariant "^2.2.0"
+    lodash "^4.2.0"
+
+"@babel/types@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.44.tgz#6b1b164591f77dec0a0342aca995f2d046b3a757"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.2.0"
+    to-fast-properties "^2.0.0"
+
 "@concordance/react@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@concordance/react/-/react-1.0.0.tgz#fcf3cad020e5121bfd1c61d05bc3516aac25f734"
@@ -557,6 +633,17 @@ babel-core@6.26.0, babel-core@^6.17.0, babel-core@^6.26.0:
     private "^0.1.7"
     slash "^1.0.0"
     source-map "^0.5.6"
+
+babel-eslint@8.2.6:
+  version "8.2.6"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-8.2.6.tgz#6270d0c73205628067c0f7ae1693a9e797acefd9"
+  dependencies:
+    "@babel/code-frame" "7.0.0-beta.44"
+    "@babel/traverse" "7.0.0-beta.44"
+    "@babel/types" "7.0.0-beta.44"
+    babylon "7.0.0-beta.44"
+    eslint-scope "3.7.1"
+    eslint-visitor-keys "^1.0.0"
 
 babel-generator@^6.1.0, babel-generator@^6.26.0:
   version "6.26.1"
@@ -1065,6 +1152,10 @@ babel-types@6.26.0, babel-types@^6.24.1, babel-types@^6.26.0:
     esutils "^2.0.2"
     lodash "^4.17.4"
     to-fast-properties "^1.0.3"
+
+babylon@7.0.0-beta.44:
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.44.tgz#89159e15e6e30c5096e22d738d8c0af8a0e8ca1d"
 
 babylon@^6.1.0, babylon@^6.18.0:
   version "6.18.0"
@@ -2514,12 +2605,16 @@ eslint-plugin-react@7.3.0:
     jsx-ast-utils "^2.0.0"
     prop-types "^15.5.10"
 
-eslint-scope@^3.7.1:
+eslint-scope@3.7.1, eslint-scope@^3.7.1:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
   dependencies:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
+
+eslint-visitor-keys@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
 
 eslint@4.7.2:
   version "4.7.2"
@@ -3025,6 +3120,10 @@ global-dirs@^0.1.0:
   dependencies:
     ini "^1.3.4"
 
+globals@^11.1.0:
+  version "11.7.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.7.0.tgz#a583faa43055b1aca771914bf68258e2fc125673"
+
 globals@^9.17.0, globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
@@ -3433,6 +3532,12 @@ invariant@^2.0.0, invariant@^2.2.2:
   dependencies:
     loose-envify "^1.0.0"
 
+invariant@^2.2.0:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
+  dependencies:
+    loose-envify "^1.0.0"
+
 invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
@@ -3759,6 +3864,10 @@ jsesc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
 
+jsesc@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.1.tgz#e421a2a8e20d6b0819df28908f782526b96dd1fe"
+
 jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
@@ -4010,6 +4119,10 @@ lodash.uniq@^4.5.0:
 lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.8.0, lodash@~4.17.4:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
+
+lodash@^4.2.0:
+  version "4.17.10"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
 log-symbols@^1.0.2:
   version "1.0.2"
@@ -6257,6 +6370,10 @@ to-arraybuffer@^1.0.0:
 to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
+
+to-fast-properties@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
 
 tough-cookie@~2.3.0, tough-cookie@~2.3.3:
   version "2.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -868,6 +868,10 @@ babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
 
+babel-plugin-syntax-class-properties@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz#d7eb23b79a317f8543962c505b827c7d6cac27de"
+
 babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
@@ -895,6 +899,15 @@ babel-plugin-transform-async-to-generator@^6.16.0:
     babel-helper-remap-async-to-generator "^6.24.1"
     babel-plugin-syntax-async-functions "^6.8.0"
     babel-runtime "^6.22.0"
+
+babel-plugin-transform-class-properties@6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz#6a79763ea61d33d36f37b611aa9def81a81b46ac"
+  dependencies:
+    babel-helper-function-name "^6.24.1"
+    babel-plugin-syntax-class-properties "^6.8.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
 
 babel-plugin-transform-es2015-destructuring@^6.19.0:
   version "6.23.0"


### PR DESCRIPTION
<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`
- If your PR changes some API, please make a PR for hyper website too: https://github.com/zeit/hyper-site.

Thanks, again! -->
This refactors components to use arrow functions. By using arrow functions, we can remove the code inside constructors that bind the class methods to `this`. Also, this refactor groups methods related to the React lifecycle closer together. Functionally, nothing should change. 

Because arrow functions are not fully supported in JavaScript, I added the `babel-eslint` and `babel-plugin-transform-class-properties` packages to fix linting/webpack errors.

This should be ready to merge.