### PR TITLE
Improve detection of selected editor on Windows

### DIFF
--- a/app/config/open.js
+++ b/app/config/open.js
@@ -25,8 +25,8 @@ if (process.platform === 'win32') {
     });
 
     // Find UserChoice key
-    const userChoice = keys.filter(k => k.key.endsWith('UserChoice'));
-    return userChoice[0];
+    const userChoice = keys.find(k => k.key.endsWith('UserChoice'));
+    return userChoice;
   };
 
   const hasDefaultSet = async () => {
@@ -44,8 +44,8 @@ if (process.platform === 'win32') {
     });
 
     // Look for default program
-    const hasDefaultProgramConfigured = values.some(
-      value => value && typeof value === 'string' && value.endsWith('.exe') && !value.includes('WScript.exe')
+    const hasDefaultProgramConfigured = values.every(
+      value => value && typeof value === 'string' && !value.includes('WScript.exe') && !value.includes('JSFile')
     );
 
     return hasDefaultProgramConfigured;


### PR DESCRIPTION
Improves upon previous work completed in #2631:

- Add additional system default check: `JSFile`
- Relax restriction on `.exe` file extension as it is an invalid assumption:

![image](https://user-images.githubusercontent.com/4730164/46571838-26c4e180-c94a-11e8-84eb-77cd5d446efd.png)


---
Closes #3223

