### PR TITLE
3 font options light, normal, medium linked to numerical font weights

### DIFF
--- a/app/config/import.ts
+++ b/app/config/import.ts
@@ -46,6 +46,15 @@ const _importConf = () => {
     notify("Couldn't parse config file. Using default config instead.");
     userCfg = JSON.parse(defaultCfgRaw);
   }
+  if (userCfg.config?.fontWeight == 'light') {
+    userCfg.config.fontWeight = 400;
+  }
+  if (userCfg.config?.fontWeight == 'normal') {
+    userCfg.config.fontWeight = 500;
+  }
+  if (userCfg.config?.fontWeight == 'medium') {
+    userCfg.config.fontWeight = 600;
+  }
 
   return {userCfg, defaultCfg: _defaultCfg};
 };

--- a/app/config/schema.json
+++ b/app/config/schema.json
@@ -14,8 +14,10 @@
                         "700",
                         "800",
                         "900",
-                        "bold",
-                        "normal"
+                        "light",
+                        "normal",
+                        "medium",
+                        "bold"
                     ],
                     "type": "string"
                 },

--- a/lib/reducers/ui.ts
+++ b/lib/reducers/ui.ts
@@ -2,6 +2,7 @@ import {release} from 'os';
 
 import Immutable from 'seamless-immutable';
 import type {Immutable as ImmutableType} from 'seamless-immutable';
+import type {FontWeight} from 'xterm';
 
 import {CONFIG_LOAD, CONFIG_RELOAD} from '../../typings/constants/config';
 import {NOTIFICATION_MESSAGE, NOTIFICATION_DISMISS} from '../../typings/constants/notifications';
@@ -155,11 +156,11 @@ const reducer: IUiReducer = (state = initial, action) => {
             }
 
             if (config.fontWeight) {
-              ret.fontWeight = config.fontWeight;
+              ret.fontWeight = config.fontWeight as FontWeight;
             }
 
             if (config.fontWeightBold) {
-              ret.fontWeightBold = config.fontWeightBold;
+              ret.fontWeightBold = config.fontWeightBold as FontWeight;
             }
 
             if (Number.isFinite(config.lineHeight)) {

--- a/typings/config.d.ts
+++ b/typings/config.d.ts
@@ -1,4 +1,20 @@
-import type {FontWeight} from 'xterm';
+// import type {FontWeight} from 'xterm';
+
+type FontWeight =
+  | number
+  | 'light'
+  | 'normal'
+  | 'medium'
+  | 'bold'
+  | '100'
+  | '200'
+  | '300'
+  | '400'
+  | '500'
+  | '600'
+  | '700'
+  | '800'
+  | '900';
 
 export type ColorMap = {
   black: string;


### PR DESCRIPTION
Potential fix for issue #7952 
Add options to hyper.json for 'medium': fontWeight 600 and 'light': FontWeight 500, changing 'normal' to be font 500 instead of 100