### PR TITLE
Remove instructions for Debian from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,6 @@ Hyper is available in the [AUR](https://aur.archlinux.org/packages/hyper/). Use 
 aurman -S hyper
 ```
 
-#### Ubuntu / Debian and derivatives
-
-Hyper is available in the Snapcraft store [here](https://snapcraft.io/hyper) and can be installed via [snap](https://docs.snapcraft.io/) using:
-
-```bash
-snap install hyper --classic
-```
-
 ### macOS
 
 Use [Homebrew Cask](https://brew.sh) to download the app by running these commands:


### PR DESCRIPTION
Snap link broken. Snap command outputs 'error: snap "hyper" not found'.

<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`
- If your PR changes some API, please make a PR for hyper website too: https://github.com/zeit/hyper-site.

Thanks, again! -->
