### PR TITLE
Update xterm-addon-search to 0.5.0 to fix search

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "xterm": "^4.4.0",
     "xterm-addon-fit": "^0.3.0",
     "xterm-addon-ligatures": "^0.2.1",
-    "xterm-addon-search": "^0.4.0",
+    "xterm-addon-search": "^0.5.0",
     "xterm-addon-web-links": "^0.2.1",
     "xterm-addon-webgl": "^0.5.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8682,10 +8682,10 @@ xterm-addon-ligatures@^0.2.1:
     font-finder "^1.0.4"
     font-ligatures "^1.3.2"
 
-xterm-addon-search@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/xterm-addon-search/-/xterm-addon-search-0.4.0.tgz#a7beadb3caa7330eb31fb1f17d92de25537684a1"
-  integrity sha512-g07qb/Z4aSfrQ25e6Z6rz6KiExm2DvesQXkx+eA715VABBr5VM/9Jf0INoCiDSYy/nn7rpna+kXiGVJejIffKg==
+xterm-addon-search@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/xterm-addon-search/-/xterm-addon-search-0.5.0.tgz#cd3a2f8056084c28e236d4e732da37682010bcc2"
+  integrity sha512-zLVqVTrg5w2nk9fRj3UuVKCPo/dmFe/cLf3EM9Is5Dm6cgOoXmeo9eq2KgD8A0gquAflTFTf0ya2NaFmShHwyg==
 
 xterm-addon-web-links@^0.2.1:
   version "0.2.1"


### PR DESCRIPTION
Search broke when xterm was upgraded to 4.4.0
This needs to be upgraded to make search work again.
I wonder why dependabot didn't update it. 🤔