### PR TITLE
Display the renderer type in the About dialog

### DIFF
--- a/app/menus/menu.js
+++ b/app/menus/menu.js
@@ -13,6 +13,7 @@ const helpMenu = require('./menus/help');
 const darwinMenu = require('./menus/darwin');
 const {getDecoratedKeymaps} = require('../plugins');
 const {execCommand} = require('../commands');
+const {getRendererTypes} = require('../utils/renderer-utils');
 
 const appName = app.getName();
 const appVersion = app.getVersion();
@@ -38,12 +39,19 @@ exports.createMenu = (createWindow, getLoadedPluginVersions) => {
     const loadedPlugins = getLoadedPluginVersions();
     const pluginList =
       loadedPlugins.length === 0 ? 'none' : loadedPlugins.map(plugin => `\n  ${plugin.name} (${plugin.version})`);
-    const renderer = global[Symbol.for('hyper.rendererType')];
+
+    const rendererCounts = Object.entries(getRendererTypes()).reduce((acc, [, type]) => {
+      acc[type] = acc[type] ? acc[type] + 1 : 1;
+      return acc;
+    }, {});
+    const renderers = Object.entries(rendererCounts)
+      .map(([type, count]) => type + (count > 1 ? ` (${count})` : ''))
+      .join(', ');
 
     dialog.showMessageBox({
       title: `About ${appName}`,
       message: `${appName} ${appVersion} (${updateChannel})`,
-      detail: `Renderer: ${renderer}\nPlugins: ${pluginList}\n\nCreated by Guillermo Rauch\nCopyright © 2018 ZEIT, Inc.`,
+      detail: `Renderers: ${renderers}\nPlugins: ${pluginList}\n\nCreated by Guillermo Rauch\nCopyright © 2018 ZEIT, Inc.`,
       buttons: [],
       icon
     });

--- a/app/menus/menu.js
+++ b/app/menus/menu.js
@@ -40,7 +40,7 @@ exports.createMenu = (createWindow, getLoadedPluginVersions) => {
     const pluginList =
       loadedPlugins.length === 0 ? 'none' : loadedPlugins.map(plugin => `\n  ${plugin.name} (${plugin.version})`);
 
-    const rendererCounts = Object.entries(getRendererTypes()).reduce((acc, [, type]) => {
+    const rendererCounts = Object.values(getRendererTypes()).reduce((acc, type) => {
       acc[type] = acc[type] ? acc[type] + 1 : 1;
       return acc;
     }, {});

--- a/app/menus/menu.js
+++ b/app/menus/menu.js
@@ -38,11 +38,12 @@ exports.createMenu = (createWindow, getLoadedPluginVersions) => {
     const loadedPlugins = getLoadedPluginVersions();
     const pluginList =
       loadedPlugins.length === 0 ? 'none' : loadedPlugins.map(plugin => `\n  ${plugin.name} (${plugin.version})`);
+    const renderer = global[Symbol.for('hyper.rendererType')];
 
     dialog.showMessageBox({
       title: `About ${appName}`,
       message: `${appName} ${appVersion} (${updateChannel})`,
-      detail: `Plugins: ${pluginList}\n\nCreated by Guillermo Rauch\nCopyright © 2018 ZEIT, Inc.`,
+      detail: `Renderer: ${renderer}\nPlugins: ${pluginList}\n\nCreated by Guillermo Rauch\nCopyright © 2018 ZEIT, Inc.`,
       buttons: [],
       icon
     });

--- a/app/ui/window.js
+++ b/app/ui/window.js
@@ -192,6 +192,10 @@ module.exports = class Window {
         }
       }
     });
+    rpc.on('info renderer', ({type}) => {
+      // Used in the "About" dialog
+      global[Symbol.for('hyper.rendererType')] = type;
+    });
     rpc.on('open external', ({url}) => {
       shell.openExternal(url);
     });

--- a/app/ui/window.js
+++ b/app/ui/window.js
@@ -13,6 +13,7 @@ const fetchNotifications = require('../notifications');
 const Session = require('../session');
 const contextMenuTemplate = require('./contextmenu');
 const {execCommand} = require('../commands');
+const {setRendererType, unsetRendererType} = require('../utils/renderer-utils');
 
 module.exports = class Window {
   constructor(options_, cfg, fn) {
@@ -153,6 +154,7 @@ module.exports = class Window {
 
       session.on('exit', () => {
         rpc.emit('session exit', {uid: options.uid});
+        unsetRendererType(options.uid);
         sessions.delete(options.uid);
       });
     });
@@ -192,9 +194,9 @@ module.exports = class Window {
         }
       }
     });
-    rpc.on('info renderer', ({type}) => {
+    rpc.on('info renderer', ({uid, type}) => {
       // Used in the "About" dialog
-      global[Symbol.for('hyper.rendererType')] = type;
+      setRendererType(uid, type);
     });
     rpc.on('open external', ({url}) => {
       shell.openExternal(url);

--- a/app/utils/renderer-utils.js
+++ b/app/utils/renderer-utils.js
@@ -1,0 +1,19 @@
+const rendererTypes = {};
+
+function getRendererTypes() {
+  return rendererTypes;
+}
+
+function setRendererType(uid, type) {
+  rendererTypes[uid] = type;
+}
+
+function unsetRendererType(uid) {
+  delete rendererTypes[uid];
+}
+
+module.exports = {
+  getRendererTypes,
+  setRendererType,
+  unsetRendererType
+};

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -52,6 +52,8 @@ const getTermOptions = props => {
       useWebGL = true;
     }
   }
+  Term.reportRenderer(useWebGL ? 'WebGL' : 'Canvas');
+
   return {
     macOptionIsMeta: props.modifierKeys.altIsMeta,
     scrollback: props.scrollback,
@@ -107,6 +109,14 @@ export default class Term extends React.PureComponent {
     this.onMouseUp = this.onMouseUp.bind(this);
     this.termOptions = {};
     this.disposableListeners = [];
+  }
+
+  // The main process shows this in the About dialog
+  static reportRenderer(type) {
+    if (Term.rendererType !== type) {
+      Term.rendererType = type;
+      window.rpc.emit('info renderer', {type});
+    }
   }
 
   componentDidMount() {

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -52,7 +52,7 @@ const getTermOptions = props => {
       useWebGL = true;
     }
   }
-  Term.reportRenderer(useWebGL ? 'WebGL' : 'Canvas');
+  Term.reportRenderer(props.uid, useWebGL ? 'WebGL' : 'Canvas');
 
   return {
     macOptionIsMeta: props.modifierKeys.altIsMeta,
@@ -112,10 +112,12 @@ export default class Term extends React.PureComponent {
   }
 
   // The main process shows this in the About dialog
-  static reportRenderer(type) {
-    if (Term.rendererType !== type) {
-      Term.rendererType = type;
-      window.rpc.emit('info renderer', {type});
+  static reportRenderer(uid, type) {
+    const rendererTypes = Term.rendererTypes || {};
+    if (rendererTypes[uid] !== type) {
+      rendererTypes[uid] = type;
+      Term.rendererTypes = rendererTypes;
+      window.rpc.emit('info renderer', {uid, type});
     }
   }
 


### PR DESCRIPTION
Since the actual renderer used is determined not only by the config but also by the bg opacity and general support. We want to display the renderer in an easy to access place for diagnostics.

![2019-01-24_14-33](https://user-images.githubusercontent.com/1410520/51703620-d3ec6400-1fe4-11e9-82c6-e2c8b7971732.png)
