### PR TITLE
Fix os-locale format

### DIFF
--- a/app/session.js
+++ b/app/session.js
@@ -90,7 +90,7 @@ module.exports = class Session extends EventEmitter {
       {},
       process.env,
       {
-        LANG: osLocale.sync() + '.UTF-8',
+        LANG: osLocale.sync().replace(/-/, '_') + '.UTF-8',
         TERM: 'xterm-256color',
         COLORTERM: 'truecolor',
         TERM_PROGRAM: productName,


### PR DESCRIPTION
`os-locale` has changed the format of result in `4.0.0` (`en_US` → `en-US`) : sindresorhus/os-locale@2a3fccb
And we updated `os-locale` to `4.0.0` in #3913
So we need to fix the using of `os-locale`