### PR TITLE
WebGL renderer (using xterm.js fork)

### DIFF
--- a/app/config/config-default.js
+++ b/app/config/config-default.js
@@ -144,6 +144,8 @@ module.exports = {
   // to load it and avoid it being `npm install`ed
   localPlugins: [],
 
+  webGLRenderer: true,
+
   keymaps: {
     // Example
     // 'window:devtools': 'cmd+alt+o',

--- a/lib/components/term-group.js
+++ b/lib/components/term-group.js
@@ -92,6 +92,7 @@ class TermGroup_ extends React.PureComponent {
       borderColor: this.props.borderColor,
       selectionColor: this.props.selectionColor,
       quickEdit: this.props.quickEdit,
+      webGLRenderer: this.props.webGLRenderer,
       uid
     });
 

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -36,8 +36,8 @@ const getTermOptions = props => {
     lineHeight: props.lineHeight,
     letterSpacing: props.letterSpacing,
     allowTransparency: needTransparency,
-    experimentalCharAtlas: 'webgl',
-    rendererType: 'webgl',
+    experimentalCharAtlas: props.webGLRenderer ? 'webgl' : 'dynamic',
+    rendererType: props.webGLRenderer ? 'webgl' : 'canvas',
     theme: {
       foreground: props.foregroundColor,
       background: backgroundColor,

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -36,7 +36,8 @@ const getTermOptions = props => {
     lineHeight: props.lineHeight,
     letterSpacing: props.letterSpacing,
     allowTransparency: needTransparency,
-    experimentalCharAtlas: 'dynamic',
+    experimentalCharAtlas: 'webgl',
+    rendererType: 'webgl',
     theme: {
       foreground: props.foregroundColor,
       background: backgroundColor,

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -36,8 +36,10 @@ const getTermOptions = props => {
     lineHeight: props.lineHeight,
     letterSpacing: props.letterSpacing,
     allowTransparency: needTransparency,
-    experimentalCharAtlas: props.webGLRenderer ? 'webgl' : 'dynamic',
+    // HACK: Terminal.setOption breaks if we don't apply these in this order
+    // TODO: This can be removed once this is addressed
     rendererType: props.webGLRenderer ? 'webgl' : 'canvas',
+    experimentalCharAtlas: props.webGLRenderer ? 'webgl' : 'dynamic',
     theme: {
       foreground: props.foregroundColor,
       background: backgroundColor,
@@ -244,7 +246,17 @@ export default class Term extends React.PureComponent {
     // Update only options that have changed.
     Object.keys(nextTermOptions)
       .filter(option => option !== 'theme' && nextTermOptions[option] !== this.termOptions[option])
-      .forEach(option => this.term.setOption(option, nextTermOptions[option]));
+      .forEach(option => {
+        try {
+          this.term.setOption(option, nextTermOptions[option]);
+        } catch (e) {
+          if (/The webgl renderer only works with the webgl char atlas/i.test(e.message)) {
+            // Ignore this because the char atlas will also be changed
+          } else {
+            throw e;
+          }
+        }
+      });
 
     // Do we need to update theme?
     const shouldUpdateTheme =

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -46,7 +46,11 @@ const getTermOptions = props => {
       background: backgroundColor,
       cursor: props.cursorColor,
       cursorAccent: props.cursorAccentColor,
-      selection: props.selectionColor,
+      // TODO: This hard codes the selection color to opaque white because the
+      // webgl renderer doesn't support anything else at the moment. Remove this
+      // once WebGL gets support for selection color. Discussed here:
+      // https://github.com/xtermjs/xterm.js/pull/1790
+      selection: props.webGLRenderer ? '#fff' : props.selectionColor,
       black: props.colors.black,
       red: props.colors.red,
       green: props.colors.green,
@@ -262,6 +266,7 @@ export default class Term extends React.PureComponent {
     // Do we need to update theme?
     const shouldUpdateTheme =
       !this.termOptions.theme ||
+      nextTermOptions.rendererType !== this.termOptions.rendererType ||
       Object.keys(nextTermOptions.theme).some(
         option => nextTermOptions.theme[option] !== this.termOptions.theme[option]
       );

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -37,7 +37,8 @@ const getTermOptions = props => {
     letterSpacing: props.letterSpacing,
     allowTransparency: needTransparency,
     // HACK: Terminal.setOption breaks if we don't apply these in this order
-    // TODO: This can be removed once this is addressed
+    // TODO: The above notice can be removed once this is addressed:
+    // https://github.com/xtermjs/xterm.js/pull/1790#issuecomment-450000121
     rendererType: props.webGLRenderer ? 'webgl' : 'canvas',
     experimentalCharAtlas: props.webGLRenderer ? 'webgl' : 'dynamic',
     theme: {

--- a/lib/components/terms.js
+++ b/lib/components/terms.js
@@ -116,6 +116,7 @@ export default class Terms extends React.Component {
             onURLAbort: this.props.onURLAbort,
             onContextMenu: this.props.onContextMenu,
             quickEdit: this.props.quickEdit,
+            webGLRenderer: this.props.webGLRenderer,
             parentProps: this.props
           });
 

--- a/lib/containers/terms.js
+++ b/lib/containers/terms.js
@@ -45,7 +45,8 @@ const TermsContainer = connect(
       bellSoundURL: state.ui.bellSoundURL,
       copyOnSelect: state.ui.copyOnSelect,
       modifierKeys: state.ui.modifierKeys,
-      quickEdit: state.ui.quickEdit
+      quickEdit: state.ui.quickEdit,
+      webGLRenderer: state.ui.webGLRenderer,
     };
   },
   dispatch => {

--- a/lib/containers/terms.js
+++ b/lib/containers/terms.js
@@ -46,7 +46,7 @@ const TermsContainer = connect(
       copyOnSelect: state.ui.copyOnSelect,
       modifierKeys: state.ui.modifierKeys,
       quickEdit: state.ui.quickEdit,
-      webGLRenderer: state.ui.webGLRenderer,
+      webGLRenderer: state.ui.webGLRenderer
     };
   },
   dispatch => {

--- a/lib/reducers/ui.js
+++ b/lib/reducers/ui.js
@@ -97,7 +97,7 @@ const initial = Immutable({
   showHamburgerMenu: '',
   showWindowControls: '',
   quickEdit: false,
-  webGLRenderer: true,
+  webGLRenderer: true
 });
 
 const currentWindow = remote.getCurrentWindow();

--- a/lib/reducers/ui.js
+++ b/lib/reducers/ui.js
@@ -96,7 +96,8 @@ const initial = Immutable({
   },
   showHamburgerMenu: '',
   showWindowControls: '',
-  quickEdit: false
+  quickEdit: false,
+  webGLRenderer: true,
 });
 
 const currentWindow = remote.getCurrentWindow();
@@ -235,6 +236,10 @@ const reducer = (state = initial, action) => {
               ret.quickEdit = true;
             } else if (typeof config.quickEdit !== 'undefined' && config.quickEdit !== null) {
               ret.quickEdit = config.quickEdit;
+            }
+
+            if (typeof config.webGLRenderer !== undefined) {
+              ret.webGLRenderer = config.webGLRenderer;
             }
 
             ret._lastUpdate = now;

--- a/package.json
+++ b/package.json
@@ -207,7 +207,7 @@
     "styled-jsx": "2.2.6",
     "stylis": "3.5.0",
     "uuid": "3.1.0",
-    "xterm": "3.9.1"
+    "xterm": "https://registry.npmjs.org/@zeit/xterm/-/xterm-3.9.1.tgz"
   },
   "devDependencies": {
     "ava": "0.25.0",
@@ -237,7 +237,6 @@
     "webpack": "3.10.0"
   },
   "resolutions": {
-    "rc": "1.2.3",
-    "xterm": "@zeit/xterm@3.9.1"
+    "rc": "1.2.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -237,6 +237,7 @@
     "webpack": "3.10.0"
   },
   "resolutions": {
-    "rc": "1.2.3"
+    "rc": "1.2.3",
+    "xterm": "@zeit/xterm@3.9.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7111,10 +7111,9 @@ xtend@~2.1.1:
   dependencies:
     object-keys "~0.4.0"
 
-xterm@3.9.1:
+"xterm@https://registry.npmjs.org/@zeit/xterm/-/xterm-3.9.1.tgz":
   version "3.9.1"
-  resolved "https://registry.yarnpkg.com/xterm/-/xterm-3.9.1.tgz#65756beb09bb6fb44aeb29032adcd6789aaaa5f4"
-  integrity sha512-5AZlhP0jvH/Sskx1UvvNFMqDRHVFqapl59rjV3RRpTJmveoharJplxPfzSThk85I4+AZo2xvD0X0nh0AAzkeZQ==
+  resolved "https://registry.npmjs.org/@zeit/xterm/-/xterm-3.9.1.tgz#576ba39c4159e8a31540b98a2bfebda4940e98ed"
 
 y18n@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
This PR enables webGL rendering behind the `webGLRenderer` config flag. It uses our own fork of xterm.js which includes the webGL renderer by @Tyriar.

Although this renderer has [a few limitations](https://github.com/xtermjs/xterm.js/pull/1790) we are enabling it by default on the canary channel because we believe that the perf benefits outweight these limitations for most users. Additionally, we want to gather as much data as possible from the canary channel.

## Tests
 - [x] Canvas rendering still works
 - [x] WebGL rendering works
 - [x] Can hot-reload config

## Benchmarks

Coming up...