### PR TITLE
Fix autoUpdater error on Linux

### DIFF
--- a/app/updater.js
+++ b/app/updater.js
@@ -12,7 +12,7 @@ import {getDecoratedConfig} from './plugins';
 const {platform} = process;
 const isLinux = platform === 'linux';
 
-const autoUpdater = isLinux ? require('./auto-updater-linux') : electron.autoUpdater;
+const autoUpdater = isLinux ? require('./auto-updater-linux').default : electron.autoUpdater;
 
 let isInit = false;
 // Default to the "stable" update channel


### PR DESCRIPTION
This bug was introduced in #4021.

We use `export default` on `AutoUpdater`:
https://github.com/zeit/hyper/blob/8423ce5d03f65b37ac308320fe0abe34bfcdb88f/app/auto-updater-linux.js#L48
If we want to `require` it, we must add `.default`.