### PR TITLE
eslint config small fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
           "bracketSpacing": false,
           "semi": true,
           "useTabs": false,
-          "parser": "babel",
           "jsxBracketSameLine": false
         }
       ]


### PR DESCRIPTION
removed babel parser override config from prettier, it should use typescript parser instead

<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`
- If your PR changes some API, please make a PR for hyper website too: https://github.com/zeit/hyper-site.

Thanks, again! -->
