### PR TITLE
Fix and simplify resize handling using ResizeObserver

### DIFF
--- a/lib/components/term-group.js
+++ b/lib/components/term-group.js
@@ -13,7 +13,6 @@ class TermGroup_ extends React.PureComponent {
     super(props, context);
     this.bound = new WeakMap();
     this.termRefs = {};
-    this.sizeChanged = false;
     this.onTermRef = this.onTermRef.bind(this);
   }
 
@@ -102,16 +101,6 @@ class TermGroup_ extends React.PureComponent {
     return <Term ref_={this.onTermRef} key={uid} {...props} />;
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (this.props.termGroup.sizes != nextProps.termGroup.sizes || nextProps.sizeChanged) {
-      this.term && this.term.fitResize();
-      // Indicate to children that their size has changed even if their ratio hasn't
-      this.sizeChanged = true;
-    } else {
-      this.sizeChanged = false;
-    }
-  }
-
   render() {
     const {childGroups, termGroup} = this.props;
     if (termGroup.sessionUid) {
@@ -122,10 +111,7 @@ class TermGroup_ extends React.PureComponent {
       const props = getTermGroupProps(
         child.uid,
         this.props.parentProps,
-        Object.assign({}, this.props, {
-          termGroup: child,
-          sizeChanged: this.sizeChanged
-        })
+        Object.assign({}, this.props, {termGroup: child})
       );
 
       return <DecoratedTermGroup key={child.uid} {...props} />;

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -1,4 +1,4 @@
-/* global Blob,URL,requestAnimationFrame */
+/* global Blob,URL,requestAnimationFrame,ResizeObserver */
 import React from 'react';
 import {Terminal} from 'xterm';
 import * as fit from 'xterm/lib/addons/fit/fit';
@@ -78,8 +78,6 @@ export default class Term extends React.PureComponent {
     this.termRef = null;
     this.termWrapperRef = null;
     this.termRect = null;
-    this.onOpen = this.onOpen.bind(this);
-    this.onWindowResize = this.onWindowResize.bind(this);
     this.onWindowPaste = this.onWindowPaste.bind(this);
     this.onTermRef = this.onTermRef.bind(this);
     this.onTermWrapperRef = this.onTermWrapperRef.bind(this);
@@ -105,8 +103,6 @@ export default class Term extends React.PureComponent {
     if (this.props.isTermActive) {
       this.term.focus();
     }
-
-    this.onOpen(this.termOptions);
 
     if (props.onTitle) {
       this.disposableListeners.push(this.term.addDisposableListener('title', props.onTitle));
@@ -144,24 +140,11 @@ export default class Term extends React.PureComponent {
       );
     }
 
-    window.addEventListener('resize', this.onWindowResize, {
-      passive: true
-    });
-
     window.addEventListener('paste', this.onWindowPaste, {
       capture: true
     });
 
     terms[this.props.uid] = this;
-  }
-
-  onOpen() {
-    // we need to delay one frame so that styles
-    // get applied and we can make an accurate measurement
-    // of the container width and height
-    requestAnimationFrame(() => {
-      this.fitResize();
-    });
   }
 
   getTermDocument() {
@@ -174,10 +157,6 @@ export default class Term extends React.PureComponent {
         'to the `document` object of the main `window`.'
     );
     return document;
-  }
-
-  onWindowResize() {
-    this.fitResize();
   }
 
   // intercepting paste event for any necessary processing of
@@ -276,12 +255,6 @@ export default class Term extends React.PureComponent {
 
     this.termOptions = nextTermOptions;
 
-    if (!this.props.isTermActive && nextProps.isTermActive) {
-      requestAnimationFrame(() => {
-        this.fitResize();
-      });
-    }
-
     if (
       this.props.fontSize !== nextProps.fontSize ||
       this.props.fontFamily !== nextProps.fontFamily ||
@@ -299,6 +272,13 @@ export default class Term extends React.PureComponent {
 
   onTermWrapperRef(component) {
     this.termWrapperRef = component;
+
+    if (component) {
+      this.resizeObserver = new ResizeObserver(() => this.fitResize());
+      this.resizeObserver.observe(component);
+    } else {
+      this.resizeObserver.disconnect();
+    }
   }
 
   onTermRef(component) {
@@ -315,10 +295,6 @@ export default class Term extends React.PureComponent {
     // to do in case of splitting, see `componentDidMount`
     this.disposableListeners.forEach(handler => handler.dispose());
     this.disposableListeners = [];
-
-    window.removeEventListener('resize', this.onWindowResize, {
-      passive: true
-    });
 
     window.removeEventListener('paste', this.onWindowPaste, {
       capture: true

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -274,7 +274,15 @@ export default class Term extends React.PureComponent {
     this.termWrapperRef = component;
 
     if (component) {
-      this.resizeObserver = new ResizeObserver(() => this.fitResize());
+      this.resizeObserver = new ResizeObserver(() => {
+        if (this.resizeTimeout) {
+          return;
+        }
+        this.resizeTimeout = setTimeout(() => {
+          delete this.resizeTimeout;
+          this.fitResize();
+        }, 0);
+      });
       this.resizeObserver.observe(component);
     } else {
       this.resizeObserver.disconnect();

--- a/lib/components/terms.js
+++ b/lib/components/terms.js
@@ -78,7 +78,7 @@ export default class Terms extends React.Component {
   render() {
     const shift = !isMac && this.props.termGroups.length > 1;
     return (
-      <div className={`terms_terms ${shift ? 'terms_termsShifted' : ''}`}>
+      <div className={`terms_terms ${shift ? 'terms_termsShifted' : 'terms_termsNotShifted'}`}>
         {this.props.customChildrenBefore}
         {this.props.termGroups.map(termGroup => {
           const {uid} = termGroup;
@@ -144,11 +144,34 @@ export default class Terms extends React.Component {
             left: 0;
             bottom: 0;
             color: #fff;
-            transition: ${isMac ? 'none' : 'margin-top 0.3s ease'};
           }
 
           .terms_termsShifted {
             margin-top: 68px;
+            animation: shift-down 0.2s ease-out;
+          }
+
+          .terms_termsNotShifted {
+            margin-top: 34px;
+            animation: shift-up 0.3s ease;
+          }
+
+          @keyframes shift-down {
+            0% {
+              transform: translateY(-34px);
+            }
+            100% {
+              transform: translateY(0px);
+            }
+          }
+
+          @keyframes shift-up {
+            0% {
+              transform: translateY(34px);
+            }
+            100% {
+              transform: translateY(0px);
+            }
           }
 
           .terms_termGroup {


### PR DESCRIPTION
Fixes #3227.

Terminals do not get properly resized when switching between single-tab and multiple-tab layout, causing a rendering issue at the bottom of the viewport. This can also be triggered when splitting panes vertically in a small window.

This is fixed by using a [ResizeObserver](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) on the wrapper element to trigger the resize, which incidentally simplifies a lot of the resizing code. In particular, `onOpen` is no longer needed as the observer fires immediately when registered.

Note that ResizeObserver is an experimental API, but has been available on Chrome stable since Chrome 64. 