### PR TITLE
Fix Hyper (canary) CMDs for install, list and silent failures

### DIFF
--- a/cli/api.js
+++ b/cli/api.js
@@ -54,23 +54,23 @@ const getParsedFile = memoize(() => recast.parse(getFileContents()));
 const getProperties = memoize(() => getParsedFile().program.body.map(obj => obj));
 
 const getPlugins = memoize(() => {
-  let plugins
+  let plugins;
   getProperties().find(property => {
     return Object.values(property.expression.right.properties).filter(
-      plugin => plugin.key.name === 'plugins' ? plugins = plugin.value.elements : null
-    )
-  })
-  return plugins
+      plugin => (plugin.key.name === 'plugins' ? (plugins = plugin.value.elements) : null)
+    );
+  });
+  return plugins;
 });
 
 const getLocalPlugins = memoize(() => {
-  let localPlugins
+  let localPlugins;
   getProperties().find(property => {
     return Object.values(property.expression.right.properties).filter(
-      plugin => plugin.key.name === 'localPlugins' ? localPlugins = plugin.value.elements : null
-    )
-  })
-  return localPlugins
+      plugin => (plugin.key.name === 'localPlugins' ? (localPlugins = plugin.value.elements) : null)
+    );
+  });
+  return localPlugins;
 });
 
 function exists() {
@@ -91,14 +91,13 @@ function save() {
 
 function existsOnNpm(plugin) {
   const name = getPackageName(plugin);
-  return got.get(registryUrl + name.toLowerCase(), { timeout: 10000, json: true })
-    .then(res => {
-      if (!res.body.versions) {
-        return Promise.reject(res);
-      } else {
-        return res
-      }
-    });
+  return got.get(registryUrl + name.toLowerCase(), {timeout: 10000, json: true}).then(res => {
+    if (!res.body.versions) {
+      return Promise.reject(res);
+    } else {
+      return res;
+    }
+  });
 }
 
 function getPackageName(plugin) {
@@ -116,7 +115,7 @@ function install(plugin, locally) {
   const array = locally ? getLocalPlugins() : getPlugins();
   return existsOnNpm(plugin)
     .catch(err => {
-      const { statusCode } = err;
+      const {statusCode} = err;
       if (statusCode && (statusCode === 404 || statusCode === 200)) {
         return Promise.reject(`${plugin} not found on npm`);
       }

--- a/cli/api.js
+++ b/cli/api.js
@@ -19,6 +19,7 @@ let fileName =
   process.env.NODE_ENV !== 'production' && fs.existsSync(devConfigFileName)
     ? devConfigFileName
     : path.join(applicationDirectory, '.hyper.js');
+
 /**
  * We need to make sure the file reading and parsing is lazy so that failure to
  * statically analyze the hyper configuration isn't fatal for all kinds of
@@ -50,13 +51,27 @@ const getFileContents = memoize(() => {
 
 const getParsedFile = memoize(() => recast.parse(getFileContents()));
 
-const getProperties = memoize(() => getParsedFile().program.body[0].expression.right.properties);
+const getProperties = memoize(() => getParsedFile().program.body.map(obj => obj));
 
-const getPlugins = memoize(() => getProperties().find(property => property.key.name === 'plugins').value.elements);
+const getPlugins = memoize(() => {
+  let plugins
+  getProperties().find(property => {
+    return Object.values(property.expression.right.properties).filter(
+      plugin => plugin.key.name === 'plugins' ? plugins = plugin.value.elements : null
+    )
+  })
+  return plugins
+});
 
-const getLocalPlugins = memoize(
-  () => getProperties().find(property => property.key.name === 'localPlugins').value.elements
-);
+const getLocalPlugins = memoize(() => {
+  let localPlugins
+  getProperties().find(property => {
+    return Object.values(property.expression.right.properties).filter(
+      plugin => plugin.key.name === 'localPlugins' ? localPlugins = plugin.value.elements : null
+    )
+  })
+  return localPlugins
+});
 
 function exists() {
   return getFileContents() !== undefined;
@@ -76,11 +91,14 @@ function save() {
 
 function existsOnNpm(plugin) {
   const name = getPackageName(plugin);
-  return got.get(registryUrl + name.toLowerCase(), {timeout: 10000, json: true}).then(res => {
-    if (!res.body.versions) {
-      return Promise.reject(res);
-    }
-  });
+  return got.get(registryUrl + name.toLowerCase(), { timeout: 10000, json: true })
+    .then(res => {
+      if (!res.body.versions) {
+        return Promise.reject(res);
+      } else {
+        return res
+      }
+    });
 }
 
 function getPackageName(plugin) {
@@ -98,7 +116,7 @@ function install(plugin, locally) {
   const array = locally ? getLocalPlugins() : getPlugins();
   return existsOnNpm(plugin)
     .catch(err => {
-      const {statusCode} = err;
+      const { statusCode } = err;
       if (statusCode && (statusCode === 404 || statusCode === 200)) {
         return Promise.reject(`${plugin} not found on npm`);
       }


### PR DESCRIPTION
Issue refs: #3620 and #3648

## The Problem
Running `hyper install <plugin_name>` ultimately failed on each run. This much was obvious.
What was not immediately obvious was the silent failure when running `hyper list`.

## The Solution
This commit primarily focusses on altering the logic behind the following function expressions:
- `getProperties`
- `getPlugins`
- `getLocalPlugins`

By using native, immutable JS Array methods rather than the former practice of hard coding index values.

As a side note, the function `existsOnNpm` needed a return of the `res` added to fulfill it's promise output correctly,  rather than `undefined`. Was not necessary but was another silent failure that wasn't immediately noticeable.

`hyper list` required broadening the context of `getProperties`

Cheers!