### PR TITLE
Expose active window positon on move to reducer

### DIFF
--- a/app/ui/window.js
+++ b/app/ui/window.js
@@ -215,7 +215,7 @@ module.exports = class Window {
     for (const ev of ['maximize', 'unmaximize', 'minimize', 'restore']) {
       window.on(ev, () => rpc.emit('windowGeometry change'));
     }
-    rpc.window.on('move', () => {
+    window.on('move', () => {
       const position = window.getPosition();
       rpc.emit('move', {bounds: {x: position[0], y: position[1]}});
     });

--- a/app/ui/window.js
+++ b/app/ui/window.js
@@ -216,7 +216,8 @@ module.exports = class Window {
       window.on(ev, () => rpc.emit('windowGeometry change'));
     }
     rpc.win.on('move', () => {
-      rpc.emit('move');
+      const position = window.getPosition();
+      rpc.emit('move', {position: {x: position[0], y: position[1]}});
     });
     rpc.on('close', () => {
       window.close();

--- a/app/ui/window.js
+++ b/app/ui/window.js
@@ -215,9 +215,9 @@ module.exports = class Window {
     for (const ev of ['maximize', 'unmaximize', 'minimize', 'restore']) {
       window.on(ev, () => rpc.emit('windowGeometry change'));
     }
-    rpc.win.on('move', () => {
+    rpc.window.on('move', () => {
       const position = window.getPosition();
-      rpc.emit('move', {position: {x: position[0], y: position[1]}});
+      rpc.emit('move', {bounds: {x: position[0], y: position[1]}});
     });
     rpc.on('close', () => {
       window.close();

--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -229,10 +229,11 @@ export function moveTo(i) {
   };
 }
 
-export function windowMove() {
+export function windowMove(window) {
   return dispatch => {
     dispatch({
       type: UI_WINDOW_MOVE,
+      window,
       effect() {
         dispatch(setFontSmoothing());
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -162,8 +162,8 @@ rpc.on('update available', ({releaseName, releaseNotes, releaseUrl, canInstall})
   store_.dispatch(updaterActions.updateAvailable(releaseName, releaseNotes, releaseUrl, canInstall));
 });
 
-rpc.on('move', () => {
-  store_.dispatch(uiActions.windowMove());
+rpc.on('move', window => {
+  store_.dispatch(uiActions.windowMove(window));
 });
 
 rpc.on('windowGeometry change', () => {


### PR DESCRIPTION
<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`
- If your PR changes some API, please make a PR for hyper website too: https://github.com/zeit/hyper-site.

Thanks, again! -->


Expose window position `{x, y}` once the active window when it's moved.

In order to add modularity for plugins: 
  - The `onWindow` only expose the window creation. But once the window is created, moved action are not accessible. 
- Allow plugins to know the current position of the active window based on the `UI_WINDOW_MOVE` from the window move action lunched by the `RPC`.
- Enable better state recording for plugins such as session restoration
