### PR TITLE
Fix babel scope tracker error on build

### DIFF
--- a/lib/actions/term-groups.ts
+++ b/lib/actions/term-groups.ts
@@ -8,7 +8,7 @@ import {
 } from '../constants/term-groups';
 import {SESSION_REQUEST} from '../constants/sessions';
 import findBySession from '../utils/term-groups';
-import getRootGroups from '../selectors';
+import {getRootGroups} from '../selectors';
 import {setActiveSession, ptyExitSession, userExitSession} from './sessions';
 import {Dispatch} from 'redux';
 import {ITermState, ITermGroup, HyperState} from '../hyper';

--- a/lib/actions/ui.ts
+++ b/lib/actions/ui.ts
@@ -1,6 +1,6 @@
 import {php_escapeshellcmd as escapeShellCmd} from 'php-escape-shell';
 import {isExecutable} from '../utils/file';
-import getRootGroups from '../selectors';
+import {getRootGroups} from '../selectors';
 import findBySession from '../utils/term-groups';
 import notify from '../utils/notify';
 import rpc from '../rpc';

--- a/lib/containers/header.ts
+++ b/lib/containers/header.ts
@@ -4,7 +4,7 @@ import {createSelector} from 'reselect';
 import Header from '../components/header';
 import {closeTab, changeTab, maximize, openHamburgerMenu, unmaximize, minimize, close} from '../actions/header';
 import {connect} from '../utils/plugins';
-import getRootGroups from '../selectors';
+import {getRootGroups} from '../selectors';
 import {HyperState} from '../hyper';
 import {Dispatch} from 'redux';
 
@@ -29,7 +29,7 @@ const getTabs = createSelector(
     })
 );
 
-const HeaderContainer = connect(
+export const HeaderContainer = connect(
   (state: HyperState) => {
     return {
       // active is an index
@@ -77,5 +77,3 @@ const HeaderContainer = connect(
   },
   null
 )(Header, 'Header');
-
-export default HeaderContainer;

--- a/lib/containers/hyper.tsx
+++ b/lib/containers/hyper.tsx
@@ -8,7 +8,7 @@ import * as uiActions from '../actions/ui';
 import {getRegisteredKeys, getCommandHandler, shouldPreventDefault} from '../command-registry';
 import stylis from 'stylis';
 
-import HeaderContainer from './header';
+import {HeaderContainer} from './header';
 import TermsContainer from './terms';
 import NotificationsContainer from './notifications';
 import {HyperState} from '../hyper';

--- a/lib/containers/terms.ts
+++ b/lib/containers/terms.ts
@@ -3,7 +3,7 @@ import {connect} from '../utils/plugins';
 import {resizeSession, sendSessionData, setSessionXtermTitle, setActiveSession, onSearch} from '../actions/sessions';
 
 import {openContextMenu} from '../actions/ui';
-import getRootGroups from '../selectors';
+import {getRootGroups} from '../selectors';
 import {HyperState, TermsProps} from '../hyper';
 import {Dispatch} from 'redux';
 

--- a/lib/selectors.ts
+++ b/lib/selectors.ts
@@ -2,10 +2,8 @@ import {createSelector} from 'reselect';
 import {HyperState} from './hyper';
 
 const getTermGroups = ({termGroups}: Pick<HyperState, 'termGroups'>) => termGroups.termGroups;
-const getRootGroups = createSelector(getTermGroups, termGroups =>
+export const getRootGroups = createSelector(getTermGroups, termGroups =>
   Object.keys(termGroups)
     .map(uid => termGroups[uid])
     .filter(({parentUid}) => !parentUid)
 );
-
-export default getRootGroups;


### PR DESCRIPTION
This fixes the following error which is triggered on `yarn run build`
```
The exported identifier "getRootGroups" is not declared in Babel's scope tracker
as a JavaScript value binding, and "@babel/plugin-transform-typescript"
never encountered it as a TypeScript type declaration.
It will be treated as a JavaScript value.

This problem is likely caused by another plugin injecting
"getRootGroups" without registering it in the scope tracker. If you are the author
 of that plugin, please use "scope.registerDeclaration(declarationPath)".
The exported identifier "HeaderContainer" is not declared in Babel's scope tracker
as a JavaScript value binding, and "@babel/plugin-transform-typescript"
never encountered it as a TypeScript type declaration.
It will be treated as a JavaScript value.

This problem is likely caused by another plugin injecting
"HeaderContainer" without registering it in the scope tracker. If you are the author
 of that plugin, please use "scope.registerDeclaration(declarationPath)".
```
