### PR TITLE
fix search addon import

### DIFF
--- a/lib/components/term-group.js
+++ b/lib/components/term-group.js
@@ -87,7 +87,6 @@ class TermGroup_ extends React.PureComponent {
       onResize: this.bind(this.props.onResize, null, uid),
       onTitle: this.bind(this.props.onTitle, null, uid),
       onData: this.bind(this.props.onData, null, uid),
-      onURLAbort: this.bind(this.props.onURLAbort, null, uid),
       toggleSearch: this.bind(this.props.toggleSearch, null, uid),
       onContextMenu: this.bind(this.props.onContextMenu, null, uid),
       borderColor: this.props.borderColor,

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -3,7 +3,7 @@ import React from 'react';
 import {Terminal} from 'xterm';
 import * as fit from 'xterm/lib/addons/fit/fit';
 import * as webLinks from 'xterm/lib/addons/webLinks/webLinks';
-import * as search from 'xterm/lib/addons/search';
+import * as search from 'xterm/lib/addons/search/search';
 import * as winptyCompat from 'xterm/lib/addons/winptyCompat/winptyCompat';
 import {clipboard} from 'electron';
 import * as Color from 'color';


### PR DESCRIPTION
<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`
- If your PR changes some API, please make a PR for hyper website too: https://github.com/zeit/hyper-site.

Thanks, again! -->
fixes the search addon import and removes onURLAbort from term props as it is undefined and blocking hyper from starting
