### PR TITLE
Better notification dismiss button visibility

### DIFF
--- a/lib/components/notification.tsx
+++ b/lib/components/notification.tsx
@@ -99,14 +99,14 @@ export default class Notification extends React.PureComponent<NotificationProps,
             position: relative;
             left: 4px;
             cursor: pointer;
-            opacity: 0.5;
+            font-weight: 600;
             color: currentColor;
-            transition: opacity 0.1s ease-in-out;
+            transition: font-weight 0.1s ease-in-out;
           }
 
           .notification_dismissLink:hover,
           .notification_dismissLink:focus {
-            opacity: 1;
+            font-weight: 900;
           }
         `}</style>
       </div>

--- a/lib/components/notifications.tsx
+++ b/lib/components/notifications.tsx
@@ -38,10 +38,10 @@ export default class Notifications extends React.PureComponent<NotificationsProp
           <Notification
             key="message"
             backgroundColor="#FE354E"
+            color="#fff"
             text={this.props.messageText}
             onDismiss={this.props.onDismissMessage}
             userDismissable={this.props.messageDismissable}
-            userDismissColor="#AA2D3C"
           >
             {this.props.messageURL
               ? [
@@ -58,7 +58,7 @@ export default class Notifications extends React.PureComponent<NotificationsProp
                   >
                     more
                   </a>,
-                  ')'
+                  ') '
                 ]
               : null}
           </Notification>


### PR DESCRIPTION
The close button on notifications seems to be a bit hard to see
e.g. see comments in #6023 

current
<img width="457" alt="Screenshot 2021-10-13 at 23 20 15" src="https://user-images.githubusercontent.com/16598275/137187919-f120b042-2f38-4031-afdf-dbdb00886238.png">

updated
<img width="486" alt="Screenshot 2021-10-13 at 23 21 50" src="https://user-images.githubusercontent.com/16598275/137187956-0562db60-61f7-482a-8773-02644e70fde9.png">
