### PR TITLE
Drag directories/files into the command line, will copy the path of this file.

### DIFF
--- a/app/ui/window.js
+++ b/app/ui/window.js
@@ -36,7 +36,10 @@ module.exports = class Window {
         transparent: process.platform === 'darwin',
         icon,
         show: process.env.HYPER_DEBUG || process.env.HYPERTERM_DEBUG || isDev,
-        acceptFirstMouse: true
+        acceptFirstMouse: true,
+        webPreferences: {
+          navigateOnDragDrop: true
+        }
       },
       options_
     );


### PR DESCRIPTION
Hey, 

I saw this issue ( #3582 ), and I found a solution for the latest version of `canary` by updating the `BrowserWindow`option. 
( I didn't see any Pull Request on this subject if there is already one I will remove mine )

This commit should be ready to be merged.
Let me know if you need anything else.