### PR TITLE
Use pseudo element to highlight active tab

### DIFF
--- a/lib/components/term.tsx
+++ b/lib/components/term.tsx
@@ -423,9 +423,26 @@ export default class Term extends React.PureComponent<TermProps> {
 
         <style jsx global>{`
           .term_fit {
+            position: relative;
             display: block;
             width: 100%;
             height: 100%;
+          }
+
+          .splitpane_pane > .term_fit::after {
+            position: absolute;
+            top: 0;
+            right: 0;
+            bottom: 0;
+            left: 0;
+            background-color: #fff;
+            opacity: 0.2;
+            content: '';
+            pointer-events: none;
+          }
+
+          .term_fit.term_active::after {
+            opacity: 0;
           }
 
           .term_wrapper {


### PR DESCRIPTION
<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`
- If your PR changes some API, please make a PR for hyper website too: https://github.com/zeit/hyper-site.

Thanks, again! -->

Just installed this great terminal few minutes ago but I was having a hard time seeing which term was actually being focused when having multiple terms open. So I added some overlay to non-active terms to highlight the active term.

Example of the result: https://gyazo.com/8823a13e8707bbcebc330b90953b46a0

### Improvements

* Don't use hardcoded white overlay color but a config color
* Add option to enable or disable this overlay in the config