### PR TITLE
Add div wrappers around window controls svg elements

### DIFF
--- a/lib/components/header.js
+++ b/lib/components/header.js
@@ -128,18 +128,12 @@ export default class Header extends React.PureComponent {
             <span className="header_appTitle">{title}</span>
             {winCtrls && (
               <div className={`header_windowControls ${left ? 'header_windowControlsLeft' : ''}`}>
-                <div
-                  className={`${left ? 'header_minimizeWindowLeft' : ''}`}
-                  onClick={this.handleMinimizeClick}
-                >
+                <div className={`${left ? 'header_minimizeWindowLeft' : ''}`} onClick={this.handleMinimizeClick}>
                   <svg className="header_shape">
                     <use xlinkHref="./renderer/assets/icons.svg#minimize-window" />
                   </svg>
                 </div>
-                <div
-                  className={`${left ? 'header_maximizeWindowLeft' : ''}`}
-                  onClick={this.handleMaximizeClick}
-                >
+                <div className={`${left ? 'header_maximizeWindowLeft' : ''}`} onClick={this.handleMaximizeClick}>
                   <svg className="header_shape">
                     <use xlinkHref={maxButtonHref} />
                   </svg>
@@ -148,7 +142,7 @@ export default class Header extends React.PureComponent {
                   className={`header_closeWindow ${left ? 'header_closeWindowLeft' : ''}`}
                   onClick={this.handleCloseClick}
                 >
-                  <svg className="header_shape">>
+                  <svg className="header_shape">
                     <use xlinkHref="./renderer/assets/icons.svg#close-window" />
                   </svg>
                 </div>
@@ -198,7 +192,8 @@ export default class Header extends React.PureComponent {
             font-size: 12px;
           }
 
-          .header_shape, .header_shape > svg {
+          .header_shape,
+          .header_shape > svg {
             width: 40px;
             height: 34px;
             padding: 12px 15px 12px 15px;

--- a/lib/components/header.js
+++ b/lib/components/header.js
@@ -128,24 +128,30 @@ export default class Header extends React.PureComponent {
             <span className="header_appTitle">{title}</span>
             {winCtrls && (
               <div className={`header_windowControls ${left ? 'header_windowControlsLeft' : ''}`}>
-                <svg
-                  className={`header_shape ${left ? 'header_minimizeWindowLeft' : ''}`}
+                <div
+                  className={`${left ? 'header_minimizeWindowLeft' : ''}`}
                   onClick={this.handleMinimizeClick}
                 >
-                  <use xlinkHref="./renderer/assets/icons.svg#minimize-window" />
-                </svg>
-                <svg
-                  className={`header_shape ${left ? 'header_maximizeWindowLeft' : ''}`}
+                  <svg className="header_shape">
+                    <use xlinkHref="./renderer/assets/icons.svg#minimize-window" />
+                  </svg>
+                </div>
+                <div
+                  className={`${left ? 'header_maximizeWindowLeft' : ''}`}
                   onClick={this.handleMaximizeClick}
                 >
-                  <use xlinkHref={maxButtonHref} />
-                </svg>
-                <svg
-                  className={`header_shape header_closeWindow ${left ? 'header_closeWindowLeft' : ''}`}
+                  <svg className="header_shape">
+                    <use xlinkHref={maxButtonHref} />
+                  </svg>
+                </div>
+                <div
+                  className={`header_closeWindow ${left ? 'header_closeWindowLeft' : ''}`}
                   onClick={this.handleCloseClick}
                 >
-                  <use xlinkHref="./renderer/assets/icons.svg#close-window" />
-                </svg>
+                  <svg className="header_shape">>
+                    <use xlinkHref="./renderer/assets/icons.svg#close-window" />
+                  </svg>
+                </div>
               </div>
             )}
           </div>
@@ -192,7 +198,7 @@ export default class Header extends React.PureComponent {
             font-size: 12px;
           }
 
-          .header_shape {
+          .header_shape, .header_shape > svg {
             width: 40px;
             height: 34px;
             padding: 12px 15px 12px 15px;


### PR DESCRIPTION
Adding `div` wrapper around `svg` element allowing change style of window controls easily just by using css.

Reason for PR: 

You cant change `svg` path using css and you can't use `:after` or `:before` on element either.

Utilization of PR:

In my plugin [hyper-macos-mjv-dark-theme](https://github.com/jakub-chatrny/hyper-macos-mjv-dark-theme) (You can see image in readme)

- PR is ready to merge

- PR  allows edits from maintainers

- PR **do not** make any changes to API
