### PR TITLE
Add a way to fix macos compiler error to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ make sure its build process is working correctly by running `yarn run rebuild-no
 If you are on macOS, this typically is related to Xcode issues (like not having agreed
 to the Terms of Service by running `sudo xcodebuild` after a fresh Xcode installation).
 
+##### Error with `c++` on macOS when running `yarn`
+
+If you are getting compiler errors when running `yarn` add the environment variable `export CXX=clang++`
+
 ##### Error with `codesign` on macOS when running `yarn run dist`
 
 If you have issues in the `codesign` step when running `yarn run dist` on macOS, you can temporarily disable code signing locally by setting


### PR DESCRIPTION
I got an error like following when running `yarn` running on macOS.

```
gyp info using node-gyp@3.8.0
gyp info using node@12.1.0 | darwin | x64
gyp info spawn /usr/bin/python
gyp info spawn args [
gyp info spawn args   '/Users/chamoda/Dev/hyper/node_modules/electron-rebuild/node_modules/node-gyp/gyp/gyp_main.py',
gyp info spawn args   'binding.gyp',
gyp info spawn args   '-f',
gyp info spawn args   'make',
gyp info spawn args   '-I',
gyp info spawn args   '/Users/chamoda/Dev/hyper/app/node_modules/node-pty/build/config.gypi',
gyp info spawn args   '-I',
gyp info spawn args   '/Users/chamoda/Dev/hyper/node_modules/electron-rebuild/node_modules/node-gyp/addon.gypi',
gyp info spawn args   '-I',
gyp info spawn args   '/Users/chamoda/.electron-gyp/.node-gyp/iojs-3.1.3/common.gypi',
gyp info spawn args   '-Dlibrary=shared_library',
gyp info spawn args   '-Dvisibility=default',
gyp info spawn args   '-Dnode_root_dir=/Users/chamoda/.electron-gyp/.node-gyp/iojs-3.1.3',
gyp info spawn args   '-Dnode_gyp_dir=/Users/chamoda/Dev/hyper/node_modules/electron-rebuild/node_modules/node-gyp',
gyp info spawn args   '-Dnode_lib_file=/Users/chamoda/.electron-gyp/.node-gyp/iojs-3.1.3/<(target_arch)/iojs.lib',
gyp info spawn args   '-Dmodule_root_dir=/Users/chamoda/Dev/hyper/app/node_modules/node-pty',
gyp info spawn args   '-Dnode_engine=v8',
gyp info spawn args   '--depth=.',
gyp info spawn args   '--no-parallel',
gyp info spawn args   '--generator-output',
gyp info spawn args   'build',
gyp info spawn args   '-Goutput_dir=.'
gyp info spawn args ]
gyp info spawn make
gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
  CXX(target) Release/obj.target/pty/src/unix/pty.o
c++: error: unrecognized command line option ‘-stdlib=libc++’
c++: error: unrecognized command line option ‘-stdlib=libc++’
make: *** [Release/obj.target/pty/src/unix/pty.o] Error 1
gyp ERR! build error
gyp ERR! stack Error: `make` failed with exit code: 2
```
Way to fix this is adding `export CXX=clang++` to the context.

I modified the README.md assuming this is a common situation on macOS.
