### PR TITLE
remove unused onURLAbort prop

### DIFF
--- a/lib/components/terms.js
+++ b/lib/components/terms.js
@@ -124,7 +124,6 @@ export default class Terms extends React.Component {
             onTitle: this.props.onTitle,
             onData: this.props.onData,
             toggleSearch: this.props.toggleSearch,
-            onURLAbort: this.props.onURLAbort,
             onContextMenu: this.props.onContextMenu,
             quickEdit: this.props.quickEdit,
             webGLRenderer: this.props.webGLRenderer,


### PR DESCRIPTION
It was removed from TermGroup in #3830 