### PR TITLE
Fix issue where hyper {command} fails

### DIFF
--- a/cli/api.js
+++ b/cli/api.js
@@ -50,7 +50,8 @@ const getFileContents = memoize(() => {
 
 const getParsedFile = memoize(() => recast.parse(getFileContents()));
 
-const getProperties = memoize(() => getParsedFile().program.body[0].expression.right.properties);
+const whichBodyIndex = getParsedFile().program.body[0].expression.right ? 0 : 1;
+const getProperties = memoize(() => getParsedFile().program.body[whichBodyIndex].expression.right.properties);
 
 const getPlugins = memoize(() => getProperties().find(property => property.key.name === 'plugins').value.elements);
 


### PR DESCRIPTION
<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`
- If your PR changes some API, please make a PR for hyper website too: https://github.com/zeit/hyper-site.

Thanks, again! -->

This is an attempt at fixing #3500. I am not super familiar with this codebase but I logged out the values here and found that when this was failing, it needed to be grabbing values from the other index on `body`. This is a relatively naive approach since I don't fully understand what's going on, but it does fix the issue as far as I was able to test. I don't really know how it even gets in a state where this fails, but as I said this seems to do the trick. Definitely open to feedback or other approaches...

cc: @chabou since he is assigned to the open issue