### PR TITLE
update typescript to 3.8.2

### DIFF
--- a/lib/reducers/sessions.ts
+++ b/lib/reducers/sessions.ts
@@ -16,7 +16,7 @@ import {
 import {sessionState, session, HyperActions} from '../hyper';
 
 const initialState: ImmutableType<sessionState> = Immutable({
-  sessions: {},
+  sessions: {} as Record<string, session>,
   activeUid: null
 });
 

--- a/lib/reducers/ui.ts
+++ b/lib/reducers/ui.ts
@@ -57,7 +57,7 @@ const initial: ImmutableType<uiState> = Immutable({
   letterSpacing: 0,
   css: '',
   termCSS: '',
-  openAt: {},
+  openAt: {} as Record<string, number>,
   resizeAt: 0,
   colors: {
     black: '#000000',
@@ -77,7 +77,7 @@ const initial: ImmutableType<uiState> = Immutable({
     lightCyan: '#68FDFE',
     lightWhite: '#FFFFFF'
   },
-  activityMarkers: {},
+  activityMarkers: {} as Record<string, boolean>,
   notifications: {
     font: false,
     resize: false,

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "terser": "4.6.3",
     "terser-webpack-plugin": "2.3.5",
     "ts-node": "8.6.2",
-    "typescript": "3.7.5",
+    "typescript": "3.8.2",
     "webpack": "4.41.6"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8305,10 +8305,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.7.5:
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
-  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
+typescript@3.8.2:
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.2.tgz#91d6868aaead7da74f493c553aeff76c0c0b1d5a"
+  integrity sha512-EgOVgL/4xfVrCMbhYKUQTdF37SQn4Iw73H5BgCrF1Abdun7Kwy/QZsE/ssAy0y4LxBbvua3PIbFsbRczWWnDdQ==
 
 union-value@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Needed to add types for `{}` in state to satisfy stricter assignability checks in 3.8