### PR TITLE
Fix undefined resizeObserver error during split

### DIFF
--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -426,18 +426,16 @@ export default class Term extends React.PureComponent {
   onTermWrapperRef(component) {
     this.termWrapperRef = component;
 
-    let resizeTimeout;
-    let resizeObserver;
     if (component) {
-      resizeObserver = new ResizeObserver(() => {
-        clearTimeout(resizeTimeout);
-        resizeTimeout = setTimeout(() => {
+      this.resizeObserver = new ResizeObserver(() => {
+        clearTimeout(this.resizeTimeout);
+        this.resizeTimeout = setTimeout(() => {
           this.fitResize();
         }, 500);
       });
-      resizeObserver.observe(component);
+      this.resizeObserver.observe(component);
     } else {
-      resizeObserver.disconnect();
+      this.resizeObserver.disconnect();
     }
   }
 


### PR DESCRIPTION
Fix 'cannot read property disconnect of undefined' error which is logged on creating a new split. This was introduced during update to electron v6.
<img width="535" alt="Screenshot 2019-10-12 at 19 38 47" src="https://user-images.githubusercontent.com/16598275/66702759-c91b6000-ed28-11e9-9f0c-a68b4a9b3b6d.png">
