### PR TITLE
Fix hanging when zoom out goes below 5px (#3498)

### DIFF
--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -70,7 +70,8 @@ export function decreaseFontSize() {
       effect() {
         const state = getState();
         const old = state.ui.fontSizeOverride || state.ui.fontSize;
-        const value = old - 1;
+        // when the font-size is really small, below 5px, xterm starts showing up issues.
+        const value = old > 5 ? old - 1 : old;
         dispatch({
           type: UI_FONT_SIZE_SET,
           value


### PR DESCRIPTION
When the font size goes below 5px, xterm starts acting up and hangs. To avoid this,
the font-size is set to 5px minimum.

It's ready to be merged.
<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`
- If your PR changes some API, please make a PR for hyper website too: https://github.com/zeit/hyper-site.

Thanks, again! -->
