### PR TITLE
change export syntax in app/plugins/install.js

### DIFF
--- a/app/plugins/install.js
+++ b/app/plugins/install.js
@@ -3,48 +3,46 @@ import queue from 'queue';
 import ms from 'ms';
 import {yarn, plugs} from '../config/paths';
 
-export default {
-  install: fn => {
-    const spawnQueue = queue({concurrency: 1});
-    function yarnFn(args, cb) {
-      const env = {
-        NODE_ENV: 'production',
-        ELECTRON_RUN_AS_NODE: 'true'
-      };
-      spawnQueue.push(end => {
-        const cmd = [process.execPath, yarn].concat(args).join(' ');
-        //eslint-disable-next-line no-console
-        console.log('Launching yarn:', cmd);
+export const install = fn => {
+  const spawnQueue = queue({concurrency: 1});
+  function yarnFn(args, cb) {
+    const env = {
+      NODE_ENV: 'production',
+      ELECTRON_RUN_AS_NODE: 'true'
+    };
+    spawnQueue.push(end => {
+      const cmd = [process.execPath, yarn].concat(args).join(' ');
+      //eslint-disable-next-line no-console
+      console.log('Launching yarn:', cmd);
 
-        cp.execFile(
-          process.execPath,
-          [yarn].concat(args),
-          {
-            cwd: plugs.base,
-            env,
-            timeout: ms('5m'),
-            maxBuffer: 1024 * 1024
-          },
-          (err, stdout, stderr) => {
-            if (err) {
-              cb(stderr);
-            } else {
-              cb(null);
-            }
-            end();
-            spawnQueue.start();
+      cp.execFile(
+        process.execPath,
+        [yarn].concat(args),
+        {
+          cwd: plugs.base,
+          env,
+          timeout: ms('5m'),
+          maxBuffer: 1024 * 1024
+        },
+        (err, stdout, stderr) => {
+          if (err) {
+            cb(stderr);
+          } else {
+            cb(null);
           }
-        );
-      });
-
-      spawnQueue.start();
-    }
-
-    yarnFn(['install', '--no-emoji', '--no-lockfile', '--cache-folder', plugs.cache], err => {
-      if (err) {
-        return fn(err);
-      }
-      fn(null);
+          end();
+          spawnQueue.start();
+        }
+      );
     });
+
+    spawnQueue.start();
   }
+
+  yarnFn(['install', '--no-emoji', '--no-lockfile', '--cache-folder', plugs.cache], err => {
+    if (err) {
+      return fn(err);
+    }
+    fn(null);
+  });
 };


### PR DESCRIPTION
It is being imported as named import in [app/plugins.js](https://github.com/zeit/hyper/blob/5b481bbc621666728a7e9ddf7b6dd911b8edb9f8/app/plugins.js#L11) (#4021 ), so changing the export.