### PR TITLE
fix: load scoped plugins

### DIFF
--- a/app/plugins.js
+++ b/app/plugins.js
@@ -245,7 +245,7 @@ exports.subscribe = fn => {
 function getPaths() {
   return {
     plugins: plugins.plugins.map(name => {
-      return resolve(path, 'node_modules', name.split('#')[0].split('@')[0]);
+      return resolve(path, 'node_modules', name.split('#')[0]);
     }),
     localPlugins: plugins.localPlugins.map(name => {
       return resolve(localPath, name);


### PR DESCRIPTION
Scoped plugins (ie. `@scoped/some-package`) are downloaded successfully, but fail to load. This was due to the resolved file name being returned as an empty string from improper string splitting.

This PR is ready for merge.
