### PR TITLE
add command handler to uncatch keyboard event if search is closed

### DIFF
--- a/lib/actions/sessions.ts
+++ b/lib/actions/sessions.ts
@@ -145,13 +145,19 @@ export function onSearch(uid?: string) {
   };
 }
 
-export function closeSearch(uid?: string) {
+export function closeSearch(uid?: string, keyEvent?: any) {
   return (dispatch: HyperDispatch, getState: () => HyperState) => {
     const targetUid = uid || getState().sessions.activeUid!;
-    dispatch({
-      type: SESSION_SEARCH_CLOSE,
-      uid: targetUid
-    });
+    if (getState().sessions.sessions[targetUid]?.search) {
+      dispatch({
+        type: SESSION_SEARCH_CLOSE,
+        uid: targetUid
+      });
+    } else {
+      if (keyEvent) {
+        keyEvent.catched = false;
+      }
+    }
   };
 }
 

--- a/lib/actions/ui.ts
+++ b/lib/actions/ui.ts
@@ -325,7 +325,7 @@ export function execCommand(command: string, fn: (...args: any[]) => void, e: an
       command,
       effect() {
         if (fn) {
-          fn(e);
+          fn(e, dispatch);
         } else {
           rpc.emit('command', command);
         }

--- a/lib/command-registry.ts
+++ b/lib/command-registry.ts
@@ -1,9 +1,15 @@
 import {remote} from 'electron';
+import {HyperDispatch} from './hyper';
+import {closeSearch} from './actions/sessions';
 // TODO: Should be updates to new async API https://medium.com/@nornagon/electrons-remote-module-considered-harmful-70d69500f31
 
 const {getDecoratedKeymaps} = remote.require('./plugins');
 
-let commands: Record<string, (...args: any[]) => void> = {};
+let commands: Record<string, (event: any, dispatch: HyperDispatch) => void> = {
+  'editor:search-close': (e, dispatch) => {
+    dispatch(closeSearch(undefined, e));
+  }
+};
 
 export const getRegisteredKeys = () => {
   const keymaps = getDecoratedKeymaps();


### PR DESCRIPTION
Fixes #3929 
Added a check to see if searchbox is open before dispatching the `SESSION_SEARCH_CLOSE` action and set `catched` to false if it isn't so that xterm is able to receive it.
Doing it by using a command handler, had to provide `dispatch` to command handlers for this to work.

Do test it out to see if it's working properly, and not impacting any plugins.