### PR TITLE
Fix OS X 'reload' accelerator key mappings

### DIFF
--- a/app/keymaps/darwin.json
+++ b/app/keymaps/darwin.json
@@ -1,7 +1,7 @@
 {
   "window:devtools": "command+alt+i",
-  "window:reload": "command+r",
-  "window:reloadFull": "command+shift+r",
+  "window:reload": "command+shift+r",
+  "window:reloadFull": "command+shift+f5",
   "window:preferences": "command+,",
   "zoom:reset": "command+0",
   "zoom:in": "command+plus",


### PR DESCRIPTION
Changed OS X 'reload' accelerator key mappings be more in line with Linux & Windows and further away from browsers.

For people constantly switching between browser and command line, having `Cmd+R` nuking output in your hyper session is a killer...

Fixes #921