### PR TITLE
add app/node_modules to circleci persist list

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ jobs:
           root: .
           paths:
             - node_modules
+            - app/node_modules
 
   test:
     macos:


### PR DESCRIPTION
To fix 'module not found' error on CircleCi build