### PR TITLE
Upgrading xterm.js with the meta key fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -210,7 +210,7 @@
     "styled-jsx": "2.2.6",
     "stylis": "3.5.0",
     "uuid": "3.1.0",
-    "xterm": "https://registry.npmjs.org/@zeit/xterm/-/xterm-3.10.0-2.tgz"
+    "xterm": "https://registry.npmjs.org/@zeit/xterm/-/xterm-3.10.0-3.tgz"
   },
   "devDependencies": {
     "ava": "0.25.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7112,9 +7112,9 @@ xtend@~2.1.1:
   dependencies:
     object-keys "~0.4.0"
 
-"xterm@https://registry.npmjs.org/@zeit/xterm/-/xterm-3.10.0-2.tgz":
-  version "3.10.0-2"
-  resolved "https://registry.npmjs.org/@zeit/xterm/-/xterm-3.10.0-2.tgz#71944e492f4e0ba4e1b763ddedd8b30356b7a5cd"
+"xterm@https://registry.npmjs.org/@zeit/xterm/-/xterm-3.10.0-3.tgz":
+  version "3.10.0-3"
+  resolved "https://registry.npmjs.org/@zeit/xterm/-/xterm-3.10.0-3.tgz#6d16c260143073fc25e64f80b037d02a84c1ec18"
 
 y18n@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
Issue discussed here: https://github.com/xtermjs/xterm.js/pull/1885

`@zeit/xterm@3.10.0-3` was built from https://github.com/zeit/xterm.js/releases/tag/3.10.0-3

