### PR TITLE
Use sane location for config

### DIFF
--- a/app/config/paths.js
+++ b/app/config/paths.js
@@ -9,7 +9,12 @@ const cfgFile = '.hyper.js';
 const defaultCfgFile = 'config-default.js';
 const homeDirectory = homedir();
 
-const applicationDirectory = app.getPath('userData');
+// If the user defines XDG_CONFIG_HOME they definitely want their config there,
+// otherwise use the home directory in linux/mac and userdata in windows
+const applicationDirectory =
+  process.env.XDG_CONFIG_HOME !== undefined
+    ? join(process.env.XDG_CONFIG_HOME, 'hyper')
+    : process.platform == 'win32' ? app.getPath('userData') : homedir();
 
 let cfgPath = join(applicationDirectory, cfgFile);
 let cfgDir = applicationDirectory;


### PR DESCRIPTION
 - If a user defines `XDG_CONFIG_HOME` use that, regardless of the operating system (why would a user define this if not to put config files there?)
 - Otherwise:
   - if linux/mac: use home
   - if windows: use `app.getPath('userData')` to prevent #1944 from coming back
