### PR TITLE
 Fix xterm.js resource leaks in split pane

### DIFF
--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -75,13 +75,11 @@ export default class Term extends React.PureComponent {
   constructor(props) {
     super(props);
     props.ref_(props.uid, this);
-    this.termRef = null;
     this.termWrapperRef = null;
     this.termRect = null;
     this.onOpen = this.onOpen.bind(this);
     this.onWindowResize = this.onWindowResize.bind(this);
     this.onWindowPaste = this.onWindowPaste.bind(this);
-    this.onTermRef = this.onTermRef.bind(this);
     this.onTermWrapperRef = this.onTermWrapperRef.bind(this);
     this.onMouseUp = this.onMouseUp.bind(this);
     this.termOptions = {};
@@ -91,34 +89,23 @@ export default class Term extends React.PureComponent {
   componentDidMount() {
     const {props} = this;
 
-    if (props.term) {
-      let _core = props.term._core;
-      // Release listeners and disposables
-      _core._disposables.forEach(d => d.dispose());
-      _core._disposables.length = 0;
-      _core._events = {};
-      // Release listeners set by LinkRenderLayer
-      _core.linkifier._events = {};
-      // Release listeners set by SelectionManager
-      _core.buffers._events = {};
-      _core.buffer.lines._events = {};
-      _core.selectionManager.dispose();
-      // Restore disposed InputHandler
-      _core._inputHandler = new _core._inputHandler.constructor(_core);
-      _core.register(_core._inputHandler);
-    }
-
     this.termOptions = getTermOptions(props);
     this.term = props.term || new Terminal(this.termOptions);
-    this.term.attachCustomKeyEventHandler(this.keyboardHandler);
-    this.term.open(this.termRef);
-    this.term.webLinksInit();
-    this.term.winptyCompatInit();
 
-    if (props.term) {
-      //We need to set options again after reattaching an existing term
-      Object.keys(this.termOptions).forEach(option => this.term.setOption(option, this.termOptions[option]));
+    // The parent element for the terminal is attached and removed manually so
+    // that we can preserve it across mounts and unmounts of the component
+    let parent = props.term ? props.term._core._parent : document.createElement('div');
+    parent.className = 'term_fit term_term';
+
+    this.termWrapperRef.appendChild(parent);
+
+    if (!props.term) {
+      this.term.attachCustomKeyEventHandler(this.keyboardHandler);
+      this.term.open(parent);
+      this.term.webLinksInit();
+      this.term.winptyCompatInit();
     }
+
     if (this.props.isTermActive) {
       this.term.focus();
     }
@@ -318,12 +305,9 @@ export default class Term extends React.PureComponent {
     this.termWrapperRef = component;
   }
 
-  onTermRef(component) {
-    this.termRef = component;
-  }
-
   componentWillUnmount() {
     terms[this.props.uid] = null;
+    this.termWrapperRef.removeChild(this.term._core._parent);
     this.props.ref_(this.props.uid, null);
 
     // to clean up the terminal, we remove the listeners
@@ -350,12 +334,10 @@ export default class Term extends React.PureComponent {
         onMouseUp={this.onMouseUp}
       >
         {this.props.customChildrenBefore}
-        <div ref={this.onTermWrapperRef} className="term_fit term_wrapper">
-          <div ref={this.onTermRef} className="term_fit term_term" />
-        </div>
+        <div ref={this.onTermWrapperRef} className="term_fit term_wrapper" />
         {this.props.customChildren}
 
-        <style jsx>{`
+        <style jsx global>{`
           .term_fit {
             display: block;
             width: 100%;

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -91,6 +91,23 @@ export default class Term extends React.PureComponent {
   componentDidMount() {
     const {props} = this;
 
+    if (props.term) {
+      let _core = props.term._core;
+      // Release listeners and disposables
+      _core._disposables.forEach(d => d.dispose());
+      _core._disposables.length = 0;
+      _core._events = {};
+      // Release listeners set by LinkRenderLayer
+      _core.linkifier._events = {};
+      // Release listeners set by SelectionManager
+      _core.buffers._events = {};
+      _core.buffer.lines._events = {};
+      _core.selectionManager.dispose();
+      // Restore disposed InputHandler
+      _core._inputHandler = new _core._inputHandler.constructor(_core);
+      _core.register(_core._inputHandler);
+    }
+
     this.termOptions = getTermOptions(props);
     this.term = props.term || new Terminal(this.termOptions);
     this.term.attachCustomKeyEventHandler(this.keyboardHandler);

--- a/lib/components/terms.js
+++ b/lib/components/terms.js
@@ -69,9 +69,9 @@ export default class Terms extends React.Component {
     });
   }
 
-  componentWillReceiveProps(nextProps) {
-    for (let uid in this.props.sessions) {
-      if (!nextProps.sessions[uid]) {
+  componentDidUpdate(prevProps) {
+    for (let uid in prevProps.sessions) {
+      if (!this.props.sessions[uid]) {
         this.terms[uid].term.dispose();
         delete this.terms[uid];
       }

--- a/lib/components/terms.js
+++ b/lib/components/terms.js
@@ -42,8 +42,6 @@ export default class Terms extends React.Component {
   onRef(uid, term) {
     if (term) {
       this.terms[uid] = term;
-    } else if (!this.props.sessions[uid]) {
-      delete this.terms[uid];
     }
   }
 
@@ -69,6 +67,15 @@ export default class Terms extends React.Component {
       const {props: {uid}} = this.getActiveTerm();
       this.props.onContextMenu(uid, selection);
     });
+  }
+
+  componentWillReceiveProps(nextProps) {
+    for (let uid in this.props.sessions) {
+      if (!nextProps.sessions[uid]) {
+        this.terms[uid].term.dispose();
+        delete this.terms[uid];
+      }
+    }
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
Fixes #3408, fixes #3351, fixes #3281.

Repeated calls to `Terminal.open()` on the same instance register a number of event listeners each time, which leads to resource leaks and erroneous listener duplication. It's not clear to me if multiple calls to `Terminal.open()` is a use case supported by xterm.js -- if it is, this issue should be fixed there. In the meantime, this is an ugly workaround to release all the event listeners prior to calling `Terminal.open()` again, while preserving the state we need to keep.

First, we run the equivalent of `Terminal.dispose()` to release disposables and events on the `Terminal` object. After this, some event listeners on non-disposable properties of the `Terminal` object itself remain set, and we must handle those separately. This is important because the old event listeners indirectly close over the previous `_parent` elements (now detached), which hold references to unmounted React components and old props, which in turn refer to old `Terminal` objects representing closed panes and tabs. Thus a single unreleased listener can be enough to cause a significant resource leak.

This can be seen using the Developer Tools by going to Memory > Take Snapshot. Multiple non-GCed `Term` components and `Terminal` instances are reachable even when only one pane remains open.

Additionally, the necessary cleanup on `TERM_GROUP_EXIT` in `lib/components/terms.js` is moved from `onRef()` to `componentWillReceiveProps()`. This is because `this.props.sessions` is not yet updated when `onRef()` is called, and currently the `delete` statement is never executed.