### PR TITLE
dev(ci): fix macos-latest CI by using brew install python- instead of pip install

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -19,7 +19,7 @@ jobs:
         os:
           - macos-latest
           - ubuntu-latest
-          - windows-latest
+          - windows-2019
       fail-fast: false
     steps:
       - name: Checkout

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -32,6 +32,7 @@ jobs:
         run: |
           if [[ "$RUNNER_OS" == "macOS" ]]; then
             EXTRA_ARGS="--break-system-packages"
+            brew install python-setuptools python-packaging
           else
             EXTRA_ARGS=""
           fi

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ defaults:
   run:
     shell: bash
 env:
-  NODE_VERSION: 18.x
+  NODE_VERSION: 20.x
 jobs:
   build:
     runs-on: ${{matrix.os}}
@@ -28,7 +28,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Fix node-gyp and Python
-        run: python3 -m pip install packaging setuptools
+        run: pip install --break-system-packages packaging setuptools
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -29,7 +29,13 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Fix node-gyp and Python
-        run: pip install --break-system-packages packaging setuptools
+        run: |
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
+            EXTRA_ARGS="--break-system-packages"
+          else
+            EXTRA_ARGS=""
+          fi
+          python3 -m pip install $EXTRA_ARGS packaging setuptools
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -31,12 +31,10 @@ jobs:
       - name: Fix node-gyp and Python
         run: |
           if [[ "$RUNNER_OS" == "macOS" ]]; then
-            EXTRA_ARGS="--break-system-packages"
             brew install python-setuptools python-packaging
           else
-            EXTRA_ARGS=""
+            python3 -m pip install $EXTRA_ARGS packaging setuptools
           fi
-          python3 -m pip install $EXTRA_ARGS packaging setuptools
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -10,7 +10,7 @@ defaults:
   run:
     shell: bash
 env:
-  NODE_VERSION: 20.x
+  NODE_VERSION: 18.x
 jobs:
   build:
     runs-on: ${{matrix.os}}
@@ -19,7 +19,7 @@ jobs:
         os:
           - macos-latest
           - ubuntu-latest
-          - windows-2019
+          - windows-latest
       fail-fast: false
     steps:
       - name: Checkout

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -5,6 +5,7 @@ on:
       - master
       - canary
   pull_request:
+  workflow_dispatch:
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
Partially resolves #8025

Also add `workflow_dispatch` trigger for CI to allow testing on fork without having to modify main branch on fork.