### PR TITLE
use `alt+f` as the default keymap for hamburger menu

### DIFF
--- a/app/keymaps/linux.json
+++ b/app/keymaps/linux.json
@@ -3,7 +3,7 @@
   "window:reload": "ctrl+shift+r",
   "window:reloadFull": "ctrl+shift+f5",
   "window:preferences": "ctrl+,",
-  "window:hamburgerMenu": "alt",
+  "window:hamburgerMenu": "alt+f",
   "zoom:reset": "ctrl+0",
   "zoom:in": "ctrl+=",
   "zoom:out": "ctrl+-",

--- a/app/keymaps/win32.json
+++ b/app/keymaps/win32.json
@@ -3,7 +3,7 @@
   "window:reload": "ctrl+shift+r",
   "window:reloadFull": "ctrl+shift+f5",
   "window:preferences": "ctrl+,",
-  "window:hamburgerMenu": "alt",
+  "window:hamburgerMenu": "alt+f",
   "zoom:reset": "ctrl+0",
   "zoom:in": "ctrl+=",
   "zoom:out": "ctrl+-",


### PR DESCRIPTION
Fixes #5801 
Fixes #5969 
Fixes #6004 