### PR TITLE
Upgrading xterm.js to 3.11.0-1

### DIFF
--- a/package.json
+++ b/package.json
@@ -208,7 +208,7 @@
     "styled-jsx": "2.2.6",
     "stylis": "3.5.0",
     "uuid": "3.1.0",
-    "xterm": "https://registry.npmjs.org/@zeit/xterm/-/xterm-3.10.1-4.tgz"
+    "xterm": "https://registry.npmjs.org/@zeit/xterm/-/xterm-3.11.0-1.tgz"
   },
   "devDependencies": {
     "ava": "0.25.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7112,9 +7112,9 @@ xtend@~2.1.1:
   dependencies:
     object-keys "~0.4.0"
 
-"xterm@https://registry.npmjs.org/@zeit/xterm/-/xterm-3.10.1-4.tgz":
-  version "3.10.1-4"
-  resolved "https://registry.npmjs.org/@zeit/xterm/-/xterm-3.10.1-4.tgz#68d2796f09340f639e28859dc0fdcba4dfaaf788"
+"xterm@https://registry.npmjs.org/@zeit/xterm/-/xterm-3.11.0-1.tgz":
+  version "3.11.0-1"
+  resolved "https://registry.npmjs.org/@zeit/xterm/-/xterm-3.11.0-1.tgz#9f01caf6c098b0755e098724296a7283ac4b1695"
 
 y18n@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
`@zeit/xterm` published from this tag: https://github.com/zeit/xterm.js/releases/tag/3.11.0-1.

Main new feature:
 - [Reflow text on resize](https://github.com/xtermjs/xterm.js/pull/1864)