### PR TITLE
Add migration path from Hyper2 config location to Hyper3

### DIFF
--- a/app/config/import.js
+++ b/app/config/import.js
@@ -1,5 +1,5 @@
 const {writeFileSync, readFileSync} = require('fs');
-const {moveSync} = require('fs-extra-p');
+const {moveSync} = require('fs-extra');
 const {sync: mkdirpSync} = require('mkdirp');
 const {defaultCfg, cfgPath, legacyCfgPath, plugs, defaultPlatformKeyPath} = require('./paths');
 const {_init, _extractDefault} = require('./init');

--- a/app/config/import.js
+++ b/app/config/import.js
@@ -55,10 +55,11 @@ const migrate = (old, _new) => {
 };
 
 const _importConf = function() {
-  if (migrate(plugs.legacyBase, plugs.base) || migrate(legacyCfgPath, cfgPath)) {
+  // Migrate Hyper2 config to Hyper3
+  if (migrate(legacyCfgPath, cfgPath)) {
     notify(
       'Hyper 3',
-      `Our settings location changed to ${cfgPath}. We've automatically migrated your existing config!`
+      `Settings location has changed to ${cfgPath}.\nWe've automatically migrated your existing config!\nPlease restart hyper`
     );
   }
 

--- a/app/config/paths.js
+++ b/app/config/paths.js
@@ -39,6 +39,7 @@ if (isDev) {
 
 const plugins = resolve(cfgDir, '.hyper_plugins');
 const plugs = {
+  legacyBase: resolve(homeDirectory, '.hyper_plugins'),
   base: plugins,
   local: resolve(plugins, 'local'),
   cache: resolve(plugins, 'cache')

--- a/app/config/paths.js
+++ b/app/config/paths.js
@@ -39,7 +39,6 @@ if (isDev) {
 
 const plugins = resolve(cfgDir, '.hyper_plugins');
 const plugs = {
-  legacyBase: resolve(homeDirectory, '.hyper_plugins'),
   base: plugins,
   local: resolve(plugins, 'local'),
   cache: resolve(plugins, 'cache')

--- a/app/config/paths.js
+++ b/app/config/paths.js
@@ -39,6 +39,8 @@ if (isDev) {
 
 const plugins = resolve(cfgDir, '.hyper_plugins');
 const plugs = {
+  legacyBase: resolve(homeDirectory, '.hyper_plugins'),
+  legacyLocal: resolve(homeDirectory, '.hyper_plugins', 'local'),
   base: plugins,
   local: resolve(plugins, 'local'),
   cache: resolve(plugins, 'cache')

--- a/app/config/paths.js
+++ b/app/config/paths.js
@@ -16,8 +16,9 @@ const applicationDirectory =
     ? join(process.env.XDG_CONFIG_HOME, 'hyper')
     : process.platform == 'win32' ? app.getPath('userData') : homedir();
 
-let cfgPath = join(applicationDirectory, cfgFile);
 let cfgDir = applicationDirectory;
+let cfgPath = join(applicationDirectory, cfgFile);
+let legacyCfgPath = join(homeDirectory, cfgFile); // Hyper 2 config location
 
 const devDir = resolve(__dirname, '../..');
 const devCfg = join(devDir, cfgFile);
@@ -69,6 +70,7 @@ const defaultPlatformKeyPath = () => {
 module.exports = {
   cfgDir,
   cfgPath,
+  legacyCfgPath,
   cfgFile,
   defaultCfg,
   icon,

--- a/app/package.json
+++ b/app/package.json
@@ -19,6 +19,7 @@
     "electron-is-dev": "1.0.1",
     "electron-squirrel-startup": "1.0.0",
     "file-uri-to-path": "1.0.0",
+    "fs-extra": "7.0.1",
     "git-describe": "4.0.2",
     "lodash": "4.17.5",
     "mkdirp": "0.5.1",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -192,6 +192,15 @@ find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
+fs-extra@7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 get-stream@^2.2.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-2.3.1.tgz#5f38f93f346009666ee0150a054167f91bdd95de"
@@ -217,6 +226,11 @@ git-describe@4.0.2:
 graceful-fs@^4.1.11:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
+
+graceful-fs@^4.1.2, graceful-fs@^4.1.6:
+  version "4.1.15"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
+  integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
 
 iconv-lite@~0.4.13:
   version "0.4.19"
@@ -277,6 +291,13 @@ isomorphic-fetch@^2.1.1:
 js-tokens@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
+
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
+  optionalDependencies:
+    graceful-fs "^4.1.6"
 
 lcid@^2.0.0:
   version "2.0.0"
@@ -622,6 +643,11 @@ strip-eof@^1.0.0:
 ua-parser-js@^0.7.9:
   version "0.7.18"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.18.tgz#a7bfd92f56edfb117083b69e31d2aa8882d4b1ed"
+
+universalify@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
+  integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
 uuid@3.2.1:
   version "3.2.1"


### PR DESCRIPTION
This PR adds a migration path from Hyper2 config file locations to Hyper3 file locations.

The idea is to use the old file by moving it to the new location. While creating back ups for any existing files.

The old file is also renamed so that this happens only on the first run.

 - [x] Test on Linux
 - [ ] Test on MacOS
 - [ ] Test on Windows