### PR TITLE
Fix handling ssh link with empty user

### DIFF
--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -287,7 +287,7 @@ export function openSSH(url) {
       type: UI_OPEN_SSH_URL,
       effect() {
         let parsedUrl = parseUrl(url, true);
-        let command = parsedUrl.protocol + ' ' + (parsedUrl.user || '') + '@' + parsedUrl.resource;
+        let command = parsedUrl.protocol + ' ' + (parsedUrl.user ? `${parsedUrl.user}@` : '') + parsedUrl.resource;
 
         if (parsedUrl.port) command += ' -p ' + parsedUrl.port;
 


### PR DESCRIPTION
<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`
- If your PR changes some API, please make a PR for hyper website too: https://github.com/zeit/hyper-site.

Thanks, again! -->

SSH links don't work when username is not specified. For example when I open _ssh://example.com_ link in Hyper I get this:
<img width="614" alt="Hyper 2019-03-13 12-20-33" src="https://user-images.githubusercontent.com/4231003/54260347-7dce8280-458a-11e9-8a59-f9ed2ec321fc.png">

According to ssh help output symbol `@` is a part of optional username param.