### PR TITLE
Add shortcut for opening hamburger menu (Windows)

### DIFF
--- a/app/commands.js
+++ b/app/commands.js
@@ -1,5 +1,5 @@
 const {app, Menu} = require('electron');
-const {openConfig} = require('./config');
+const {openConfig, getConfig} = require('./config');
 const {updatePlugins} = require('./plugins');
 const {installCLI} = require('./utils/cli-install');
 
@@ -105,7 +105,9 @@ const commands = {
     installCLI(true);
   },
   'window:hamburgerMenu': () => {
-    Menu.getApplicationMenu().popup({x: 15, y: 15});
+    if (getConfig().showHamburgerMenu) {
+      Menu.getApplicationMenu().popup({x: 15, y: 15});
+    }
   }
 };
 

--- a/app/commands.js
+++ b/app/commands.js
@@ -1,4 +1,4 @@
-const {app} = require('electron');
+const {app, Menu} = require('electron');
 const {openConfig} = require('./config');
 const {updatePlugins} = require('./plugins');
 const {installCLI} = require('./utils/cli-install');
@@ -103,6 +103,9 @@ const commands = {
   },
   'cli:install': () => {
     installCLI(true);
+  },
+  'window:hamburgerMenu': () => {
+    Menu.getApplicationMenu().popup({x: 15, y: 15});
   }
 };
 

--- a/app/keymaps/win32.json
+++ b/app/keymaps/win32.json
@@ -3,6 +3,7 @@
   "window:reload": "ctrl+shift+r",
   "window:reloadFull": "ctrl+shift+f5",
   "window:preferences": "ctrl+,",
+  "window:hamburgerMenu": "alt",
   "zoom:reset": "ctrl+0",
   "zoom:in": "ctrl+=",
   "zoom:out": "ctrl+-",


### PR DESCRIPTION
Opens hamburger menu for `alt` shortcut on Windows.

PR for #3443.