### PR TITLE
Add config option for selected text color setting

### DIFF
--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -77,6 +77,8 @@ const getTermOptions = props => {
       background: backgroundColor,
       cursor: props.cursorColor,
       cursorAccent: props.cursorAccentColor,
+    // TODO: Add a config option for selected text color setting #2934
+    // https://github.com/zeit/hyper/issues/2934
       selection: props.selectionColor,
       black: props.colors.black,
       red: props.colors.red,

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -77,8 +77,8 @@ const getTermOptions = props => {
       background: backgroundColor,
       cursor: props.cursorColor,
       cursorAccent: props.cursorAccentColor,
-    // TODO: Add a config option for selected text color setting #2934
-    // https://github.com/zeit/hyper/issues/2934
+      // TODO: Add a config option for selected text color setting #2934
+      // https://github.com/zeit/hyper/issues/2934
       selection: props.selectionColor,
       black: props.colors.black,
       red: props.colors.red,


### PR DESCRIPTION

## as per: Add a config option for selected text colour setting #2934
**Not really useful you may think, I have put a "commented out" reminder within a `TODO` memo,** *to remember to do it* **I will try to change it myself but until then it could stay there as a reminder**  

- **To help whoever reviews this PR, it'd be extremely helpful to list whether this PR is ready to be merged:** 
it is only a commented TODO, for now at least, so it is ready to be merged indeed

- **If your PR changes some API, please make a PR for hyper website too: https://github.com/zeit/hyper-site.**
If I can change it myself without breaking everything I will add the option in the list on the web site.  



