### PR TITLE
update onCursorMove to match changes in xterm

### DIFF
--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -190,12 +190,12 @@ export default class Term extends React.PureComponent {
       this.disposableListeners.push(
         this.term.onCursorMove(() => {
           const cursorFrame = {
-            x: this.term._core.buffer.x * this.term._core.renderer.dimensions.actualCellWidth,
-            y: this.term._core.buffer.y * this.term._core.renderer.dimensions.actualCellHeight,
-            width: this.term._core.renderer.dimensions.actualCellWidth,
-            height: this.term._core.renderer.dimensions.actualCellHeight,
-            col: this.term._core.buffer.x,
-            row: this.term._core.buffer.y
+            x: this.term.buffer.cursorX * this.term._core._renderService.dimensions.actualCellWidth,
+            y: this.term.buffer.cursorY * this.term._core._renderService.dimensions.actualCellHeight,
+            width: this.term._core._renderService.dimensions.actualCellWidth,
+            height: this.term._core._renderService.dimensions.actualCellHeight,
+            col: this.term.buffer.cursorX,
+            row: this.term.buffer.cursorY
           };
           props.onCursorMove(cursorFrame);
         })


### PR DESCRIPTION
Replaced `_core.renderer` with `_core._renderService`.
Also changed `_core.buffer.x|y` with `buffer.cursorX|Y` which points to the same values, but we don't have to depend on internal field `_core` for this.
Couldn't find a public field to get the dimensions though.