### PR TITLE
Replace deprecated use of node-pty

### DIFF
--- a/app/session.js
+++ b/app/session.js
@@ -131,7 +131,7 @@ module.exports = class Session extends EventEmitter {
     }
 
     this.batcher = new DataBatcher(uid);
-    this.pty.on('data', chunk => {
+    this.pty.onData(chunk => {
       if (this.ended) {
         return;
       }
@@ -142,7 +142,7 @@ module.exports = class Session extends EventEmitter {
       this.emit('data', data);
     });
 
-    this.pty.on('exit', () => {
+    this.pty.onExit(() => {
       if (!this.ended) {
         this.ended = true;
         this.emit('exit');

--- a/app/session.js
+++ b/app/session.js
@@ -117,7 +117,7 @@ module.exports = class Session extends EventEmitter {
 
     // if config do not set the useConpty, it will be judged by the node-pty
     if (typeof useConpty === 'boolean') {
-      options.experimentalUseConpty = useConpty;
+      options.useConpty = useConpty;
     }
 
     try {


### PR DESCRIPTION
[`node-pty@0.9.0`](https://github.com/microsoft/node-pty/releases/tag/0.9.0) has deprecated the `on` event format and conpty support to stable. This PR switches to the new methods.