### PR TITLE
Style invisible term groups with display: none

### DIFF
--- a/lib/components/terms.js
+++ b/lib/components/terms.js
@@ -152,7 +152,7 @@ export default class Terms extends React.Component {
           }
 
           .terms_termGroup {
-            display: block;
+            display: none;
             width: 100%;
             height: 100%;
             position: absolute;
@@ -161,6 +161,7 @@ export default class Terms extends React.Component {
           }
 
           .terms_termGroupActive {
+            display: block;
             left: 0;
           }
         `}</style>


### PR DESCRIPTION
This solves two problems:

 1. Makes resizing the window way more responsive (~8X) when multiple tabs are open (e.g. maximize a small window with 10+ tabs)
 1. When using WebGL:
    1. maximize a small window
    1. switch to another tab
    1. result: the old contents of the canvas are flashed for a frame or two, scaled and distorted.

I'm not entirely sure why this improves (1). I think it's a combination of:
 - The browser doesn't need to run layout for the invisible term-groups
 - From the profiles, I can see that rendering is faster but I'm not sure why (see screenshots)

Before (canvas renderer):
![before](https://user-images.githubusercontent.com/1410520/51218137-0ae1bc00-18f9-11e9-8697-2d5836c496fd.png)
After (canvas renderer):
![after](https://user-images.githubusercontent.com/1410520/51218138-0b7a5280-18f9-11e9-9382-c9826e852688.png)

## Testing

 - [x] The `IntersectionObserver` still pauses rendering correctly
 - [x] Canvas renderer
 - [x] WebGL renderer