### PR TITLE
Configure Electron Builder to build Snap in classic confinement mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,6 +168,9 @@
     "rpm": {
       "afterInstall": "./build/linux/after-install.tpl"
     },
+    "snap": {
+      "confinement": "classic"
+    },
     "protocols": {
       "name": "ssh URL",
       "schemes": ["ssh"]


### PR DESCRIPTION
This is needed to allow Hyper to access files outside of its image such as `~/.hyper.js`. Related to #1229. This is ready for merge :+1: 

Documentation for this configuration is here:
https://www.electron.build/configuration/snap

If anyone would like to test, install the snap like so:
```bash
snap install --dangerous --classic ./dist/hyper_3.0.0-canary.1_amd64.snap
```