### PR TITLE
Add Window class and options plugin decoration

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -19,7 +19,6 @@ const checkSquirrel = () => {
     squirrel = require('electron-squirrel-startup');
     //eslint-disable-next-line no-empty
   } catch (err) {}
-
   if (squirrel) {
     // eslint-disable-next-line unicorn/no-process-exit
     process.exit();

--- a/app/plugins.js
+++ b/app/plugins.js
@@ -318,6 +318,20 @@ exports.onApp = app_ => {
   });
 };
 
+exports.onWindowClass = win => {
+  modules.forEach(plugin => {
+    if (plugin.onWindowClass) {
+      try {
+        plugin.onWindowClass(win);
+      } catch (e) {
+        notify('Plugin error!', `"${plugin._name}" has encountered an error. Check Developer Tools for details.`, {
+          error: e
+        });
+      }
+    }
+  });
+};
+
 exports.onWindow = win => {
   modules.forEach(plugin => {
     if (plugin.onWindow) {
@@ -415,6 +429,10 @@ exports.getDecoratedKeymaps = () => {
 
 exports.getDecoratedBrowserOptions = defaults => {
   return decorateObject(defaults, 'decorateBrowserOptions');
+};
+
+exports.decorateWindowClass = defaults => {
+  return decorateObject(defaults, 'decorateWindowClass');
 };
 
 exports.decorateSessionOptions = defaults => {

--- a/app/plugins/extensions.js
+++ b/app/plugins/extensions.js
@@ -1,6 +1,8 @@
 module.exports = {
   availableExtensions: new Set([
     'onApp',
+    'onWindowClass',
+    'decorateWindowClass',
     'onWindow',
     'onRendererWindow',
     'onUnload',

--- a/app/ui/window.js
+++ b/app/ui/window.js
@@ -19,9 +19,10 @@ const {decorateSessionOptions, decorateSessionClass} = require('../plugins');
 module.exports = class Window {
   constructor(options_, cfg, fn) {
     const classOpts = Object.assign({uid: uuid.v4()});
-
-    app.plugins.onWindowClass(app.plugins.decorateWindowClass(classOpts));
+    app.plugins.decorateWindowClass(classOpts);
     this.uid = classOpts.uid;
+
+    app.plugins.onWindowClass(this);
 
     const winOpts = Object.assign(
       {
@@ -39,7 +40,9 @@ module.exports = class Window {
       },
       options_
     );
+
     const window = new BrowserWindow(app.plugins.getDecoratedBrowserOptions(winOpts));
+    window.uid = classOpts.uid;
 
     const rpc = createRPC(window);
     const sessions = new Map();

--- a/app/ui/window.js
+++ b/app/ui/window.js
@@ -18,6 +18,11 @@ const {decorateSessionOptions, decorateSessionClass} = require('../plugins');
 
 module.exports = class Window {
   constructor(options_, cfg, fn) {
+    const classOpts = Object.assign({uid: uuid.v4()});
+
+    app.plugins.onWindowClass(app.plugins.decorateWindowClass(classOpts));
+    this.uid = classOpts.uid;
+
     const winOpts = Object.assign(
       {
         minWidth: 370,
@@ -35,6 +40,7 @@ module.exports = class Window {
       options_
     );
     const window = new BrowserWindow(app.plugins.getDecoratedBrowserOptions(winOpts));
+
     const rpc = createRPC(window);
     const sessions = new Map();
 


### PR DESCRIPTION
<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`
- If your PR changes some API, please make a PR for hyper website too: https://github.com/zeit/hyper-site.

Thanks, again! -->

- Since the current: `onWindow` is the BrowserWindow and `decorateBrowserOptions` decorate it.
- Since the current  `onWindow` doesn't refer to the `Window` object https://github.com/zeit/hyper/blob/canary/app/ui/window.js#L19
- Since #3352 Make session creation optimistic. 

The current implementation make the session creation happen before the instance of the window. There for, if the plugin want to bind a session to a window. The new `decorateSessionClass` and `decorateSessionOptions` will result on the session not being accessible to the window's instance of the plugin. And therefor, not being able to bind it to an `UID`.

This PR include more extensibility by allowing the developer to either access `onWindowClass` the window's uid, or decorate it using `decorateWindowClass`.

This enable the possibility to give window's profile ID as unique name
```
exports.decorateWindowClass = defaults => {
  defaults = {uid: 'profileId_dev'};
  return defaults;
}
```
or acces the default `UID` created: 
```
{ uid: 'b545deb5-c1e4-4ecd-af3b-e722126f1d40' }
```

Target: https://github.com/ppot/hyper-automator/issues/4