### PR TITLE
Add Session class and Session options decoration by plugins

### DIFF
--- a/app/plugins.js
+++ b/app/plugins.js
@@ -417,12 +417,12 @@ exports.getDecoratedBrowserOptions = defaults => {
   return decorateObject(defaults, 'decorateBrowserOptions');
 };
 
-exports.decorateSessionClass = Session => {
-  return decorateClass(Session, 'decorateSessionClass');
-};
-
 exports.decorateSessionOptions = defaults => {
   return decorateObject(defaults, 'decorateSessionOptions');
+};
+
+exports.decorateSessionClass = Session => {
+  return decorateClass(Session, 'decorateSessionClass');
 };
 
 exports._toDependencies = toDependencies;

--- a/app/plugins.js
+++ b/app/plugins.js
@@ -332,9 +332,9 @@ exports.onWindow = win => {
   });
 };
 
-// decorates the base object by calling plugin[key]
+// decorates the base entity by calling plugin[key]
 // for all the available plugins
-function decorateObject(base, key) {
+function decorateEntity(base, key, type) {
   let decorated = base;
   modules.forEach(plugin => {
     if (plugin[key]) {
@@ -345,7 +345,7 @@ function decorateObject(base, key) {
         notify('Plugin error!', `"${plugin._name}" when decorating ${key}`, {error: e});
         return;
       }
-      if (res && typeof res === 'object') {
+      if (res && (!type || typeof res === type)) {
         decorated = res;
       } else {
         notify('Plugin error!', `"${plugin._name}": invalid return type for \`${key}\``);
@@ -354,6 +354,14 @@ function decorateObject(base, key) {
   });
 
   return decorated;
+}
+
+function decorateObject(base, key) {
+  return decorateEntity(base, key, 'object');
+}
+
+function decorateClass(base, key) {
+  return decorateEntity(base, key, 'function');
 }
 
 exports.getDeprecatedConfig = () => {
@@ -407,6 +415,14 @@ exports.getDecoratedKeymaps = () => {
 
 exports.getDecoratedBrowserOptions = defaults => {
   return decorateObject(defaults, 'decorateBrowserOptions');
+};
+
+exports.decorateSessionClass = Session => {
+  return decorateClass(Session, 'decorateSessionClass');
+};
+
+exports.decorateSessionOptions = defaults => {
+  return decorateObject(defaults, 'decorateSessionOptions');
 };
 
 exports._toDependencies = toDependencies;

--- a/app/plugins/extensions.js
+++ b/app/plugins/extensions.js
@@ -4,6 +4,8 @@ module.exports = {
     'onWindow',
     'onRendererWindow',
     'onUnload',
+    'decorateSessionClass',
+    'decorateSessionOptions',
     'middleware',
     'reduceUI',
     'reduceSessions',

--- a/app/session.js
+++ b/app/session.js
@@ -74,9 +74,17 @@ class DataBatcher extends EventEmitter {
 }
 
 module.exports = class Session extends EventEmitter {
-  constructor({uid, rows, cols: columns, cwd, shell, shellArgs}) {
-    const osLocale = require('os-locale');
+  constructor(options) {
     super();
+    this.pty = null;
+    this.batcher = null;
+    this.shell = null;
+    this.ended = false;
+    this.init(options);
+  }
+
+  init({uid, rows, cols: columns, cwd, shell, shellArgs}) {
+    const osLocale = require('os-locale');
     const baseEnv = Object.assign(
       {},
       process.env,

--- a/app/session.js
+++ b/app/session.js
@@ -149,24 +149,39 @@ module.exports = class Session extends EventEmitter {
   }
 
   write(data) {
-    this.pty && this.pty.write(data);
+    if (this.pty) {
+      this.pty.write(data);
+    } else {
+      //eslint-disable-next-line no-console
+      console.warn('Warning: Attempted to write to a session with no pty');
+    }
   }
 
   resize({cols, rows}) {
-    try {
-      this.pty && this.pty.resize(cols, rows);
-    } catch (err) {
+    if (this.pty) {
+      try {
+        this.pty.resize(cols, rows);
+      } catch (err) {
+        //eslint-disable-next-line no-console
+        console.error(err.stack);
+      }
+    } else {
       //eslint-disable-next-line no-console
-      console.error(err.stack);
+      console.warn('Warning: Attempted to resize a session with no pty');
     }
   }
 
   destroy() {
-    try {
-      this.pty && this.pty.kill();
-    } catch (err) {
+    if (this.pty) {
+      try {
+        this.pty.kill();
+      } catch (err) {
+        //eslint-disable-next-line no-console
+        console.error('exit error', err.stack);
+      }
+    } else {
       //eslint-disable-next-line no-console
-      console.error('exit error', err.stack);
+      console.warn('Warning: Attempted to destroy a session with no pty');
     }
     this.emit('exit');
     this.ended = true;

--- a/app/session.js
+++ b/app/session.js
@@ -141,12 +141,12 @@ module.exports = class Session extends EventEmitter {
   }
 
   write(data) {
-    this.pty.write(data);
+    this.pty && this.pty.write(data);
   }
 
   resize({cols, rows}) {
     try {
-      this.pty.resize(cols, rows);
+      this.pty && this.pty.resize(cols, rows);
     } catch (err) {
       //eslint-disable-next-line no-console
       console.error(err.stack);
@@ -155,7 +155,7 @@ module.exports = class Session extends EventEmitter {
 
   destroy() {
     try {
-      this.pty.kill();
+      this.pty && this.pty.kill();
     } catch (err) {
       //eslint-disable-next-line no-console
       console.error('exit error', err.stack);

--- a/app/ui/window.js
+++ b/app/ui/window.js
@@ -14,6 +14,7 @@ const Session = require('../session');
 const contextMenuTemplate = require('./contextmenu');
 const {execCommand} = require('../commands');
 const {setRendererType, unsetRendererType} = require('../utils/renderer-utils');
+const {decorateSessionOptions, decorateSessionClass} = require('../plugins');
 
 module.exports = class Window {
   constructor(options_, cfg, fn) {
@@ -89,7 +90,7 @@ module.exports = class Window {
     function createSession(extraOptions = {}) {
       const uid = uuid.v4();
 
-      const options = Object.assign(
+      const defaultOptions = Object.assign(
         {
           rows: 40,
           cols: 100,
@@ -101,8 +102,9 @@ module.exports = class Window {
         extraOptions,
         {uid}
       );
-
-      const session = new Session(options);
+      const options = decorateSessionOptions(defaultOptions);
+      const DecoratedSession = decorateSessionClass(Session);
+      const session = new DecoratedSession(options);
       sessions.set(uid, session);
       return {session, options};
     }


### PR DESCRIPTION
This PR implements [this RFC](https://github.com/zeit/hyper/issues/3446)

It adds 2 new plugin hook to our API `decorateSessionClass` and `decorateSessionOptions`.

It unlocks some awesome new plugin possiblities. I made a plugin as an example (and a proof of concept): https://github.com/chabou/hyper-session-log