### PR TITLE
update tsc target to es2018

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -17,6 +17,6 @@
     "resolveJsonModule": true,
     "sourceMap": true,
     "strict": true,
-    "target": "es6"
+    "target": "es2018"
   }
 }


### PR DESCRIPTION
It's better to update tsc target to es2017/es2018 because the electron is the latest version and no need to be compatible with older browser.
describe here #4080
https://github.com/microsoft/vscode/pull/80050
I update to es2018, looks work fine. @LabhanshAgrawal, I hope you can test it again.

<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`
- If your PR changes some API, please make a PR for hyper website too: https://github.com/zeit/hyper-site.

Thanks, again! -->
