### PR TITLE
Upgrading xterm.js to 3.12.0-1

### DIFF
--- a/package.json
+++ b/package.json
@@ -208,7 +208,7 @@
     "styled-jsx": "2.2.6",
     "stylis": "3.5.0",
     "uuid": "3.1.0",
-    "xterm": "https://registry.npmjs.org/@zeit/xterm/-/xterm-3.11.0-1.tgz"
+    "xterm": "https://registry.npmjs.org/@zeit/xterm/-/xterm-3.12.0-1.tgz"
   },
   "devDependencies": {
     "ava": "0.25.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7112,9 +7112,9 @@ xtend@~2.1.1:
   dependencies:
     object-keys "~0.4.0"
 
-"xterm@https://registry.npmjs.org/@zeit/xterm/-/xterm-3.11.0-1.tgz":
-  version "3.11.0-1"
-  resolved "https://registry.npmjs.org/@zeit/xterm/-/xterm-3.11.0-1.tgz#9f01caf6c098b0755e098724296a7283ac4b1695"
+"xterm@https://registry.npmjs.org/@zeit/xterm/-/xterm-3.12.0-1.tgz":
+  version "3.12.0-1"
+  resolved "https://registry.npmjs.org/@zeit/xterm/-/xterm-3.12.0-1.tgz#df7bb98fe53d621c0bfd559d0ae87be401c8f246"
 
 y18n@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
This upgrades our fork of xterm.js to include the improvements from [3.12.0](https://github.com/xtermjs/xterm.js/releases/tag/3.12.0)
