### PR TITLE
Bump xterm@4.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -261,7 +261,7 @@
     "stylis": "3.5.0",
     "uuid": "3.1.0",
     "webpack-cli": "3.3.7",
-    "xterm": "~4.0.2",
+    "xterm": "~4.1.0",
     "xterm-addon-fit": "^0.2.1",
     "xterm-addon-search": "^0.2.1",
     "xterm-addon-web-links": "^0.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9237,10 +9237,10 @@ xterm-addon-webgl@^0.2.1:
   resolved "https://registry.yarnpkg.com/xterm-addon-webgl/-/xterm-addon-webgl-0.2.1.tgz#86452460601dc29b7d907dbcd0b8a058bcbc6bcf"
   integrity sha512-MZyh/KGbOBEEOqGpgilHuKHSj0OCXiZsBedTtLesHNerc79710shUHnfBlk31ggYU9G/WJ91qoNNux3ek5QBPA==
 
-xterm@~4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/xterm/-/xterm-4.0.2.tgz#c6a1b9586c0786627625e2ee9e78ad519dbc8c99"
-  integrity sha512-NIr11b6C782TZznU8e6K/IMfmwlWMWRI6ba9GEDG9uX25SadkpjoMnzvxOS0Z/15sfrbn0rghPiarGDmmP0uhQ==
+xterm@~4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/xterm/-/xterm-4.1.0.tgz#f6b6e127d1a1e31cef709b45fca845bf818602ce"
+  integrity sha512-RolKCONgwaEqt7FBMUeoxn4W/2JoopNi3nxfZDmQ6xwelCNCAAYNw4W97QenXefQyvholn5xMAsS0nnIwjwhHw==
 
 y18n@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
[Release notes of xterm@4.1.0](https://github.com/xtermjs/xterm.js/releases/tag/4.1.0).

I quickly tested this upgrade and haven't seen any problems so far on macOS.