### PR TITLE
Emoji Fix

### DIFF
--- a/app/keymaps/darwin.json
+++ b/app/keymaps/darwin.json
@@ -45,7 +45,6 @@
   "editor:deleteBeginningLine": "command+backspace",
   "editor:deleteEndLine": "command+delete",
   "editor:clearBuffer": "command+k",
-  "editor:emojis": "command+ctrl+space",
   "editor:break": "ctrl+c",
   "plugins:update": "command+shift+u"
 }

--- a/package.json
+++ b/package.json
@@ -210,7 +210,7 @@
     "styled-jsx": "2.2.6",
     "stylis": "3.5.0",
     "uuid": "3.1.0",
-    "xterm": "https://registry.npmjs.org/@zeit/xterm/-/xterm-3.9.1-3.tgz"
+    "xterm": "https://registry.npmjs.org/@zeit/xterm/-/xterm-3.10.0-1.tgz"
   },
   "devDependencies": {
     "ava": "0.25.0",


### PR DESCRIPTION
## Problem
cmd+ctrl+space didn't show the emoji dialog

## Solution
Stop intercepting this keymapping and let the browser handle it. This makes sense now that we're always using a `textarea` as our source of input

**NOTE:** The rest of the changes to make emoji work are on this PR: https://github.com/zeit/xterm.js/pull/6

![2019-01-04_16-24](https://user-images.githubusercontent.com/1410520/50713903-aabf6000-1044-11e9-996f-66021d08161e.png)
