### PR TITLE
Support dark mode on macOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,8 @@
     },
     "mac": {
       "category": "public.app-category.developer-tools",
-      "extendInfo": "build/Info.plist"
+      "extendInfo": "build/Info.plist",
+      "darkModeSupport": true
     },
     "deb": {
       "afterInstall": "./build/linux/after-install.tpl"


### PR DESCRIPTION
Using this option of `electron-builder` makes the native title bar to match system theme (for example using [leo/hyper-native](https://github.com/leo/hyper-native))

![dark hyper](https://user-images.githubusercontent.com/4324982/58124196-e92d7400-7c0d-11e9-8ca3-b83054356b3b.gif)
