### PR TITLE
Fixed file paste

### DIFF
--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -189,7 +189,7 @@ export default class Term extends React.PureComponent {
     if (processed) {
       e.preventDefault();
       e.stopPropagation();
-      this.term.send(processed);
+      this.term._core.handler(processed);
     }
   }
 

--- a/lib/utils/paste.js
+++ b/lib/utils/paste.js
@@ -1,10 +1,16 @@
 import {clipboard} from 'electron';
+import plist from 'plist';
 
 const getPath = platform => {
   switch (platform) {
     case 'darwin': {
-      const filepath = clipboard.read('public.file-url');
-      return filepath.replace('file://', '');
+      if (clipboard.has('NSFilenamesPboardType')) {
+        // Parse plist file containing the path list of copied files
+        const list = plist.parse(clipboard.read('NSFilenamesPboardType'));
+        return "'" + list.join("' '") + "'";
+      } else {
+        return null;
+      }
     }
     case 'win32': {
       const filepath = clipboard.read('FileNameW');


### PR DESCRIPTION
This commit fixes zeit/hyper#3340.
Since `xterm.js` changed its interface, the `send()` method has been replaced by `handler()` method.
It also fixes macOS clipboard handling for files, discarding the `file-url` that could contain url-encoded string that wouldn’t work as path.

