### PR TITLE
remove duplicate aliases in cli commands

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -46,7 +46,7 @@ args.command(
       .then(() => console.log(chalk.green(`${pluginName} installed successfully!`)))
       .catch((err: any) => console.error(chalk.red(err)));
   },
-  ['i', 'install']
+  ['i']
 );
 
 args.command(
@@ -61,7 +61,7 @@ args.command(
       .then(() => console.log(chalk.green(`${pluginName} uninstalled successfully!`)))
       .catch(err => console.log(chalk.red(err)));
   },
-  ['u', 'uninstall', 'rm', 'remove']
+  ['u', 'rm', 'remove']
 );
 
 args.command(
@@ -78,7 +78,7 @@ args.command(
     }
     process.exit(0);
   },
-  ['ls', 'list']
+  ['ls']
 );
 
 const lsRemote = (pattern?: string) => {
@@ -127,7 +127,7 @@ args.command(
         console.error(chalk.red(err)); // TODO
       });
   },
-  ['s', 'search']
+  ['s']
 );
 
 args.command(
@@ -149,7 +149,7 @@ args.command(
         console.error(chalk.red(err)); // TODO
       });
   },
-  ['lsr', 'list-remote', 'ls-remote']
+  ['lsr', 'ls-remote']
 );
 
 args.command(
@@ -161,7 +161,7 @@ args.command(
     open(`http://ghub.io/${pluginName}`, {wait: false, url: true});
     process.exit(0);
   },
-  ['d', 'docs', 'h', 'home']
+  ['d', 'h', 'home']
 );
 
 args.command(
@@ -171,7 +171,7 @@ args.command(
     console.log(version);
     process.exit(0);
   },
-  ['version']
+  []
 );
 
 args.command('<default>', 'Launch Hyper');


### PR DESCRIPTION
In f76eae2 while updating the syntax for args.command, the command name was included in aliases list also.
This causes below output on running `hyper help`
```
Usage: hyper [options] [command]
  
  Commands:
    <default>                                 Launch Hyper
    docs, d, docs, h, home                    Open the npm page of a plugin
    help                                      Display help
    install, i, install                       Install a plugin
    list, ls, list                            List installed plugins
    list-remote, lsr, list-remote, ls-remote  List plugins available on npm
    search, s, search                         Search for plugins on npm
    uninstall, u, uninstall, rm, remove       Uninstall a plugin
    version, version                          Show the version of hyper
  
  Options:
    -h, --help     Output usage information
    -v, --verbose  Verbose mode (disabled by default)
```
This contains duplicates in the commands list.
With the changes in this pr, it gives
```
Usage: hyper [options] [command]
  
  Commands:
    <default>                    Launch Hyper
    docs, d, h, home             Open the npm page of a plugin
    help                         Display help
    install, i                   Install a plugin
    list, ls                     List installed plugins
    list-remote, lsr, ls-remote  List plugins available on npm
    search, s                    Search for plugins on npm
    uninstall, u, rm, remove     Uninstall a plugin
    version                      Show the version of hyper
  
  Options:
    -h, --help     Output usage information
    -v, --verbose  Verbose mode (disabled by default)
```