### PR TITLE
Fixes #3542: x coordinate maps to col, and y coordinate maps to row

### DIFF
--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -174,8 +174,8 @@ export default class Term extends React.PureComponent {
             y: this.term._core.buffer.y * this.term._core.renderer.dimensions.actualCellHeight,
             width: this.term._core.renderer.dimensions.actualCellWidth,
             height: this.term._core.renderer.dimensions.actualCellHeight,
-            col: this.term._core.buffer.y,
-            row: this.term._core.buffer.x
+            col: this.term._core.buffer.x,
+            row: this.term._core.buffer.y
           };
           props.onCursorMove(cursorFrame);
         })


### PR DESCRIPTION
`cols` and `rows` properties of the `CursorFrame` object were swapped. `x` coordinate should be mapped to `col` and `y` coordinate to `row`.
![Rows and columns](https://i.imgur.com/FTRTYQL.png)