### PR TITLE
add link handler to use shell.openExternal

### DIFF
--- a/lib/components/term.tsx
+++ b/lib/components/term.tsx
@@ -5,7 +5,7 @@ import {WebLinksAddon} from 'xterm-addon-web-links';
 import {SearchAddon} from 'xterm-addon-search';
 import {WebglAddon} from 'xterm-addon-webgl';
 import {LigaturesAddon} from 'xterm-addon-ligatures';
-import {clipboard} from 'electron';
+import {clipboard, shell} from 'electron';
 import Color from 'color';
 import terms from '../terms';
 import processClipboard from '../utils/paste';
@@ -151,7 +151,11 @@ export default class Term extends React.PureComponent<TermProps> {
       this.term.attachCustomKeyEventHandler(this.keyboardHandler);
       this.term.loadAddon(this.fitAddon);
       this.term.loadAddon(this.searchAddon);
-      this.term.loadAddon(new WebLinksAddon());
+      this.term.loadAddon(
+        new WebLinksAddon((event, uri) => {
+          shell.openExternal(uri);
+        })
+      );
       this.term.open(this.termRef);
       if (useWebGL) {
         this.term.loadAddon(new WebglAddon());


### PR DESCRIPTION
Since updating to xterm-web-links-addon 0.3.0 clicking on links in terminal is causing a new electron window to open instead of opening them in browser
I opened https://github.com/xtermjs/xterm.js/issues/2875 about this but it seems like it's more strange that it was working earlier as `window.open` should open new electron window (tested in https://github.com/electron/electron-quick-start) but it was opening the browser for us.
So, added a link handler to the web-links addon constructor to instead use electron.shell.openExternal