### PR TITLE
use electron app name property instead of getName function

### DIFF
--- a/app/menus/menu.ts
+++ b/app/menus/menu.ts
@@ -15,7 +15,7 @@ import {getDecoratedKeymaps} from '../plugins';
 import {execCommand} from '../commands';
 import {getRendererTypes} from '../utils/renderer-utils';
 
-const appName = app.getName();
+const appName = app.name;
 const appVersion = app.getVersion();
 
 let menu_: Menu;

--- a/app/menus/menus/darwin.ts
+++ b/app/menus/menus/darwin.ts
@@ -8,7 +8,7 @@ export default (
   showAbout: () => void
 ): MenuItemConstructorOptions => {
   return {
-    label: `${app.getName()}`,
+    label: `${app.name}`,
     submenu: [
       {
         label: 'About Hyper',

--- a/app/menus/menus/help.ts
+++ b/app/menus/menus/help.ts
@@ -7,7 +7,7 @@ import {version} from '../../package.json';
 export default (commands: Record<string, string>, showAbout: () => void): MenuItemConstructorOptions => {
   const submenu: MenuItemConstructorOptions[] = [
     {
-      label: `${app.getName()} Website`,
+      label: `${app.name} Website`,
       click() {
         shell.openExternal('https://hyper.is');
       }
@@ -42,7 +42,7 @@ export default (commands: Record<string, string>, showAbout: () => void): MenuIt
 
 
 <!-- ~/.hyper.js config -->
- - **${app.getName()} version**: ${env.TERM_PROGRAM_VERSION} "${app.getVersion()}"
+ - **${app.name} version**: ${env.TERM_PROGRAM_VERSION} "${app.getVersion()}"
 
  - **OS ARCH VERSION:** ${platform} ${arch} ${release()}
  - **Electron:** ${versions.electron}  **LANG:** ${env.LANG}


### PR DESCRIPTION
Fixes `(electron) 'getName function' is deprecated and will be removed. Please use 'name property' instead.` warning which occurs during `yarn run app`