### PR TITLE
Fix CLI tool with python3

### DIFF
--- a/build/mac/hyper
+++ b/build/mac/hyper
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Deeply inspired by https://github.com/Microsoft/vscode/blob/1.17.0/resources/darwin/bin/code.sh
 
-function realpath() { /usr/bin/python -c "import os,sys; print os.path.realpath(sys.argv[1])" "$0"; }
+function realpath() { /usr/bin/python -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$0"; }
 CONTENTS="$(dirname "$(dirname "$(dirname "$(realpath "$0")")")")"
 ELECTRON="$CONTENTS/MacOS/Hyper"
 CLI="$CONTENTS/Resources/bin/cli.js"


### PR DESCRIPTION
I realise having ```python``` linked to ```python3``` is currently discouraged, but being compatible does not hurt, and may avoid problems whenever it becomes more common for python 3 to be the default.
