### PR TITLE
fix fs stats.mtime usage in app/config.js

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -30,10 +30,10 @@ const _watch = () => {
     // watch for changes on config every 2s on Windows
     // https://github.com/zeit/hyper/pull/1772
     _watcher = fs.watchFile(cfgPath, {interval: 2000}, (curr, prev) => {
-      if (curr.mtime === 0) {
+      if (!curr.mtime || curr.mtime.getTime() === 0) {
         //eslint-disable-next-line no-console
         console.error('error watching config');
-      } else if (curr.mtime !== prev.mtime) {
+      } else if (curr.mtime.getTime() !== prev.mtime.getTime()) {
         onChange();
       }
     });


### PR DESCRIPTION
mtime is a Date object, not a number. So comparing it with 0 will always be false, and comparing two mtimes will compare them by reference, as they are objects, which will always be true (!==).

Please build and check once before merging as I couldn't test it (no windows)