### PR TITLE
Add eslint-comments plugin and remove unnecessary eslint-disable directives

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,12 +2,14 @@
   "plugins": [
     "react",
     "prettier",
-    "@typescript-eslint"
+    "@typescript-eslint",
+    "eslint-comments"
   ],
   "extends": [
     "eslint:recommended",
     "plugin:react/recommended",
-    "plugin:prettier/recommended"
+    "plugin:prettier/recommended",
+    "plugin:eslint-comments/recommended"
   ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
@@ -54,7 +56,8 @@
         "useTabs": false,
         "jsxBracketSameLine": false
       }
-    ]
+    ],
+    "eslint-comments/no-unused-disable": "error"
   },
   "overrides": [
     {

--- a/app/config.ts
+++ b/app/config.ts
@@ -54,7 +54,6 @@ const _watch = () => {
     // https://github.com/zeit/hyper/pull/1772
     _watcher = fs.watchFile(cfgPath, {interval: 2000}, (curr, prev) => {
       if (!curr.mtime || curr.mtime.getTime() === 0) {
-        //eslint-disable-next-line no-console
         console.error('error watching config');
       } else if (curr.mtime.getTime() !== prev.mtime.getTime()) {
         onChange();
@@ -73,13 +72,11 @@ const _watch = () => {
         }
       });
     } catch (e) {
-      //eslint-disable-next-line no-console
       console.error('Failed to watch config file:', cfgPath, e);
       return;
     }
     _watcher.on('change', onChange);
     _watcher.on('error', error => {
-      //eslint-disable-next-line no-console
       console.error('error watching config', error);
     });
   }

--- a/app/config/import.ts
+++ b/app/config/import.ts
@@ -89,7 +89,6 @@ const _importConf = () => {
   try {
     migrateHyper2Config();
   } catch (err) {
-    //eslint-disable-next-line no-console
     console.error(err);
   }
 
@@ -102,7 +101,6 @@ const _importConf = () => {
       const mapping = JSON.parse(content) as Record<string, string | string[]>;
       _defaultCfg.keymaps = mapping;
     } catch (err) {
-      //eslint-disable-next-line no-console
       console.error(err);
     }
 
@@ -115,7 +113,6 @@ const _importConf = () => {
       return {userCfg: defaultCfgRaw, defaultCfg: _defaultCfg};
     }
   } catch (err) {
-    //eslint-disable-next-line no-console
     console.log(err);
   }
 };

--- a/app/config/open.ts
+++ b/app/config/open.ts
@@ -64,12 +64,10 @@ if (process.platform === 'win32') {
         if (yes) {
           return shell.openItem(cfgPath);
         }
-        //eslint-disable-next-line no-console
         console.warn('No default app set for .js files, using notepad.exe fallback');
         return openNotepad(cfgPath);
       })
       .catch(err => {
-        //eslint-disable-next-line no-console
         console.error('Open config with default app error:', err);
         return openNotepad(cfgPath);
       });

--- a/app/config/paths.ts
+++ b/app/config/paths.ts
@@ -32,7 +32,6 @@ if (isDev) {
     statSync(devCfg);
     cfgPath = devCfg;
     cfgDir = devDir;
-    //eslint-disable-next-line no-console
     console.log('using config file:', cfgPath);
   } catch (err) {
     // ignore

--- a/app/index.ts
+++ b/app/index.ts
@@ -3,11 +3,8 @@ if (['--help', '-v', '--version'].includes(process.argv[1])) {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const {version} = require('./package');
   const configLocation = process.platform === 'win32' ? `${process.env.userprofile}\\.hyper.js` : '~/.hyper.js';
-  //eslint-disable-next-line no-console
   console.log(`Hyper version ${version}`);
-  //eslint-disable-next-line no-console
   console.log('Hyper does not accept any command line arguments. Please modify the config file instead.');
-  //eslint-disable-next-line no-console
   console.log(`Hyper configuration file located at: ${configLocation}`);
   process.exit();
 }
@@ -104,12 +101,10 @@ app.getLastFocusedWindow = () => {
   });
 };
 
-//eslint-disable-next-line no-console
 console.log('Disabling Chromium GPU blacklist');
 app.commandLine.appendSwitch('ignore-gpu-blacklist');
 
 if (isDev) {
-  //eslint-disable-next-line no-console
   console.log('running in dev mode');
 
   // Override default appVersion which is set from package.json
@@ -119,19 +114,16 @@ if (isDev) {
     }
   });
 } else {
-  //eslint-disable-next-line no-console
   console.log('running in prod mode');
 }
 
 const url = `file://${resolve(isDev ? __dirname : app.getAppPath(), 'index.html')}`;
-//eslint-disable-next-line no-console
 console.log('electron will open', url);
 
 function installDevExtensions(isDev_: boolean) {
   if (!isDev_) {
     return Promise.resolve([]);
   }
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
   const installer = require('electron-devtools-installer') as typeof import('electron-devtools-installer');
 
   const extensions = ['REACT_DEVELOPER_TOOLS', 'REDUX_DEVTOOLS'] as const;
@@ -248,11 +240,9 @@ app.on('ready', () =>
       if (!isDev) {
         // check if should be set/removed as default ssh protocol client
         if (config.getConfig().defaultSSHApp && !app.isDefaultProtocolClient('ssh')) {
-          //eslint-disable-next-line no-console
           console.log('Setting Hyper as default client for ssh:// protocol');
           app.setAsDefaultProtocolClient('ssh');
         } else if (!config.getConfig().defaultSSHApp && app.isDefaultProtocolClient('ssh')) {
-          //eslint-disable-next-line no-console
           console.log('Removing Hyper from default client for ssh:// protocol');
           app.removeAsDefaultProtocolClient('ssh');
         }
@@ -260,7 +250,6 @@ app.on('ready', () =>
       }
     })
     .catch(err => {
-      //eslint-disable-next-line no-console
       console.error('Error while loading devtools extensions', err);
     })
 );

--- a/app/notifications.ts
+++ b/app/notifications.ts
@@ -10,11 +10,9 @@ export default function fetchNotifications(win: BrowserWindow) {
   const retry = (err?: any) => {
     setTimeout(() => fetchNotifications(win), ms('30m'));
     if (err) {
-      //eslint-disable-next-line no-console
       console.error('Notification messages fetch error', err.stack);
     }
   };
-  //eslint-disable-next-line no-console
   console.log('Checking for notification messages');
   fetch(NEWS_URL, {
     headers: {
@@ -29,7 +27,6 @@ export default function fetchNotifications(win: BrowserWindow) {
         throw new Error('Bad response');
       }
       if (message === '') {
-        //eslint-disable-next-line no-console
         console.log('No matching notification messages');
       } else {
         rpc.emit('add notification', message);

--- a/app/notify.ts
+++ b/app/notify.ts
@@ -12,10 +12,8 @@ let win: BrowserWindow;
 let buffer: string[][] = [];
 
 function notify(title: string, body = '', details: any = {}) {
-  //eslint-disable-next-line no-console
   console.log(`[Notification] ${title}: ${body}`);
   if (details.error) {
-    //eslint-disable-next-line no-console
     console.error(details.error);
   }
   if (win) {

--- a/app/plugins.ts
+++ b/app/plugins.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import {app, dialog, BrowserWindow, App} from 'electron';
 import {resolve, basename} from 'path';
@@ -102,7 +103,6 @@ function updatePlugins({force = false} = {}) {
     updating = false;
 
     if (err) {
-      //eslint-disable-next-line no-console
       notify('Error updating plugins.', err, {error: err});
     } else {
       // flag successful plugin update
@@ -177,7 +177,6 @@ export const getLoadedPluginVersions = () => {
 // to prevent slowness
 if (cache.get('hyper.plugins') !== id || process.env.HYPER_FORCE_UPDATE) {
   // install immediately if the user changed plugins
-  //eslint-disable-next-line no-console
   console.log('plugins have changed / not init, scheduling plugins installation');
   setTimeout(() => {
     updatePlugins();
@@ -287,16 +286,13 @@ function requirePlugins(): any[] {
       try {
         mod._version = require(resolve(path_, 'package.json')).version;
       } catch (err) {
-        //eslint-disable-next-line no-console
         console.warn(`No package.json found in ${path_}`);
       }
-      //eslint-disable-next-line no-console
       console.log(`Plugin ${mod._name} (${mod._version}) loaded.`);
 
       return mod;
     } catch (err) {
       if (err.code === 'MODULE_NOT_FOUND') {
-        //eslint-disable-next-line no-console
         console.warn(`Plugin error while loading "${basename(path_)}" (${path_}): ${err.message}`);
       } else {
         notify('Plugin error!', `Plugin "${basename(path_)}" failed to load (${err.message})`, {error: err});

--- a/app/plugins/install.ts
+++ b/app/plugins/install.ts
@@ -12,7 +12,6 @@ export const install = (fn: Function) => {
     };
     spawnQueue.push(end => {
       const cmd = [process.execPath, yarn].concat(args).join(' ');
-      //eslint-disable-next-line no-console
       console.log('Launching yarn:', cmd);
 
       cp.execFile(

--- a/app/session.ts
+++ b/app/session.ts
@@ -100,7 +100,6 @@ export default class Session extends EventEmitter {
   }
 
   init({uid, rows, cols: columns, cwd, shell, shellArgs}: SessionOptions) {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const osLocale = require('os-locale') as typeof import('os-locale');
     const baseEnv = Object.assign(
       {},
@@ -176,7 +175,6 @@ export default class Session extends EventEmitter {
     if (this.pty) {
       this.pty.write(data);
     } else {
-      //eslint-disable-next-line no-console
       console.warn('Warning: Attempted to write to a session with no pty');
     }
   }
@@ -186,11 +184,9 @@ export default class Session extends EventEmitter {
       try {
         this.pty.resize(cols, rows);
       } catch (err) {
-        //eslint-disable-next-line no-console
         console.error(err.stack);
       }
     } else {
-      //eslint-disable-next-line no-console
       console.warn('Warning: Attempted to resize a session with no pty');
     }
   }
@@ -200,11 +196,9 @@ export default class Session extends EventEmitter {
       try {
         this.pty.kill();
       } catch (err) {
-        //eslint-disable-next-line no-console
         console.error('exit error', err.stack);
       }
     } else {
-      //eslint-disable-next-line no-console
       console.warn('Warning: Attempted to destroy a session with no pty');
     }
     this.emit('exit');

--- a/app/system-context-menu.ts
+++ b/app/system-context-menu.ts
@@ -11,17 +11,14 @@ const regParts = [
 function addValues(hyperKey: Registry.Registry, commandKey: Registry.Registry, callback: Function) {
   hyperKey.set(regParts[1].name, Registry.REG_SZ, regParts[1].value, error => {
     if (error) {
-      //eslint-disable-next-line no-console
       console.error(error.message);
     }
     hyperKey.set(regParts[2].name, Registry.REG_SZ, regParts[2].value, err => {
       if (err) {
-        //eslint-disable-next-line no-console
         console.error(err.message);
       }
       commandKey.set(regParts[0].name, Registry.REG_SZ, regParts[0].value, err_ => {
         if (err_) {
-          //eslint-disable-next-line no-console
           console.error(err_.message);
         }
         callback();
@@ -39,13 +36,11 @@ export const add = (callback: Function) => {
 
   hyperKey.keyExists((error, exists) => {
     if (error) {
-      //eslint-disable-next-line no-console
       console.error(error.message);
     }
     if (exists) {
       commandKey.keyExists((err_, exists_) => {
         if (err_) {
-          //eslint-disable-next-line no-console
           console.error(err_.message);
         }
         if (exists_) {
@@ -53,7 +48,6 @@ export const add = (callback: Function) => {
         } else {
           commandKey.create(err => {
             if (err) {
-              //eslint-disable-next-line no-console
               console.error(err.message);
             }
             addValues(hyperKey, commandKey, callback);
@@ -63,12 +57,10 @@ export const add = (callback: Function) => {
     } else {
       hyperKey.create(err => {
         if (err) {
-          //eslint-disable-next-line no-console
           console.error(err.message);
         }
         commandKey.create(err_ => {
           if (err_) {
-            //eslint-disable-next-line no-console
             console.error(err_.message);
           }
           addValues(hyperKey, commandKey, callback);
@@ -81,7 +73,6 @@ export const add = (callback: Function) => {
 export const remove = (callback: Function) => {
   new Registry({hive: 'HKCU', key: regKey}).destroy(err => {
     if (err) {
-      //eslint-disable-next-line no-console
       console.error(err.message);
     }
     callback();

--- a/app/ui/window.ts
+++ b/app/ui/window.ts
@@ -106,7 +106,6 @@ export function newWindow(
     if (!isDev) {
       updater(window);
     } else {
-      //eslint-disable-next-line no-console
       console.log('ignoring auto updates during dev');
     }
   });

--- a/app/updater.js
+++ b/app/updater.js
@@ -5,7 +5,6 @@ import ms from 'ms';
 import retry from 'async-retry';
 
 // Utilities
-// eslint-disable-next-line no-unused-vars
 import {version} from './package';
 import {getDecoratedConfig} from './plugins';
 
@@ -27,7 +26,6 @@ const isCanary = updateChannel => updateChannel === 'canary';
 
 async function init() {
   autoUpdater.on('error', (err, msg) => {
-    //eslint-disable-next-line no-console
     console.error('Error fetching updates', `${msg} (${err.stack})`);
   });
 

--- a/app/utils/cli-install.ts
+++ b/app/utils/cli-install.ts
@@ -29,11 +29,9 @@ const checkInstall = () => {
 const addSymlink = () => {
   return checkInstall().then(isInstalled => {
     if (isInstalled) {
-      //eslint-disable-next-line no-console
       console.log('Hyper CLI already in PATH');
       return Promise.resolve();
     }
-    //eslint-disable-next-line no-console
     console.log('Linking HyperCLI');
     return symlink(cliScriptPath, cliLinkPath);
   });
@@ -65,7 +63,6 @@ const addBinToUserPath = () => {
         const pathParts = value.split(';');
         const existingPath = pathParts.includes(binPath);
         if (existingPath) {
-          //eslint-disable-next-line no-console
           console.log('Hyper CLI already in PATH');
           resolve();
           return;
@@ -77,7 +74,6 @@ const addBinToUserPath = () => {
           .concat([binPath])
           .join(';');
       }
-      //eslint-disable-next-line no-console
       console.log('Adding HyperCLI path (registry)');
       Registry.setValueRaw(envKey, pathItemName, type, Registry.formatString(newPathValue));
       Registry.closeKey(envKey);
@@ -117,7 +113,6 @@ export const installCLI = (withNotification: boolean) => {
             ? `File already exists: ${cliLinkPath}`
             : `Symlink creation failed: ${err.code}`;
 
-        //eslint-disable-next-line no-console
         console.error(err);
         logNotify(withNotification, 'Hyper CLI installation failed', error);
       });

--- a/app/utils/map-keys.ts
+++ b/app/utils/map-keys.ts
@@ -24,7 +24,6 @@ export default (config: Record<string, string[] | string>) => {
       let newShortcut = shortcut;
       if (newShortcut.indexOf('cmd') !== -1) {
         // Mousetrap use `command` and not `cmd`
-        //eslint-disable-next-line no-console
         console.warn('Your config use deprecated `cmd` in key combination. Please use `command` instead.');
         newShortcut = newShortcut.replace('cmd', 'command');
       }

--- a/lib/actions/ui.ts
+++ b/lib/actions/ui.ts
@@ -143,7 +143,6 @@ function moveToNeighborPane(type: typeof UI_MOVE_NEXT_PANE | typeof UI_MOVE_PREV
         const {uid} = findBySession(termGroups, sessions.activeUid!)!;
         const childGroups = findChildSessions(termGroups.termGroups, termGroups.activeRootGroup!);
         if (childGroups.length === 1) {
-          //eslint-disable-next-line no-console
           console.log('ignoring move for single group');
         } else {
           const index = getNeighborIndex(childGroups, uid!, type);
@@ -174,7 +173,6 @@ export function moveLeft() {
         const index = groupUids.indexOf(uid);
         const next = groupUids[index - 1] || groupUids[groupUids.length - 1];
         if (!next || uid === next) {
-          //eslint-disable-next-line no-console
           console.log('ignoring left move action');
         } else {
           dispatch(setActiveGroup(next));
@@ -195,7 +193,6 @@ export function moveRight() {
         const index = groupUids.indexOf(uid);
         const next = groupUids[index + 1] || groupUids[0];
         if (!next || uid === next) {
-          //eslint-disable-next-line no-console
           console.log('ignoring right move action');
         } else {
           dispatch(setActiveGroup(next));
@@ -223,12 +220,10 @@ export function moveTo(i: number | 'last') {
         const groupUids = getGroupUids(state);
         const uid = state.termGroups.activeRootGroup;
         if (uid === groupUids[i as number]) {
-          //eslint-disable-next-line no-console
           console.log('ignoring same uid');
         } else if (groupUids[i as number]) {
           dispatch(setActiveGroup(groupUids[i as number]));
         } else {
-          //eslint-disable-next-line no-console
           console.log('ignoring inexistent index', i);
         }
       }

--- a/lib/components/split-pane.js
+++ b/lib/components/split-pane.js
@@ -1,4 +1,3 @@
-/* eslint-disable quote-props */
 import React from 'react';
 import _ from 'lodash';
 

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -121,13 +121,11 @@ export default class Term extends React.PureComponent {
       let useWebGL = false;
       if (props.webGLRenderer) {
         if (needTransparency) {
-          // eslint-disable-next-line no-console
           console.warn(
             'WebGL Renderer has been disabled since it does not support transparent backgrounds yet. ' +
               'Falling back to canvas-based rendering.'
           );
         } else if (!isWebgl2Supported()) {
-          // eslint-disable-next-line no-console
           console.warn('WebGL2 is not supported on your machine. Falling back to canvas-based rendering.');
         } else {
           // Experimental WebGL renderer needs some more glue-code to make it work on Hyper.
@@ -210,7 +208,6 @@ export default class Term extends React.PureComponent {
   }
 
   getTermDocument() {
-    // eslint-disable-next-line no-console
     console.warn(
       'The underlying terminal engine of Hyper no longer ' +
         'uses iframes with individual `document` objects for each ' +

--- a/lib/containers/header.ts
+++ b/lib/containers/header.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-params */
 import {createSelector} from 'reselect';
 
 import Header from '../components/header';

--- a/lib/containers/hyper.tsx
+++ b/lib/containers/hyper.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable react/no-danger */
-
 import React from 'react';
 import Mousetrap from 'mousetrap';
 

--- a/lib/reducers/sessions.ts
+++ b/lib/reducers/sessions.ts
@@ -99,7 +99,6 @@ const reducer = (state: ImmutableType<sessionState> = initialState, action: Hype
       if (state.sessions[action.uid]) {
         return deleteSession(state, action.uid);
       }
-      // eslint-disable-next-line no-console
       console.log('ignore pty exit: session removed by user');
       return state;
 

--- a/lib/reducers/ui.ts
+++ b/lib/reducers/ui.ts
@@ -117,10 +117,8 @@ const currentWindow = remote.getCurrentWindow();
 const reducer = (state = initial, action: HyperActions) => {
   let state_ = state;
   let isMax;
-  //eslint-disable-next-line default-case
   switch (action.type) {
     case CONFIG_LOAD:
-    // eslint-disable-next-line no-case-declarations, no-fallthrough
     case CONFIG_RELOAD: {
       const {config, now} = action;
       state_ = state
@@ -325,7 +323,6 @@ const reducer = (state = initial, action: HyperActions) => {
       );
       break;
 
-    // eslint-disable-next-line no-case-declarations
     case SESSION_PTY_DATA:
       // ignore activity markers for current tab
       if (action.uid === state.activeUid) {

--- a/lib/utils/file.ts
+++ b/lib/utils/file.ts
@@ -25,7 +25,6 @@ export function getBase64FileData(filePath: string): Promise<string | null> {
     return fs.readFile(filePath, (err, data) => {
       if (err) {
         // Gracefully fail with a warning
-        //eslint-disable-next-line no-console
         console.warn('There was an error reading the file at the local location:', err);
         return resolve(null);
       }

--- a/lib/utils/notify.ts
+++ b/lib/utils/notify.ts
@@ -1,9 +1,7 @@
 /* eslint no-new:0 */
 export default function notify(title: string, body: string, details: Record<string, any> = {}) {
-  //eslint-disable-next-line no-console
   console.log(`[Notification] ${title}: ${body}`);
   if (details.error) {
-    //eslint-disable-next-line no-console
     console.error(details.error);
   }
   new Notification(title, {body});

--- a/lib/utils/plugins.ts
+++ b/lib/utils/plugins.ts
@@ -144,15 +144,12 @@ Module._load = function _load(path: string) {
   // app/plugins.js
   switch (path) {
     case 'react':
-      //eslint-disable-next-line no-console
       console.warn('DEPRECATED: If your plugin requires `react`, it must bundle it as a dependency');
       return React;
     case 'react-dom':
-      //eslint-disable-next-line no-console
       console.warn('DEPRECATED: If your plugin requires `react-dom`, it must bundle it as a dependency');
       return ReactDOM;
     case 'hyper/component':
-      //eslint-disable-next-line no-console
       console.warn(
         'DEPRECATED: If your plugin requires `hyper/component`, it must requires `react.PureComponent` instead and bundle `react` as a dependency'
       );
@@ -198,14 +195,12 @@ const getPluginVersion = (path: string): string | null => {
   try {
     version = (window.require(pathModule.resolve(path, 'package.json')) as any).version as string;
   } catch (err) {
-    //eslint-disable-next-line no-console
     console.warn(`No package.json found in ${path}`);
   }
   return version;
 };
 
 const loadModules = () => {
-  //eslint-disable-next-line no-console
   console.log('(re)loading renderer plugins');
   const paths = plugins.getPaths();
 
@@ -270,14 +265,12 @@ const loadModules = () => {
       // mapHyperTermState mapping for backwards compatibility with hyperterm
       if (mod.mapHyperTermState) {
         mod.mapHyperState = mod.mapHyperTermState;
-        //eslint-disable-next-line no-console
         console.error('mapHyperTermState is deprecated. Use mapHyperState instead.');
       }
 
       // mapHyperTermDispatch mapping for backwards compatibility with hyperterm
       if (mod.mapHyperTermDispatch) {
         mod.mapHyperDispatch = mod.mapHyperTermDispatch;
-        //eslint-disable-next-line no-console
         console.error('mapHyperTermDispatch is deprecated. Use mapHyperDispatch instead.');
       }
 
@@ -348,7 +341,6 @@ const loadModules = () => {
       if (mod.onRendererWindow) {
         mod.onRendererWindow(window);
       }
-      //eslint-disable-next-line no-console
       console.log(`Plugin ${pluginName} (${pluginVersion}) loaded.`);
 
       return mod;
@@ -359,7 +351,6 @@ const loadModules = () => {
   Object.keys(deprecatedPlugins).forEach(name => {
     const {css} = deprecatedPlugins[name];
     if (css) {
-      //eslint-disable-next-line no-console
       console.warn(`Warning: "${name}" plugin uses some deprecated CSS classes (${css.join(', ')}).`);
     }
   });

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "electron-rebuild": "1.10.0",
     "eslint": "6.8.0",
     "eslint-config-prettier": "6.10.0",
+    "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-prettier": "3.1.2",
     "eslint-plugin-react": "7.18.3",
     "husky": "4.2.3",

--- a/release.js
+++ b/release.js
@@ -12,7 +12,6 @@ module.exports = async markdown => {
   const {intro} = answers;
 
   if (intro === '') {
-    //eslint-disable-next-line no-console
     console.error('Please specify a release summary!');
 
     process.exit(1);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3297,6 +3297,14 @@ eslint-config-prettier@6.10.0:
   dependencies:
     get-stdin "^6.0.0"
 
+eslint-plugin-eslint-comments@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.1.2.tgz#4ef6c488dbe06aa1627fea107b3e5d059fc8a395"
+  integrity sha512-QexaqrNeteFfRTad96W+Vi4Zj1KFbkHHNMMaHZEYcovKav6gdomyGzaxSDSL3GoIyUOo078wRAdYlu1caiauIQ==
+  dependencies:
+    escape-string-regexp "^1.0.5"
+    ignore "^5.0.5"
+
 eslint-plugin-prettier@3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.2.tgz#432e5a667666ab84ce72f945c72f77d996a5c9ba"
@@ -4414,7 +4422,7 @@ ignore@^4.0.3, ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.1.1, ignore@^5.1.4:
+ignore@^5.0.5, ignore@^5.1.1, ignore@^5.1.4:
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.4.tgz#84b7b3dbe64552b6ef0eca99f6743dbec6d97adf"
   integrity sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==


### PR DESCRIPTION
The purpose of eslint-comments plugin is to apply best practices on directive comments.
One utility from this is that with changes in the eslint config over time, some rules might get disabled but the directive comments for those rules get left in the code, e.g. the `no-console` rule has been removed from the eslint recommended list, and it's used a lot of times in our code.
This plugin will give errors in such cases and also other bad practices.