### PR TITLE
Verify that webgl2 is supported before using it

### DIFF
--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -20,11 +20,27 @@ const CURSOR_STYLES = {
   BLOCK: 'block'
 };
 
+const isWebgl2Supported = (() => {
+  let isSupported;
+  return () => {
+    if (isSupported === undefined) {
+      const canvas = document.createElement('canvas');
+      const gl = canvas.getContext('webgl2', {depth: false, antialias: false});
+      isSupported = gl instanceof window.WebGL2RenderingContext;
+      if (!isSupported) {
+        // eslint-disable-next-line no-console
+        console.warn(`WebGL2 is not supported on your machine. Falling back to canvas-based rendering.`);
+      }
+    }
+    return isSupported;
+  };
+})();
+
 const getTermOptions = props => {
   // Set a background color only if it is opaque
   const needTransparency = Color(props.backgroundColor).alpha() < 1;
   const backgroundColor = needTransparency ? 'transparent' : props.backgroundColor;
-  const useWebGL = props.webGLRenderer && !needTransparency;
+  const useWebGL = props.webGLRenderer && !needTransparency && isWebgl2Supported();
   return {
     macOptionIsMeta: props.modifierKeys.altIsMeta,
     scrollback: props.scrollback,

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -27,10 +27,6 @@ const isWebgl2Supported = (() => {
       const canvas = document.createElement('canvas');
       const gl = canvas.getContext('webgl2', {depth: false, antialias: false});
       isSupported = gl instanceof window.WebGL2RenderingContext;
-      if (!isSupported) {
-        // eslint-disable-next-line no-console
-        console.warn(`WebGL2 is not supported on your machine. Falling back to canvas-based rendering.`);
-      }
     }
     return isSupported;
   };
@@ -40,7 +36,22 @@ const getTermOptions = props => {
   // Set a background color only if it is opaque
   const needTransparency = Color(props.backgroundColor).alpha() < 1;
   const backgroundColor = needTransparency ? 'transparent' : props.backgroundColor;
-  const useWebGL = props.webGLRenderer && !needTransparency && isWebgl2Supported();
+
+  let useWebGL = false;
+  if (props.webGLRenderer) {
+    if (needTransparency) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'WebGL Renderer has been disabled since it does not support transparent backgrounds yet. ' +
+          'Falling back to canvas-based rendering.'
+      );
+    } else if (!isWebgl2Supported()) {
+      // eslint-disable-next-line no-console
+      console.warn('WebGL2 is not supported on your machine. Falling back to canvas-based rendering.');
+    } else {
+      useWebGL = true;
+    }
+  }
   return {
     macOptionIsMeta: props.modifierKeys.altIsMeta,
     scrollback: props.scrollback,

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -21,7 +21,7 @@ const CURSOR_STYLES = {
 };
 
 const isWebgl2Supported = (() => {
-  let isSupported;
+  let isSupported = window.WebGL2RenderingContext ? undefined : false;
   return () => {
     if (isSupported === undefined) {
       const canvas = document.createElement('canvas');


### PR DESCRIPTION
Some hardware/drivers seem to not support WebGL2 (now our default renderer) which completely breaks hyper.

Check that webgl2 is supported before using.

This seems to add ~10ms to my startup time, which I think it's acceptable. The alternative being catching an exception in `Terminal.open` and *then* falling back to canvas.

fixes #3433