### PR TITLE
remove @types/webdriverio from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "@types/styled-jsx": "2.2.8",
     "@types/terser-webpack-plugin": "2.2.0",
     "@types/uuid": "3.4.7",
-    "@types/webdriverio": "^4.8.0",
     "@types/webpack": "4.41.6",
     "@types/winreg": "1.2.30",
     "@typescript-eslint/eslint-plugin": "2.19.0",


### PR DESCRIPTION
See https://github.com/zeit/hyper/pull/4074#issuecomment-566130839
it's included now in spectron itself, so we can remove it.