### PR TITLE
 Upgrading xterm.js with a couple of emoji fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -210,7 +210,7 @@
     "styled-jsx": "2.2.6",
     "stylis": "3.5.0",
     "uuid": "3.1.0",
-    "xterm": "https://registry.npmjs.org/@zeit/xterm/-/xterm-3.10.0-1.tgz"
+    "xterm": "https://registry.npmjs.org/@zeit/xterm/-/xterm-3.10.0-2.tgz"
   },
   "devDependencies": {
     "ava": "0.25.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7112,9 +7112,9 @@ xtend@~2.1.1:
   dependencies:
     object-keys "~0.4.0"
 
-"xterm@https://registry.npmjs.org/@zeit/xterm/-/xterm-3.9.1-3.tgz":
-  version "3.9.1-3"
-  resolved "https://registry.npmjs.org/@zeit/xterm/-/xterm-3.9.1-3.tgz#8fbdfa3dbfa1af6f3832aa7fc4313c8f19af0509"
+"xterm@https://registry.npmjs.org/@zeit/xterm/-/xterm-3.10.0-2.tgz":
+  version "3.10.0-2"
+  resolved "https://registry.npmjs.org/@zeit/xterm/-/xterm-3.10.0-2.tgz#71944e492f4e0ba4e1b763ddedd8b30356b7a5cd"
 
 y18n@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
Addresses the feedback I got in https://github.com/zeit/xterm.js/pull/6, plus a couple additional fixes.

Needed for `3.0.0-canary.2`

https://github.com/zeit/xterm.js/pull/6 hasn't been merged but I want to move forward with canary-2 asap.