### PR TITLE
remove getLastTermIndex

### DIFF
--- a/lib/components/terms.js
+++ b/lib/components/terms.js
@@ -53,10 +53,6 @@ export default class Terms extends React.Component {
     return this.getTermByUid(this.props.activeSession);
   }
 
-  getLastTermIndex() {
-    return this.props.sessions.length - 1;
-  }
-
   onTerminal(uid, term) {
     this.terms[uid] = term;
   }


### PR DESCRIPTION
sessions is an object {[uid]: session} not an array
getLastTermIndex doesn't seem to be referenced anywhere though, we can also remove it.