### PR TITLE
Added startup directory option, addressing #3000

### DIFF
--- a/app/config/config-default.js
+++ b/app/config/config-default.js
@@ -57,6 +57,10 @@ module.exports = {
     // custom CSS to embed in the terminal window
     termCSS: '',
 
+    // Default startup directory, if not supplied on command line.
+    // Must be an absolute path.
+    workingDirectory: '',
+
     // if you're using a Linux setup which show native menus, set to false
     // default: `true` on Linux, `true` on Windows, ignored on macOS
     showHamburgerMenu: '',

--- a/app/index.js
+++ b/app/index.js
@@ -55,6 +55,7 @@ const {resolve} = require('path');
 const {app, BrowserWindow, Menu} = require('electron');
 const {gitDescribe} = require('git-describe');
 const isDev = require('electron-is-dev');
+const {isAbsolute} = require('path');
 
 const config = require('./config');
 
@@ -155,7 +156,9 @@ app.on('ready', () =>
           [startX, startY] = config.windowDefaults.windowPosition;
         }
 
-        const hwin = new Window({width, height, x: startX, y: startY}, cfg, fn);
+        let workingDirectory = process.argv[1] && isAbsolute(process.argv[1]) ? process.argv[1] : null;
+
+        const hwin = new Window({width, height, x: startX, y: startY, workingDirectory: workingDirectory}, cfg, fn);
         windowSet.add(hwin);
         hwin.loadURL(url);
 

--- a/app/ui/window.js
+++ b/app/ui/window.js
@@ -85,12 +85,20 @@ module.exports = class Window {
       }
     });
 
+    let cwd = cfgDir;
+    // Check if working directory is set in options or in config
+    if (winOpts.workingDirectory) {
+      cwd = winOpts.workingDirectory;
+    } else if (cfg.workingDirectory && isAbsolute(cfg.workingDirectory)) {
+      cwd = cfg.workingDirectory;
+    }
+
     rpc.on('new', options => {
       const sessionOpts = Object.assign(
         {
           rows: 40,
           cols: 100,
-          cwd: process.argv[1] && isAbsolute(process.argv[1]) ? process.argv[1] : cfgDir,
+          cwd: cwd,
           splitDirection: undefined,
           shell: cfg.shell,
           shellArgs: cfg.shellArgs && Array.from(cfg.shellArgs)


### PR DESCRIPTION
Based off @mtslzr's work

- Added workingDirectory config option
- Moved parsing  to index.js, as requested. Not sure about this change, requires an additional import in index.js.
- Startup directory heirarchy: command line -> config -> home dir

<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`
- If your PR changes some API, please make a PR for hyper website too: https://github.com/zeit/hyper-site.

Thanks, again! -->
