### PR TITLE
Add web-link activation modifier

### DIFF
--- a/app/config/config-default.js
+++ b/app/config/config-default.js
@@ -154,6 +154,10 @@ module.exports = {
     // rendering (slower, but supports transparent backgrounds)
     webGLRenderer: true,
 
+    // keypress required for weblink activation: [ctrl|alt|meta|shift]
+    // todo: does not pick up config changes automatically, need to restart terminal :/
+    webLinksActivationKey: '',
+
     // if `true` (without backticks and without quotes), Hyper will ignore ligatures provided by some fonts
     disableLigatures: false,
 

--- a/lib/components/term-group.tsx
+++ b/lib/components/term-group.tsx
@@ -102,6 +102,7 @@ class TermGroup_ extends React.PureComponent<TermGroupProps> {
       selectionColor: this.props.selectionColor,
       quickEdit: this.props.quickEdit,
       webGLRenderer: this.props.webGLRenderer,
+      webLinksActivationKey: this.props.webLinksActivationKey,
       macOptionSelectionMode: this.props.macOptionSelectionMode,
       disableLigatures: this.props.disableLigatures,
       uid

--- a/lib/components/term.tsx
+++ b/lib/components/term.tsx
@@ -148,13 +148,27 @@ export default class Term extends React.PureComponent<TermProps> {
       }
       Term.reportRenderer(props.uid, useWebGL ? 'WebGL' : 'Canvas');
 
+      const shallActivateWebLink = (event: Record<string, any> | undefined) => {
+        return event && (!props.webLinksActivationKey || event[`${props.webLinksActivationKey}Key`]);
+      };
+
       this.term.attachCustomKeyEventHandler(this.keyboardHandler);
       this.term.loadAddon(this.fitAddon);
       this.term.loadAddon(this.searchAddon);
       this.term.loadAddon(
-        new WebLinksAddon((event, uri) => {
-          shell.openExternal(uri);
-        })
+        new WebLinksAddon(
+          (event: MouseEvent | undefined, uri: string) => {
+            if (shallActivateWebLink(event)) shell.openExternal(uri);
+          },
+          {
+            // prevent default electron link handling to allow selection, e.g. via double-click
+            willLinkActivate: (event: MouseEvent | undefined) => {
+              event?.preventDefault();
+              return shallActivateWebLink(event);
+            },
+            priority: Date.now()
+          }
+        )
       );
       this.term.open(this.termRef);
       if (useWebGL) {

--- a/lib/components/terms.tsx
+++ b/lib/components/terms.tsx
@@ -113,6 +113,7 @@ export default class Terms extends React.Component<TermsProps> {
             onContextMenu: this.props.onContextMenu,
             quickEdit: this.props.quickEdit,
             webGLRenderer: this.props.webGLRenderer,
+            webLinksActivationKey: this.props.webLinksActivationKey,
             macOptionSelectionMode: this.props.macOptionSelectionMode,
             disableLigatures: this.props.disableLigatures,
             parentProps: this.props

--- a/lib/config.d.ts
+++ b/lib/config.d.ts
@@ -59,6 +59,7 @@ export type configOptions = {
   updateChannel: 'stable' | 'canary';
   useConpty: boolean;
   webGLRenderer: boolean;
+  webLinksActivationKey: 'ctrl' | 'alt' | 'meta' | 'shift';
   windowSize: [number, number];
 };
 

--- a/lib/containers/terms.ts
+++ b/lib/containers/terms.ts
@@ -43,6 +43,7 @@ const mapStateToProps = (state: HyperState) => {
     modifierKeys: state.ui.modifierKeys,
     quickEdit: state.ui.quickEdit,
     webGLRenderer: state.ui.webGLRenderer,
+    webLinksActivationKey: state.ui.webLinksActivationKey,
     macOptionSelectionMode: state.ui.macOptionSelectionMode,
     disableLigatures: state.ui.disableLigatures
   };

--- a/lib/hyper.d.ts
+++ b/lib/hyper.d.ts
@@ -105,6 +105,7 @@ export type uiState = {
   updateReleaseUrl: string | null;
   updateVersion: string | null;
   webGLRenderer: boolean;
+  webLinksActivationKey: string;
 };
 
 export type session = {
@@ -308,6 +309,7 @@ export type TermGroupOwnProps = {
   | 'toggleSearch'
   | 'uiFontFamily'
   | 'webGLRenderer'
+  | 'webLinksActivationKey'
 >;
 
 import {TermGroupConnectedProps} from './components/term-group';
@@ -368,6 +370,7 @@ export type TermProps = {
   uiFontFamily: string;
   url: string | null;
   webGLRenderer: boolean;
+  webLinksActivationKey: string;
 } & extensionProps & {ref_?: any};
 
 export type Assignable<T, U> = {[k in keyof U]: k extends keyof T ? T[k] : U[k]} & Partial<T>;

--- a/lib/reducers/ui.ts
+++ b/lib/reducers/ui.ts
@@ -108,6 +108,7 @@ const initial: ImmutableType<uiState> = Immutable({
   showWindowControls: '',
   quickEdit: false,
   webGLRenderer: true,
+  webLinksActivationKey: '',
   macOptionSelectionMode: 'vertical',
   disableLigatures: false
 });
@@ -254,6 +255,10 @@ const reducer = (state = initial, action: HyperActions) => {
 
             if (config.webGLRenderer !== undefined) {
               ret.webGLRenderer = config.webGLRenderer;
+            }
+
+            if (config.webLinksActivationKey !== undefined) {
+              ret.webLinksActivationKey = config.webLinksActivationKey;
             }
 
             if (config.macOptionSelectionMode) {


### PR DESCRIPTION
Resolves zeit/hyper#3426, resolves zeit/hyper#4193

What is this PR going to fix:
- Hyper eagerly opens any link we click on, often unintentionally, which can be very distracting.
- It is currently harder than it should be to select a web link (because Hyper opens it in the browser instead of triggering selection).

How is it going to do it:
- add new entry to hyper config - webLinksActivationKey - to configure which key modifier needs to be pressed in order for a web-link to be activated on click. 4 values (alt, ctrl, meta, shift) are prefixes of corresponding properties of [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent) passed to web-links add-on click handler.
- override WebLinksAddon click handler to check if required modifier is pressed.
- additionally, provide ILinkMatcherOptions.willLinkActivate callback to fix a problem with link selection.

There's a couple things though:
- Adding new config entry in 9 different places seems awkward, maybe there's a better way?
- Hyper does not re-initialize xTerm instance on config reload. Because of that, if config entry is updated it is not picked up on the fly (requires restart).
- Some of the MouseEvent modifier keys may be used in different shortcut combinations e.g. Ctrl+Click'ing the link won't work, but I guess this may be left at user discretion. Shift and Cmd (meta) works on Mac :)