### PR TITLE
Upgrading xterm to 3.10.1-4

### DIFF
--- a/package.json
+++ b/package.json
@@ -208,7 +208,7 @@
     "styled-jsx": "2.2.6",
     "stylis": "3.5.0",
     "uuid": "3.1.0",
-    "xterm": "https://registry.npmjs.org/@zeit/xterm/-/xterm-3.10.1-3.tgz"
+    "xterm": "https://registry.npmjs.org/@zeit/xterm/-/xterm-3.10.1-4.tgz"
   },
   "devDependencies": {
     "ava": "0.25.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7112,9 +7112,9 @@ xtend@~2.1.1:
   dependencies:
     object-keys "~0.4.0"
 
-"xterm@https://registry.npmjs.org/@zeit/xterm/-/xterm-3.10.1-3.tgz":
-  version "3.10.1-3"
-  resolved "https://registry.npmjs.org/@zeit/xterm/-/xterm-3.10.1-3.tgz#f4abb4dcfb128b8b14669605cebc476b50493a10"
+"xterm@https://registry.npmjs.org/@zeit/xterm/-/xterm-3.10.1-4.tgz":
+  version "3.10.1-4"
+  resolved "https://registry.npmjs.org/@zeit/xterm/-/xterm-3.10.1-4.tgz#68d2796f09340f639e28859dc0fdcba4dfaaf788"
 
 y18n@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
Removing selection outline. A reversal of https://github.com/zeit/xterm.js/pull/5

Built from https://github.com/zeit/xterm.js/releases/tag/3.10.1-4

