### PR TITLE
Fix Issue-3955 Blurry Text

### DIFF
--- a/lib/reducers/ui.js
+++ b/lib/reducers/ui.js
@@ -132,8 +132,8 @@ const reducer = (state = initial, action) => {
             }
 
             if (config.fontSize) {
-                ret.lineHeight = config.lineHeight;
-              if(config.fontSize % 2 === 0){
+              ret.lineHeight = config.lineHeight;
+              if (config.fontSize % 2 === 0) {
                 ret.lineHeight = config.lineHeight + 0.1;
               }
             }
@@ -155,7 +155,7 @@ const reducer = (state = initial, action) => {
             }
 
             if (Number.isFinite(config.lineHeight)) {
-                ret.lineHeight = config.lineHeight;
+              ret.lineHeight = config.lineHeight;
             }
 
             if (Number.isFinite(config.letterSpacing)) {

--- a/lib/reducers/ui.js
+++ b/lib/reducers/ui.js
@@ -50,7 +50,7 @@ const initial = Immutable({
   fontSmoothingOverride: 'antialiased',
   fontWeight: 'normal',
   fontWeightBold: 'bold',
-  lineHeight: 1,
+  lineHeight: 1.1,
   letterSpacing: 0,
   css: '',
   termCSS: '',
@@ -132,7 +132,10 @@ const reducer = (state = initial, action) => {
             }
 
             if (config.fontSize) {
-              ret.fontSize = config.fontSize;
+                ret.lineHeight = config.lineHeight;
+              if(config.fontSize % 2 === 0){
+                ret.lineHeight = config.lineHeight + 0.1;
+              }
             }
 
             if (config.fontFamily) {
@@ -152,7 +155,7 @@ const reducer = (state = initial, action) => {
             }
 
             if (Number.isFinite(config.lineHeight)) {
-              ret.lineHeight = config.lineHeight;
+                ret.lineHeight = config.lineHeight;
             }
 
             if (Number.isFinite(config.letterSpacing)) {


### PR DESCRIPTION
Issue #3955, there is a blurry text issue when resizing the window size or zooming in/out. 
I found out that the blurry text is related to the font-size and line-height. 

Interestingly, the font-size is an even number, it becomes blurry when the line-height is 1 but not line-height is over 1.1. In contrast, a font size is an odd number, text look blurry when the line-height is over 1. I fix the issue by adding line-height in ui.js.

Perhaps, it may need to be addressed in a different way. So I hope this code will be reviewed. 

Thanks.
