### PR TITLE
Downgrade electron to v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ language: node_js
 matrix:
   include:
     - os: linux
-      node_js: 10.11.0
+      node_js: 10.2.0
       env: CC=clang CXX=clang++ npm_config_clang=1
       compiler: clang
 

--- a/app/commands.js
+++ b/app/commands.js
@@ -53,16 +53,6 @@ const commands = {
       webContents.openDevTools({mode: 'detach'});
     }
   },
-  'editor:copy': focusedWindow => {
-    // HACK: Had to add this because the "editor:copy" role is not firing with
-    // ctrl+shift+c after upgrading to electron 4
-    // Electron issue: https://github.com/electron/electron#16088
-    if (!focusedWindow) {
-      return;
-    }
-    const webContents = focusedWindow.webContents;
-    webContents.copy();
-  },
   'zoom:reset': focusedWindow => {
     focusedWindow && focusedWindow.rpc.emit('reset fontSize req');
   },

--- a/app/ui/window.js
+++ b/app/ui/window.js
@@ -21,7 +21,7 @@ module.exports = class Window {
         minWidth: 370,
         minHeight: 190,
         backgroundColor: toElectronBackgroundColor(cfg.backgroundColor || '#000'),
-        titleBarStyle: 'hiddenInset',
+        titleBarStyle: 'hidden-inset',
         title: 'Hyper.app',
         // we want to go frameless on Windows and Linux
         frame: process.platform === 'darwin',

--- a/app/ui/window.js
+++ b/app/ui/window.js
@@ -21,7 +21,7 @@ module.exports = class Window {
         minWidth: 370,
         minHeight: 190,
         backgroundColor: toElectronBackgroundColor(cfg.backgroundColor || '#000'),
-        titleBarStyle: 'hidden-inset',
+        titleBarStyle: 'hiddenInset',
         title: 'Hyper.app',
         // we want to go frameless on Windows and Linux
         frame: process.platform === 'darwin',

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ init:
   - yarn config set msvs_version 2015 # we need this to build `pty.js`
 
 install:
-  - ps: Install-Product node 10.11.0 x64
+  - ps: Install-Product node 10.2.0 x64
   - set CI=true
   - yarn
 

--- a/package.json
+++ b/package.json
@@ -219,7 +219,7 @@
     "babel-preset-react": "6.24.1",
     "copy-webpack-plugin": "4.3.1",
     "cross-env": "5.1.4",
-    "electron": "4.0.0",
+    "electron": "3.1.1",
     "electron-builder": "20.38.2",
     "electron-builder-squirrel-windows": "20.38.2",
     "electron-devtools-installer": "2.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2432,10 +2432,10 @@ electron-to-chromium@^1.2.7:
   version "1.3.33"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.33.tgz#bf00703d62a7c65238136578c352d6c5c042a545"
 
-electron@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-4.0.0.tgz#6ccb40cc8bf2d49954dcea73b97ae7ad12ee04b3"
-  integrity sha512-3XPG/3IXlvnT1oe1K6zEushoD0SKbP8xwdrL10EWGe6k2iOV4hSHqJ8vWnR8yZ7VbSXmBRfomEFDNAo/q/cwKw==
+electron@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-3.1.1.tgz#983492f0eb25740d1ba1da47712b16139ebc6d17"
+  integrity sha512-ZamfKY9xp8P6/prtBbhOoOsdCaqyArr7GOmgJuBgWY95ZW5nJVP5aA5lLTh8IeVSW1/IM1KyKYPTrTS/RGercQ==
   dependencies:
     "@types/node" "^8.0.24"
     electron-download "^4.1.0"
@@ -7112,9 +7112,9 @@ xtend@~2.1.1:
   dependencies:
     object-keys "~0.4.0"
 
-"xterm@https://registry.npmjs.org/@zeit/xterm/-/xterm-3.10.1-1.tgz":
-  version "3.10.1-1"
-  resolved "https://registry.npmjs.org/@zeit/xterm/-/xterm-3.10.1-1.tgz#8bddffff852a6d9c3a3096ec5dcd34b1a082b0cf"
+"xterm@https://registry.npmjs.org/@zeit/xterm/-/xterm-3.10.1-2.tgz":
+  version "3.10.1-2"
+  resolved "https://registry.npmjs.org/@zeit/xterm/-/xterm-3.10.1-2.tgz#02bf8c8c5d66835afbc1b8d152ceed5f2a29479f"
 
 y18n@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
### Problem
Electron v4 has a big performance issue with 2d canvases Tracked here:

 https://github.com/electron/electron/issues/16439

### Solution

Revert back to Electron v3 for now.

### Testing

  - [x] No errors on output
  - [x] Plugins work (tested installing and using hypercwd)
  - [x] Multiple tabs
  - [x] Multiple windows
  - [x] Splits
  - [x] Menus
  - [ ] Auto update (pop up shows)
  - [x] Clean shutdown
  - [x] Vim session with splits
  - [x] Clipboard works
     - [x] Through menu
     - [x] Hotkeys
  - [x] Performance looks fine
     - [x] canvas
     - [x] webgl
----
  - [x] Linux
  - [x]  MacOS
  - [x]  Windows