### PR TITLE
Optimistic session creation

### DIFF
--- a/app/ui/window.js
+++ b/app/ui/window.js
@@ -91,16 +91,16 @@ module.exports = class Window {
         const uid = uuid.v4();
         const session = new Session(Object.assign({}, options, {uid}));
         sessions.set(uid, session);
-        return { uid, session };
+        return {uid, session};
       }
 
       // Optimistically create the initial session so that when the window sends
       // the first "new" IPC message, there's a session already warmed up.
       function createInitialSession() {
-        let { session, uid }= createSession({});
+        let {session, uid} = createSession({});
         const initialEvents = [];
         const handleData = data => initialEvents.push(['session data', uid + data]);
-        const handleExit = () => initialEvents.push(['session exit'])
+        const handleExit = () => initialEvents.push(['session exit']);
         session.on('data', handleData);
         session.on('exit', handleExit);
 
@@ -111,7 +111,7 @@ module.exports = class Window {
           session.removeListener('data', handleData);
           session.removeListener('exit', handleExit);
         }
-        return { session, uid, flushEvents };
+        return {session, uid, flushEvents};
       }
       let initialSession = createInitialSession();
 
@@ -136,7 +136,7 @@ module.exports = class Window {
           options
         );
 
-        const { uid, session } = initialSession || createSession();
+        const {uid, session} = initialSession || createSession();
 
         sessions.set(uid, session);
         rpc.emit('session add', {

--- a/app/ui/window.js
+++ b/app/ui/window.js
@@ -87,6 +87,34 @@ module.exports = class Window {
         }
       });
 
+      function createSession(options) {
+        const uid = uuid.v4();
+        const session = new Session(Object.assign({}, options, {uid}));
+        sessions.set(uid, session);
+        return { uid, session };
+      }
+
+      // Optimistically create the initial session so that when the window sends
+      // the first "new" IPC message, there's a session already warmed up.
+      function createInitialSession() {
+        let { session, uid }= createSession({});
+        const initialEvents = [];
+        const handleData = data => initialEvents.push(['session data', uid + data]);
+        const handleExit = () => initialEvents.push(['session exit'])
+        session.on('data', handleData);
+        session.on('exit', handleExit);
+
+        function flushEvents() {
+          for (let args of initialEvents) {
+            rpc.emit(...args);
+          }
+          session.removeListener('data', handleData);
+          session.removeListener('exit', handleExit);
+        }
+        return { session, uid, flushEvents };
+      }
+      let initialSession = createInitialSession();
+
       rpc.on('new', options => {
         let cwd = null;
         if (workingDirectory) {
@@ -108,29 +136,32 @@ module.exports = class Window {
           options
         );
 
-        const initSession = (opts, fn_) => {
-          fn_(uuid.v4(), new Session(opts));
-        };
+        const { uid, session } = initialSession || createSession();
 
-        initSession(sessionOpts, (uid, session) => {
-          sessions.set(uid, session);
-          rpc.emit('session add', {
-            rows: sessionOpts.rows,
-            cols: sessionOpts.cols,
-            uid,
-            splitDirection: sessionOpts.splitDirection,
-            shell: session.shell,
-            pid: session.pty.pid
-          });
+        sessions.set(uid, session);
+        rpc.emit('session add', {
+          rows: sessionOpts.rows,
+          cols: sessionOpts.cols,
+          uid,
+          splitDirection: sessionOpts.splitDirection,
+          shell: session.shell,
+          pid: session.pty.pid
+        });
 
-          session.on('data', data => {
-            rpc.emit('session data', uid + data);
-          });
+        // If this is the initial session, flush any events that might have
+        // occurred while the window was initializing
+        if (initialSession) {
+          initialSession.flushEvents();
+          initialSession = null;
+        }
 
-          session.on('exit', () => {
-            rpc.emit('session exit', {uid});
-            sessions.delete(uid);
-          });
+        session.on('data', data => {
+          rpc.emit('session data', uid + data);
+        });
+
+        session.on('exit', () => {
+          rpc.emit('session exit', {uid});
+          sessions.delete(uid);
         });
       });
       rpc.on('exit', ({uid}) => {


### PR DESCRIPTION
## Problem
Launch takes too long

## Solution

Not a complete solution but an improvement.

Instead of waiting for the window to initialize then *then* send a `new` message so that we can create a new session. The session is optimistically created so that when the `new` messages is received, a session is already warmed up

## Benchmarks

This measures the time from when `app/index.js` first runs until the first `session data` message is sent to the renderer. Ran it 5 consecutive times.

canary: `749, 728, 765, 777, 762`
this branch: `617, 656, 615, 590, 596`

Averages:

| canary | this branch | diff |
|----|----|----|
| 756ms | 614ms | 142ms |

Not a hell of a lot but doesn't hurt either. I've only tested on Linux, but [should help even more on other platforms](https://stackoverflow.com/a/51396188/653799)