### PR TITLE
add new profile popup

### DIFF
--- a/app/config/config-default.json
+++ b/app/config/config-default.json
@@ -22,6 +22,7 @@
     "workingDirectory": "",
     "showHamburgerMenu": "",
     "showWindowControls": "",
+    "showPopupOnNewTab": "",
     "padding": "12px 14px",
     "colors": {
       "black": "#000000",

--- a/app/config/schema.json
+++ b/app/config/schema.json
@@ -261,6 +261,14 @@
                         true
                     ]
                 },
+                "showPopupOnTab": {
+                    "description": "set to `true` if you want to show a popup of your profile when creating a new tab\n\ndefault: `false`",
+                    "enum": [
+                        "",
+                        false,
+                        true
+                    ]
+                },
                 "showWindowControls": {
                     "description": "set to `false` if you want to hide the minimize, maximize and close buttons\n\nadditionally, set to `'left'` if you want them on the left, like in Ubuntu\n\ndefault: `true` on Windows and Linux, ignored on macOS",
                     "enum": [

--- a/app/keymaps/darwin.json
+++ b/app/keymaps/darwin.json
@@ -41,6 +41,8 @@
   "editor:selectAll": "command+a",
   "editor:search": "command+f",
   "editor:search-close": "esc",
+  "editor:profilePopup": "command+a",
+  "editor:profilePopup-close": "esc",
   "editor:movePreviousWord": "alt+left",
   "editor:moveNextWord": "alt+right",
   "editor:moveBeginningLine": "command+left",

--- a/app/keymaps/linux.json
+++ b/app/keymaps/linux.json
@@ -39,6 +39,8 @@
   "editor:selectAll": "ctrl+shift+a",
   "editor:search": "ctrl+shift+f",
   "editor:search-close": "esc",
+  "editor:profilePopup": "ctrl+shift+t",
+  "editor:profilePopup-close": "esc",
   "editor:movePreviousWord": "ctrl+left",
   "editor:moveNextWord": "ctrl+right",
   "editor:moveBeginningLine": "home",

--- a/app/keymaps/win32.json
+++ b/app/keymaps/win32.json
@@ -36,6 +36,8 @@
   "editor:selectAll": "ctrl+shift+a",
   "editor:search": "ctrl+shift+f",
   "editor:search-close": "esc",
+  "editor:profilePopup": "ctrl+shift+t",
+  "editor:profilePopup-close": "esc",
   "editor:movePreviousWord": "",
   "editor:moveNextWord": "",
   "editor:moveBeginningLine": "Home",

--- a/app/ui/window.ts
+++ b/app/ui/window.ts
@@ -270,9 +270,9 @@ export function newWindow(
   rpc.on('close', () => {
     window.close();
   });
-  rpc.on('command', (command) => {
+  rpc.on('command', ({command, event}) => {
     const focusedWindow = BrowserWindow.getFocusedWindow();
-    execCommand(command, focusedWindow!);
+    execCommand(command, focusedWindow!, event);
   });
   // pass on the full screen events from the window to react
   rpc.win.on('enter-full-screen', () => {

--- a/lib/actions/sessions.ts
+++ b/lib/actions/sessions.ts
@@ -11,7 +11,8 @@ import {
   SESSION_CLEAR_ACTIVE,
   SESSION_USER_DATA,
   SESSION_SET_XTERM_TITLE,
-  SESSION_SEARCH
+  SESSION_SEARCH,
+  SESSION_PROFILE_POPUP
 } from '../../typings/constants/sessions';
 import type {HyperState, HyperDispatch, HyperActions} from '../../typings/hyper';
 import rpc from '../rpc';
@@ -152,6 +153,34 @@ export function closeSearch(uid?: string, keyEvent?: any) {
     if (getState().sessions.sessions[targetUid]?.search) {
       dispatch({
         type: SESSION_SEARCH,
+        uid: targetUid,
+        value: false
+      });
+    } else {
+      if (keyEvent) {
+        keyEvent.catched = false;
+      }
+    }
+  };
+}
+
+export function openProfilePopup(uid?: string) {
+  return (dispatch: HyperDispatch, getState: () => HyperState) => {
+    const targetUid = uid || getState().sessions.activeUid!;
+    dispatch({
+      type: SESSION_PROFILE_POPUP,
+      value: true,
+      uid: targetUid
+    });
+  };
+}
+
+export function closeProfilePopup(uid?: string, keyEvent?: any) {
+  return (dispatch: HyperDispatch, getState: () => HyperState) => {
+    const targetUid = uid || getState().sessions.activeUid!;
+    if (getState().sessions.sessions[targetUid]?.profilePopup) {
+      dispatch({
+        type: SESSION_PROFILE_POPUP,
         uid: targetUid,
         value: false
       });

--- a/lib/actions/ui.ts
+++ b/lib/actions/ui.ts
@@ -327,7 +327,7 @@ export function execCommand(command: string, fn: (e: any, dispatch: HyperDispatc
         if (fn) {
           fn(e, dispatch);
         } else {
-          rpc.emit('command', command);
+          rpc.emit('command', {command, event: e.type});
         }
       }
     });

--- a/lib/components/profile-popup.tsx
+++ b/lib/components/profile-popup.tsx
@@ -1,0 +1,111 @@
+import React, {forwardRef, useEffect, useRef} from 'react';
+import type {KeyboardEvent} from 'react';
+
+import type {ProfilePopupConnectedProps} from '../containers/profile-popup';
+
+const ProfilePopup = forwardRef<HTMLDivElement, ProfilePopupConnectedProps>((props, ref) => {
+  const {backgroundColor, foregroundColor, borderColor, profiles, openNewTab, close} = props;
+  const listItemsRef = useRef<(HTMLLIElement | null)[]>([]);
+
+  useEffect(() => {
+    listItemsRef.current[0]?.focus();
+  }, [listItemsRef.current]);
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    const currentIndex = listItemsRef.current.findIndex((item) => item === document.activeElement);
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      const nextIndex = (currentIndex + 1) % profiles.length;
+      listItemsRef.current[nextIndex]?.focus();
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      const prevIndex = (currentIndex - 1 + profiles.length) % profiles.length;
+      listItemsRef.current[prevIndex]?.focus();
+    } else if (e.key === 'Tab') {
+      e.preventDefault();
+      const nextIndex = (currentIndex + 1) % profiles.length;
+      listItemsRef.current[nextIndex]?.focus();
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      listItemsRef.current[currentIndex]?.click();
+    }
+  };
+
+  const handleOpen = (profile: string) => {
+    openNewTab(profile);
+    close();
+  };
+  return (
+    <div className="profile_popup" ref={ref}>
+      <div className="profile_popup_overlay" onClick={close}></div>
+      <div className="profile_popup_list_container" onKeyDown={handleKeyDown}>
+        <ul className="profile_popup_list">
+          {profiles.map((profile, index) => (
+            <li
+              tabIndex={0}
+              key={profile.name}
+              className="profile_list_item"
+              onMouseOver={() => listItemsRef.current[index]?.focus()}
+              ref={(el) => (listItemsRef.current[index] = el)}
+              onClick={() => handleOpen(profile.name)}
+            >
+              {profile.name}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <style jsx>{`
+        .profile_popup {
+          position: absolute;
+          inset: 0;
+          z-index: 1000;
+
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          padding-bottom: 2%;
+        }
+        .profile_popup_overlay {
+          position: absolute;
+          inset: 0;
+          background-color: rgba(0, 0, 0, 0.5);
+        }
+        .profile_popup_list_container {
+          background-color: ${backgroundColor};
+          border: 1px solid ${borderColor};
+          color: ${foregroundColor};
+          padding: 10px;
+          z-index: 10;
+          min-width: 180px;
+        }
+        .profile_popup_list {
+          list-style-type: none;
+        }
+        .profile_list_item {
+          padding: 8px 10px;
+          font-size: 12px;
+          font-weight: 500;
+          cursor: pointer;
+          border-radius: 3px;
+          transition:
+            background-color 200ms ease,
+            box-shadow 200ms ease;
+        }
+        .profile_list_item:hover {
+          background-color: ${borderColor};
+        }
+        .profile_list_item:focus {
+          outline: none;
+          background-color: ${borderColor};
+          box-shadow: 0 0 0 3px rgba(0, 150, 136, 0.5);
+        }
+      `}</style>
+    </div>
+  );
+});
+
+ProfilePopup.displayName = 'ProfilePopup';
+
+export default ProfilePopup;

--- a/lib/components/term-group.tsx
+++ b/lib/components/term-group.tsx
@@ -87,6 +87,7 @@ class TermGroup_ extends React.PureComponent<TermGroupProps> {
       padding: this.props.padding,
       cleared: session.cleared,
       search: session.search,
+      profilePopup: session.profilePopup,
       cols: session.cols,
       rows: session.rows,
       copyOnSelect: this.props.copyOnSelect,

--- a/lib/components/term.tsx
+++ b/lib/components/term.tsx
@@ -17,6 +17,7 @@ import {WebLinksAddon} from 'xterm-addon-web-links';
 import {WebglAddon} from 'xterm-addon-webgl';
 
 import type {TermProps} from '../../typings/hyper';
+import {ProfilePopupContainer} from '../containers/profile-popup';
 import terms from '../terms';
 import processClipboard from '../utils/paste';
 import {decorate} from '../utils/plugins';
@@ -550,6 +551,7 @@ export default class Term extends React.PureComponent<
             font={this.props.uiFontFamily}
           />
         ) : null}
+        {this.props.profilePopup ? <ProfilePopupContainer /> : null}
 
         <style jsx global>{`
           .term_fit {

--- a/lib/components/terms.tsx
+++ b/lib/components/terms.tsx
@@ -114,6 +114,7 @@ export default class Terms extends React.Component<React.PropsWithChildren<Terms
             onData: this.props.onData,
             onOpenSearch: this.props.onOpenSearch,
             onCloseSearch: this.props.onCloseSearch,
+            closeProfilePopup: this.props.closeProfilePopup,
             onContextMenu: this.props.onContextMenu,
             quickEdit: this.props.quickEdit,
             webGLRenderer: this.props.webGLRenderer,

--- a/lib/containers/hyper.tsx
+++ b/lib/containers/hyper.tsx
@@ -58,11 +58,20 @@ const Hyper = forwardRef<HTMLDivElement, HyperProps>((props, ref) => {
       mousetrap.current?.bind(
         commandKeys,
         (e) => {
-          const command = keys[commandKeys];
-          // We should tell xterm to ignore this event.
-          (e as any).catched = true;
-          props.execCommand(command, getCommandHandler(command), e);
-          shouldPreventDefault(command) && e.preventDefault();
+          const commandList = keys[commandKeys];
+          if (Array.isArray(commandList)) {
+            commandList.forEach((command) => {
+              // We should tell xterm to ignore this event.
+              (e as any).catched = true;
+              props.execCommand(command, getCommandHandler(command), e);
+              shouldPreventDefault(command) && e.preventDefault();
+            });
+          } else {
+            // We should tell xterm to ignore this event.
+            (e as any).catched = true;
+            props.execCommand(commandList, getCommandHandler(commandList), e);
+            shouldPreventDefault(commandList) && e.preventDefault();
+          }
         },
         'keydown'
       );

--- a/lib/containers/profile-popup.ts
+++ b/lib/containers/profile-popup.ts
@@ -1,0 +1,31 @@
+import type {HyperState, HyperDispatch} from '../../typings/hyper';
+import {closeProfilePopup} from '../actions/sessions';
+import {requestTermGroup} from '../actions/term-groups';
+import ProfilePopup from '../components/profile-popup';
+import {connect} from '../utils/plugins';
+
+const mapStateToProps = (state: HyperState) => {
+  return {
+    borderColor: state.ui.borderColor,
+    backgroundColor: state.ui.backgroundColor,
+    foregroundColor: state.ui.foregroundColor,
+    defaultProfile: state.ui.defaultProfile,
+    profiles: state.ui.profiles
+  };
+};
+
+const mapDispatchToProps = (dispatch: HyperDispatch) => {
+  return {
+    close: () => {
+      dispatch(closeProfilePopup());
+    },
+
+    openNewTab: (profile: string) => {
+      dispatch(requestTermGroup(undefined, profile));
+    }
+  };
+};
+
+export const ProfilePopupContainer = connect(mapStateToProps, mapDispatchToProps, null)(ProfilePopup, 'ProfilePopup');
+
+export type ProfilePopupConnectedProps = ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDispatchToProps>;

--- a/lib/containers/terms.ts
+++ b/lib/containers/terms.ts
@@ -5,7 +5,8 @@ import {
   setSessionXtermTitle,
   setActiveSession,
   openSearch,
-  closeSearch
+  closeSearch,
+  closeProfilePopup
 } from '../actions/sessions';
 import {openContextMenu} from '../actions/ui';
 import Terms from '../components/terms';
@@ -82,6 +83,10 @@ const mapDispatchToProps = (dispatch: HyperDispatch) => {
 
     onCloseSearch(uid: string) {
       dispatch(closeSearch(uid));
+    },
+
+    closeProfilePopup(uid: string) {
+      dispatch(closeProfilePopup(uid));
     },
 
     onContextMenu(uid: string, selection: string) {

--- a/lib/index.tsx
+++ b/lib/index.tsx
@@ -157,6 +157,14 @@ rpc.on('session search close', () => {
   store_.dispatch(sessionActions.closeSearch());
 });
 
+rpc.on('session profilePopup', () => {
+  store_.dispatch(sessionActions.openProfilePopup());
+});
+
+rpc.on('session profilePopup close', () => {
+  store_.dispatch(sessionActions.closeProfilePopup());
+});
+
 rpc.on('termgroup add req', ({activeUid, profile}) => {
   store_.dispatch(termGroupActions.requestTermGroup(activeUid, profile));
 });

--- a/lib/reducers/sessions.ts
+++ b/lib/reducers/sessions.ts
@@ -10,7 +10,8 @@ import {
   SESSION_RESIZE,
   SESSION_SET_XTERM_TITLE,
   SESSION_SET_CWD,
-  SESSION_SEARCH
+  SESSION_SEARCH,
+  SESSION_PROFILE_POPUP
 } from '../../typings/constants/sessions';
 import type {sessionState, session, Mutable, ISessionReducer} from '../../typings/hyper';
 import {decorateSessionsReducer} from '../utils/plugins';
@@ -28,6 +29,7 @@ function Session(obj: Immutable.DeepPartial<session>) {
     rows: null,
     cleared: false,
     search: false,
+    profilePopup: false,
     shell: '',
     pid: null,
     profile: ''
@@ -63,6 +65,9 @@ const reducer: ISessionReducer = (state = initialState, action) => {
 
     case SESSION_SEARCH:
       return state.setIn(['sessions', action.uid, 'search'], action.value);
+
+    case SESSION_PROFILE_POPUP:
+      return state.setIn(['sessions', action.uid, 'profilePopup'], action.value);
 
     case SESSION_CLEAR_ACTIVE:
       return state.merge(

--- a/lib/reducers/ui.ts
+++ b/lib/reducers/ui.ts
@@ -110,6 +110,7 @@ const initial: uiState = Immutable<Mutable<uiState>>({
   },
   showHamburgerMenu: '',
   showWindowControls: '',
+  showPopupOnNewTab: '',
   quickEdit: false,
   webGLRenderer: true,
   webLinksActivationKey: '',

--- a/lib/utils/plugins.ts
+++ b/lib/utils/plugins.ts
@@ -48,6 +48,7 @@ let connectors: {
   Header: {state: any[]; dispatch: any[]};
   Hyper: {state: any[]; dispatch: any[]};
   Notifications: {state: any[]; dispatch: any[]};
+  ProfilePopup: {state: any[]; dispatch: any[]};
 };
 let middlewares: Middleware[];
 let uiReducers: IUiReducer[];
@@ -242,7 +243,8 @@ const loadModules = () => {
     Terms: {state: [], dispatch: []},
     Header: {state: [], dispatch: []},
     Hyper: {state: [], dispatch: []},
-    Notifications: {state: [], dispatch: []}
+    Notifications: {state: [], dispatch: []},
+    ProfilePopup: {state: [], dispatch: []}
   };
   uiReducers = [];
   middlewares = [];

--- a/typings/common.d.ts
+++ b/typings/common.d.ts
@@ -31,7 +31,7 @@ export type sessionExtraOptions = {
 
 export type MainEvents = {
   close: never;
-  command: string;
+  command: {command: string; event?: string | undefined};
   data: {uid: string | null; data: string; escaped?: boolean};
   exit: {uid: string};
   'info renderer': {uid: string; type: string};
@@ -65,6 +65,8 @@ export type RendererEvents = {
   'session quit req': never;
   'session search close': never;
   'session search': never;
+  'session profilePopup': never;
+  'session profilePopup close': never;
   'session stop req': never;
   'session tmux req': never;
   'session del line beginning req': never;

--- a/typings/config.d.ts
+++ b/typings/config.d.ts
@@ -165,6 +165,12 @@ type profileConfigOptions = {
    */
   showHamburgerMenu: boolean | '';
   /**
+   * set to `true` if you want to show a popup of your profiles when creating a new tab
+   *
+   * default: `false`
+   */
+  showPopupOnNewTab: boolean | '';
+  /**
    * set to `false` if you want to hide the minimize, maximize and close buttons
    *
    * additionally, set to `'left'` if you want them on the left, like in Ubuntu

--- a/typings/constants/sessions.d.ts
+++ b/typings/constants/sessions.d.ts
@@ -11,6 +11,7 @@ export const SESSION_USER_DATA = 'SESSION_USER_DATA';
 export const SESSION_SET_XTERM_TITLE = 'SESSION_SET_XTERM_TITLE';
 export const SESSION_SET_CWD = 'SESSION_SET_CWD';
 export const SESSION_SEARCH = 'SESSION_SEARCH';
+export const SESSION_PROFILE_POPUP = 'SESSION_PROFILE_POPUP';
 
 export interface SessionAddAction {
   type: typeof SESSION_ADD;
@@ -59,6 +60,11 @@ export interface SessionSetActiveAction {
 export interface SessionClearActiveAction {
   type: typeof SESSION_CLEAR_ACTIVE;
 }
+export interface SessionTabPopupAction {
+  type: typeof SESSION_PROFILE_POPUP;
+  uid: string;
+  value: boolean;
+}
 export interface SessionUserDataAction {
   type: typeof SESSION_USER_DATA;
 }
@@ -90,4 +96,5 @@ export type SessionActions =
   | SessionUserDataAction
   | SessionSetXtermTitleAction
   | SessionSetCwdAction
-  | SessionSearchAction;
+  | SessionSearchAction
+  | SessionTabPopupAction;

--- a/typings/hyper.d.ts
+++ b/typings/hyper.d.ts
@@ -99,6 +99,7 @@ export type uiState = Immutable<{
   selectionColor: string;
   showHamburgerMenu: boolean | '';
   showWindowControls: boolean | 'left' | '';
+  showPopupOnNewTab: boolean | '';
   termCSS: string;
   uiFontFamily: string;
   updateCanInstall: null | boolean;
@@ -119,6 +120,7 @@ export type session = {
   resizeAt?: number;
   rows: number | null;
   search: boolean;
+  profilePopup: boolean;
   shell: string | null;
   title: string;
   uid: string;
@@ -304,6 +306,7 @@ export type TermGroupOwnProps = {
   | 'onActive'
   | 'onContextMenu'
   | 'onCloseSearch'
+  | 'closeProfilePopup'
   | 'onData'
   | 'onOpenSearch'
   | 'onResize'
@@ -386,6 +389,7 @@ export type TermProps = {
   screenReaderMode: boolean;
   scrollback: number;
   search: boolean;
+  profilePopup: boolean;
   searchAddon: SearchAddon | null;
   selectionColor: string;
   term: Terminal | null;


### PR DESCRIPTION
<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`
- If your PR changes some API, please make a PR for hyper website too: https://github.com/vercel/hyper-site.

Thanks, again! -->

Adds support for choosing profiles when creating a new tab.
Right now, it overrides the default keymap (ctrl+shift+t). which I think can be changed to (alt+shit+t)

![Screenshot 2024-08-13 222311](https://github.com/user-attachments/assets/dd5224be-c4ad-4bec-bc1f-25136ce162bf)

