### PR TITLE
Add snapcraft build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ addons:
       - snapd
 
 before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo snap install snapcraft --classic; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start; sleep 3; fi
 
 cache: yarn

--- a/package.json
+++ b/package.json
@@ -144,6 +144,10 @@
         {
           "target": "rpm",
           "arch": ["x64"]
+        },
+        {
+          "target": "snap",
+          "arch": ["x64"]
         }
       ]
     },


### PR DESCRIPTION
Not sure why this was removed at some point but I got it working on my pc. The only thing left is to upload the snap to snapcraft (https://docs.snapcraft.io/build-snaps/electron) and set up the github integration for automatic builds and updates (https://snapcraft.io/build)

This is related to https://github.com/zeit/hyper/issues/1229