### PR TITLE
Bump prettier from 1.18.2 to 1.19.1 and fix lint errors

### DIFF
--- a/lib/reducers/ui.ts
+++ b/lib/reducers/ui.ts
@@ -432,7 +432,8 @@ const reducer = (state = initial, action: any) => {
   if (
     typeof state.cols !== 'undefined' &&
     state.cols !== null &&
-    (typeof state.rows !== 'undefined' && state.rows !== null) &&
+    typeof state.rows !== 'undefined' &&
+    state.rows !== null &&
     (state.rows !== state_.rows || state.cols !== state_.cols)
   ) {
     state_ = state_.merge({notifications: {resize: true}}, {deep: true});

--- a/lib/selectors.ts
+++ b/lib/selectors.ts
@@ -2,12 +2,10 @@ import {createSelector} from 'reselect';
 import {HyperState} from './hyper';
 
 const getTermGroups = ({termGroups}: Pick<HyperState, 'termGroups'>) => termGroups.termGroups;
-const getRootGroups = createSelector(
-  getTermGroups,
-  termGroups =>
-    Object.keys(termGroups)
-      .map(uid => termGroups[uid])
-      .filter(({parentUid}) => !parentUid)
+const getRootGroups = createSelector(getTermGroups, termGroups =>
+  Object.keys(termGroups)
+    .map(uid => termGroups[uid])
+    .filter(({parentUid}) => !parentUid)
 );
 
 export default getRootGroups;

--- a/package.json
+++ b/package.json
@@ -321,7 +321,7 @@
     "node-gyp": "6.0.1",
     "null-loader": "3.0.0",
     "plist": "3.0.1",
-    "prettier": "1.18.2",
+    "prettier": "1.19.1",
     "proxyquire": "2.1.3",
     "spectron": "9.0.0",
     "style-loader": "1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6616,10 +6616,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@1.18.2:
-  version "1.18.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
-  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+prettier@1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
 pretty-bytes@^1.0.2:
   version "1.0.4"


### PR DESCRIPTION
#3989 
fixes the eslint errors in ci