### PR TITLE
replace winreg with native-reg

### DIFF
--- a/app/config/open.ts
+++ b/app/config/open.ts
@@ -1,65 +1,74 @@
 import {shell} from 'electron';
 import {cfgPath} from './paths';
-export default () => Promise.resolve(shell.openItem(cfgPath));
+import * as regTypes from '../typings/native-reg';
 
-// Windows opens .js files with  WScript.exe by default
-// If the user hasn't set up an editor for .js files, we fallback to notepad.
-if (process.platform === 'win32') {
-  const Registry = require('winreg') as typeof import('winreg');
-  const {exec} = require('child_process') as typeof import('child_process');
+export default () => {
+  // Windows opens .js files with  WScript.exe by default
+  // If the user hasn't set up an editor for .js files, we fallback to notepad.
+  if (process.platform === 'win32') {
+    try {
+      // eslint-disable-next-line no-var, @typescript-eslint/no-var-requires
+      var Registry: typeof regTypes = require('native-reg');
+    } catch (err) {
+      console.error(err);
+    }
+    const {exec} = require('child_process') as typeof import('child_process');
 
-  const getUserChoiceKey = async () => {
-    // Load FileExts keys for .js files
-    const keys: Winreg.Registry[] = await new Promise((resolve, reject) => {
-      new Registry({
-        hive: Registry.HKCU,
-        key: '\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\FileExts\\.js'
-      }).keys((error, items) => {
-        if (error) {
-          reject(error);
-        } else {
-          resolve(items || []);
-        }
+    const getUserChoiceKey = async () => {
+      try {
+        // Load FileExts keys for .js files
+        const fileExtsKeys = Registry.openKey(
+          Registry.HKCU,
+          'Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\FileExts\\.js',
+          Registry.Access.READ
+        );
+        const keys = fileExtsKeys ? Registry.enumKeyNames(fileExtsKeys) : [];
+        Registry.closeKey(fileExtsKeys);
+
+        // Find UserChoice key
+        const userChoice = keys.find(k => k.endsWith('UserChoice'));
+        return userChoice
+          ? `Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\FileExts\\.js\\${userChoice}`
+          : userChoice;
+      } catch (error) {
+        console.error(error);
+        return;
+      }
+    };
+
+    const hasDefaultSet = async () => {
+      const userChoice = await getUserChoiceKey();
+      if (!userChoice) return false;
+
+      try {
+        // Load key values
+        const userChoiceKey = Registry.openKey(Registry.HKCU, userChoice, Registry.Access.READ)!;
+        const values: string[] = Registry.enumValueNames(userChoiceKey).map(
+          x => (Registry.queryValue(userChoiceKey, x) as string) || ''
+        );
+        Registry.closeKey(userChoiceKey);
+
+        // Look for default program
+        const hasDefaultProgramConfigured = values.every(
+          value => value && typeof value === 'string' && !value.includes('WScript.exe') && !value.includes('JSFile')
+        );
+
+        return hasDefaultProgramConfigured;
+      } catch (error) {
+        console.error(error);
+        return false;
+      }
+    };
+
+    // This mimics shell.openItem, true if it worked, false if not.
+    const openNotepad = (file: string) =>
+      new Promise<boolean>(resolve => {
+        exec(`start notepad.exe ${file}`, error => {
+          resolve(!error);
+        });
       });
-    });
 
-    // Find UserChoice key
-    const userChoice = keys.find(k => k.key.endsWith('UserChoice'));
-    return userChoice;
-  };
-
-  const hasDefaultSet = async () => {
-    const userChoice = await getUserChoiceKey();
-    if (!userChoice) return false;
-
-    // Load key values
-    const values: string[] = await new Promise((resolve, reject) => {
-      userChoice.values((error, items) => {
-        if (error) {
-          reject(error);
-        }
-        resolve(items.map(item => item.value || '') || []);
-      });
-    });
-
-    // Look for default program
-    const hasDefaultProgramConfigured = values.every(
-      value => value && typeof value === 'string' && !value.includes('WScript.exe') && !value.includes('JSFile')
-    );
-
-    return hasDefaultProgramConfigured;
-  };
-
-  // This mimics shell.openItem, true if it worked, false if not.
-  const openNotepad = (file: string) =>
-    new Promise(resolve => {
-      exec(`start notepad.exe ${file}`, error => {
-        resolve(!error);
-      });
-    });
-
-  module.exports = () =>
-    hasDefaultSet()
+    return hasDefaultSet()
       .then(yes => {
         if (yes) {
           return shell.openItem(cfgPath);
@@ -71,4 +80,7 @@ if (process.platform === 'win32') {
         console.error('Open config with default app error:', err);
         return openNotepad(cfgPath);
       });
-}
+  } else {
+    return Promise.resolve(shell.openItem(cfgPath));
+  }
+};

--- a/app/package.json
+++ b/app/package.json
@@ -33,10 +33,9 @@
     "react-dom": "16.13.0",
     "semver": "7.1.3",
     "shell-env": "3.0.0",
-    "uuid": "7.0.1",
-    "winreg": "1.2.4"
+    "uuid": "7.0.1"
   },
   "optionalDependencies": {
-    "native-reg": "0.3.3"
+    "native-reg": "0.3.4"
   }
 }

--- a/app/utils/cli-install.ts
+++ b/app/utils/cli-install.ts
@@ -5,11 +5,13 @@ import notify from '../notify';
 import {cliScriptPath, cliLinkPath} from '../config/paths';
 
 import * as regTypes from '../typings/native-reg';
-try {
-  // eslint-disable-next-line no-var, @typescript-eslint/no-var-requires
-  var Registry: typeof regTypes = require('native-reg');
-} catch (err) {
-  console.log(err);
+if (process.platform === 'win32') {
+  try {
+    // eslint-disable-next-line no-var, @typescript-eslint/no-var-requires
+    var Registry: typeof regTypes = require('native-reg');
+  } catch (err) {
+    console.error(err);
+  }
 }
 
 const readlink = pify(fs.readlink);

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -397,10 +397,10 @@ nan@^2.14.0:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
 
-native-reg@0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/native-reg/-/native-reg-0.3.3.tgz#820bcd6246029ab49cb10c9258b6ba3cb6d22ebe"
-  integrity sha512-zt7A29wK2yvPcSsRfx7snWjo2AUTWRVIE3QMuNfKqtwNhwSpo3V3FDQekja7amH0/rjDe8u2MKOkFSV8+I4i/A==
+native-reg@0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/native-reg/-/native-reg-0.3.4.tgz#764c75e96ef99dc134024c91be0a9c693d71658b"
+  integrity sha512-5U728JozXdfs4PGxxWpki4LBC6wi9itLYvi6BR/5wLKBmFC2fDbqMOct/CRk2vlMEWtI8MINnIDiEIEREV8DdQ==
   dependencies:
     node-gyp-build "^4.2.0"
 
@@ -706,11 +706,6 @@ which@^1.2.9:
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
   dependencies:
     isexe "^2.0.0"
-
-winreg@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/winreg/-/winreg-1.2.4.tgz#ba065629b7a925130e15779108cf540990e98d1b"
-  integrity sha1-ugZWKbepJRMOFXeRCM9UCZDpjRs=
 
 wrappy@1:
   version "1.0.2"

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "@types/terser-webpack-plugin": "2.2.0",
     "@types/uuid": "7.0.0",
     "@types/webpack": "4.41.7",
-    "@types/winreg": "1.2.30",
     "@typescript-eslint/eslint-plugin": "2.21.0",
     "@typescript-eslint/parser": "2.21.0",
     "ava": "3.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -808,11 +808,6 @@
     "@types/webpack-sources" "*"
     source-map "^0.6.0"
 
-"@types/winreg@1.2.30":
-  version "1.2.30"
-  resolved "https://registry.yarnpkg.com/@types/winreg/-/winreg-1.2.30.tgz#91d6710e536d345b9c9b017c574cf6a8da64c518"
-  integrity sha1-kdZxDlNtNFucmwF8V0z2qNpkxRg=
-
 "@typescript-eslint/eslint-plugin@2.21.0":
   version "2.21.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.21.0.tgz#a34de84a0791cae0357c4dda805c5b4e8203b6c6"


### PR DESCRIPTION
Fixes #4262 & Fixes #4320 

https://github.com/zeit/hyper/pull/4355/files#diff-078bb555e09169f1e72ff2bbb2fdb71eL11-R35

Here earlier step failing does not stop the subsequent steps, so similarly put three different `trycatch`s, if we want it to instead stop in such cases, then the three `Registry.setValueSZ`s can be put in a single `trycatch`