### PR TITLE
fix: Hyper window freezes when I try to close it

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -24,7 +24,7 @@
     "lodash": "4.17.13",
     "mkdirp": "0.5.1",
     "ms": "2.1.1",
-    "node-pty": "0.8.0",
+    "node-pty": "0.8.1",
     "os-locale": "3.1.0",
     "parse-url": "3.0.2",
     "queue": "4.4.2",

--- a/app/session.js
+++ b/app/session.js
@@ -20,6 +20,7 @@ try {
 }
 
 const envFromConfig = config.getConfig().env || {};
+const useConpty = config.getConfig().useConpty;
 
 // Max duration to batch session data before sending it to the renderer process.
 const BATCH_DURATION_MS = 16;
@@ -107,13 +108,20 @@ module.exports = class Session extends EventEmitter {
 
     const defaultShellArgs = ['--login'];
 
+    const options = {
+      cols: columns,
+      rows,
+      cwd,
+      env: getDecoratedEnv(baseEnv)
+    };
+
+    // if config do not set the useConpty, it will be judged by the node-pty
+    if (typeof useConpty === 'boolean') {
+      options.experimentalUseConpty = useConpty;
+    }
+
     try {
-      this.pty = spawn(shell || defaultShell, shellArgs || defaultShellArgs, {
-        cols: columns,
-        rows,
-        cwd,
-        env: getDecoratedEnv(baseEnv)
-      });
+      this.pty = spawn(shell || defaultShell, shellArgs || defaultShellArgs, options);
     } catch (err) {
       if (/is not a function/.test(err.message)) {
         throw createNodePtyError();

--- a/app/ui/window.js
+++ b/app/ui/window.js
@@ -127,7 +127,12 @@ module.exports = class Window {
       let {session, options} = createSession();
       const initialEvents = [];
       const handleData = data => initialEvents.push(['session data', data]);
-      const handleExit = () => initialEvents.push(['session exit']);
+      const handleExit = () => {
+        // the warmed up session exits when open hyper by cli.
+        session.removeListener('data', handleData);
+        session.removeListener('exit', handleExit);
+        initialSession = null;
+      };
       session.on('data', handleData);
       session.on('exit', handleExit);
 

--- a/app/ui/window.js
+++ b/app/ui/window.js
@@ -123,12 +123,13 @@ module.exports = class Window {
 
     // Optimistically create the initial session so that when the window sends
     // the first "new" IPC message, there's a session already warmed up.
+    let initialSession = null;
     function createInitialSession() {
       let {session, options} = createSession();
       const initialEvents = [];
       const handleData = data => initialEvents.push(['session data', data]);
       const handleExit = () => {
-        // the warmed up session exits when open hyper by cli.
+        // the warmed up session should be cleaned if exit before add a new session.
         session.removeListener('data', handleData);
         session.removeListener('exit', handleExit);
         initialSession = null;
@@ -145,7 +146,7 @@ module.exports = class Window {
       }
       return {session, options, flushEvents};
     }
-    let initialSession = createInitialSession();
+    initialSession = createInitialSession();
 
     rpc.on('new', extraOptions => {
       const {session, options} = initialSession || createSession(extraOptions);

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -375,10 +375,10 @@ ms@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
 
-nan@2.10.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
-  integrity sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==
+nan@2.12.1:
+  version "2.12.1"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.12.1.tgz#7b1aa193e9aa86057e3c7bbd0ac448e770925552"
+  integrity sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==
 
 nice-try@^1.0.4:
   version "1.0.5"
@@ -392,12 +392,12 @@ node-fetch@^1.0.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
-node-pty@0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.8.0.tgz#08bccb633f49e2e3f7245eb56ea6b40f37ccd64f"
-  integrity sha512-g5ggk3gN4gLrDmAllee5ScFyX3YzpOC/U8VJafha4pE7do0TIE1voiIxEbHSRUOPD1xYqmY+uHhOKAd3avbxGQ==
+node-pty@0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.8.1.tgz#94b457bec013e7a09b8d9141f63b0787fa25c23f"
+  integrity sha512-j+/g0Q5dR+vkELclpJpz32HcS3O/3EdPSGPvDXJZVJQLCvgG0toEbfmymxAEyQyZEpaoKHAcoL+PvKM+4N9nlw==
   dependencies:
-    nan "2.10.0"
+    nan "2.12.1"
 
 normalize-url@^1.9.1:
   version "1.9.1"


### PR DESCRIPTION
<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`
- If your PR changes some API, please make a PR for hyper website too: https://github.com/zeit/hyper-site.

Thanks, again! -->
I found the windows freezes because of node-pty can not be killed, and the new version [0.8.1](https://github.com/microsoft/node-pty/releases/tag/0.8.1) of node-pty fix it. and I also add a config `useConpty`. the related issues #3736.
another related issues #3758 happened because of the warmed-up session exit(I don't know why). If set config `useConpty` to false, it will open correctly according to the test on my windows 10  version 1903.