### PR TITLE
Keep homedir as session startup endpoint

### DIFF
--- a/app/config/paths.js
+++ b/app/config/paths.js
@@ -1,4 +1,5 @@
 // This module exports paths, names, and other metadata that is referenced
+const {homedir} = require('os');
 const {app} = require('electron');
 const {statSync} = require('fs');
 const {resolve, join} = require('path');
@@ -6,10 +7,12 @@ const isDev = require('electron-is-dev');
 
 const cfgFile = '.hyper.js';
 const defaultCfgFile = 'config-default.js';
-const homeDir = app.getPath('userData');
+const homeDirectory = homedir();
 
-let cfgPath = join(homeDir, cfgFile);
-let cfgDir = homeDir;
+const applicationDirectory = app.getPath('userData');
+
+let cfgPath = join(applicationDirectory, cfgFile);
+let cfgDir = applicationDirectory;
 
 const devDir = resolve(__dirname, '../..');
 const devCfg = join(devDir, cfgFile);
@@ -68,5 +71,6 @@ module.exports = {
   plugs,
   yarn,
   cliScriptPath,
-  cliLinkPath
+  cliLinkPath,
+  homeDirectory
 };

--- a/app/ui/window.js
+++ b/app/ui/window.js
@@ -6,7 +6,7 @@ const fileUriToPath = require('file-uri-to-path');
 const isDev = require('electron-is-dev');
 const updater = require('../updater');
 const toElectronBackgroundColor = require('../utils/to-electron-background-color');
-const {icon, cfgDir} = require('../config/paths');
+const {icon, homeDirectory} = require('../config/paths');
 const createRPC = require('../rpc');
 const notify = require('../notify');
 const fetchNotifications = require('../notifications');
@@ -103,7 +103,7 @@ module.exports = class Window {
         {
           rows: 40,
           cols: 100,
-          cwd: process.argv[1] && isAbsolute(process.argv[1]) ? process.argv[1] : cfgDir,
+          cwd: process.argv[1] && isAbsolute(process.argv[1]) ? process.argv[1] : homeDirectory,
           splitDirection: undefined,
           shell: cfg.shell,
           shellArgs: cfg.shellArgs && Array.from(cfg.shellArgs)


### PR DESCRIPTION
<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`
- If your PR changes some API, please make a PR for hyper website too: https://github.com/zeit/hyper-site.

Thanks, again! -->

#2948 introduced a unwanted behavior.
By changing base path it produced the `cfgDir` being used as session root.
In this case `Library/Application Support/Hyper` was used instead of `homedir` for the session.

This fix the introduced behavior and roll back it to it's previous state.


