### PR TITLE
Bumping electron to 3.1.3

### DIFF
--- a/app/menus/menus/edit.js
+++ b/app/menus/menus/edit.js
@@ -21,7 +21,8 @@ module.exports = (commandKeys, execCommand) => {
     {
       role: 'copy',
       command: 'editor:copy',
-      accelerator: commandKeys['editor:copy']
+      accelerator: commandKeys['editor:copy'],
+      registerAccelerator: true
     },
     {
       role: 'paste',

--- a/package.json
+++ b/package.json
@@ -219,7 +219,7 @@
     "babel-preset-react": "6.24.1",
     "copy-webpack-plugin": "4.3.1",
     "cross-env": "5.1.4",
-    "electron": "3.1.1",
+    "electron": "3.1.3",
     "electron-builder": "20.38.2",
     "electron-builder-squirrel-windows": "20.38.2",
     "electron-devtools-installer": "2.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2432,10 +2432,10 @@ electron-to-chromium@^1.2.7:
   version "1.3.33"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.33.tgz#bf00703d62a7c65238136578c352d6c5c042a545"
 
-electron@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-3.1.1.tgz#983492f0eb25740d1ba1da47712b16139ebc6d17"
-  integrity sha512-ZamfKY9xp8P6/prtBbhOoOsdCaqyArr7GOmgJuBgWY95ZW5nJVP5aA5lLTh8IeVSW1/IM1KyKYPTrTS/RGercQ==
+electron@3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-3.1.3.tgz#848fa0fc62d131978cde15ec04ce195a08dc4155"
+  integrity sha512-Y1TbV5py2O0br0JVYh+ew1cW4cIOOgRNRMzwTwWuZNMZ9fK/XLlqsbZr1GpYHdiN2yIU1koO+g4Cw8VuW86NXQ==
   dependencies:
     "@types/node" "^8.0.24"
     electron-download "^4.1.0"


### PR DESCRIPTION
This version includes a vulnerability fix but also broke our copy mechanism due to [this change](https://github.com/electron/electron/pull/15892). Adding `registerAccelerator: true` seems to fix it on Linux. 

 - [x] Linux
 - [ ] MacOS
