### PR TITLE
mark bin/* as vendored code to get correct language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 * text=auto
 *.js text eol=lf
+bin/* linguist-vendored


### PR DESCRIPTION
[ref](https://github.com/github/linguist#vendored-code)
This will get github to ignore files in bin/ i.e. yarn and rimraf while calculating the language stats of the repo. Thus giving a better idea of the distribution.