### PR TITLE
Fix getters in lib/index.js

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -26,10 +26,10 @@ if (process.platform === 'linux') {
 
 const store_ = configureStore();
 
-window.__defineGetter__('store', () => store_);
-window.__defineGetter__('rpc', () => rpc);
-window.__defineGetter__('config', () => config);
-window.__defineGetter__('plugins', () => plugins);
+Object.defineProperty(window, 'store', {get: () => store_});
+Object.defineProperty(window, 'rpc', {get: () => rpc});
+Object.defineProperty(window, 'config', {get: () => config});
+Object.defineProperty(window, 'plugins', {get: () => plugins});
 
 const fetchFileData = configData => {
   const configInfo = Object.assign({}, configData, {bellSound: null});


### PR DESCRIPTION
Object.prototype.\_\_defineGetter__() is deprecated [ref](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineGetter__)
Using Object.defineProperty() instead.