### PR TITLE
Zoom with both cmd+= and cmd+plus

### DIFF
--- a/app/keymaps/darwin.json
+++ b/app/keymaps/darwin.json
@@ -4,7 +4,10 @@
   "window:reloadFull": "command+shift+f5",
   "window:preferences": "command+,",
   "zoom:reset": "command+0",
-  "zoom:in": "command+plus",
+  "zoom:in": [
+    "command+plus",
+    "command+="
+  ],
   "zoom:out": "command+-",
   "window:new": "command+n",
   "window:minimize": "command+m",


### PR DESCRIPTION
## Problem

The behavior of cmd+plus was changed in Electron v3 (see https://github.com/electron/electron/issues/14742) so that it now fires with cmd+shift+=

On MacOS we want to zoom in with cmd+= and cmd+shift+=

## Solution

Add multiple mappings