### PR TITLE
Updating xterm to include a selection outline

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,7 +207,7 @@
     "styled-jsx": "2.2.6",
     "stylis": "3.5.0",
     "uuid": "3.1.0",
-    "xterm": "https://registry.npmjs.org/@zeit/xterm/-/xterm-3.9.1.tgz"
+    "xterm": "https://registry.npmjs.org/@zeit/xterm/-/xterm-3.9.1-3.tgz"
   },
   "devDependencies": {
     "ava": "0.25.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7111,9 +7111,9 @@ xtend@~2.1.1:
   dependencies:
     object-keys "~0.4.0"
 
-"xterm@https://registry.npmjs.org/@zeit/xterm/-/xterm-3.9.1.tgz":
-  version "3.9.1"
-  resolved "https://registry.npmjs.org/@zeit/xterm/-/xterm-3.9.1.tgz#576ba39c4159e8a31540b98a2bfebda4940e98ed"
+"xterm@https://registry.npmjs.org/@zeit/xterm/-/xterm-3.9.1-3.tgz":
+  version "3.9.1-3"
+  resolved "https://registry.npmjs.org/@zeit/xterm/-/xterm-3.9.1-3.tgz#8fbdfa3dbfa1af6f3832aa7fc4313c8f19af0509"
 
 y18n@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
This is a stopgap measure to allow folks with white backgrounds to see what they are selecting. There's a simpler solution being worked on that we might use later on but this should do the trick for now.
