### PR TITLE
Update redux devtools usage syntax

### DIFF
--- a/lib/store/configure-store.dev.js
+++ b/lib/store/configure-store.dev.js
@@ -8,7 +8,7 @@ import writeMiddleware from './write-middleware';
 export default () => {
   const enhancer = compose(
     applyMiddleware(thunk, plugins.middleware, thunk, writeMiddleware, effects),
-    window.devToolsExtension()
+    window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
   );
 
   return createStore(rootReducer, enhancer);


### PR DESCRIPTION
redux devtools [repo](https://github.com/zalmoxisus/redux-devtools-extension#11-basic-store) states new usage syntax.
Fixes this error in console.
<img width="1190" alt="Screenshot 2019-10-19 at 11 02 54" src="https://user-images.githubusercontent.com/16598275/67138421-63673080-f260-11e9-8fd4-cc0e539ef5fd.png">

