### PR TITLE
feat: add tab:close keyboard shortcut

### DIFF
--- a/app/commands.ts
+++ b/app/commands.ts
@@ -27,6 +27,9 @@ const commands: Record<string, (focusedWindow?: BrowserWindow) => void> = {
   'pane:close': (focusedWindow) => {
     focusedWindow?.rpc.emit('termgroup close req');
   },
+  'tab:close': (focusedWindow) => {
+    focusedWindow?.rpc.emit('tab close req');
+  },
   'window:preferences': () => {
     void openConfig();
   },

--- a/app/keymaps/darwin.json
+++ b/app/keymaps/darwin.json
@@ -27,6 +27,7 @@
     "command+alt+left",
     "ctrl+shift+tab"
   ],
+  "tab:close": "command+w",
   "tab:jump:prefix": "command",
   "pane:next": "command+]",
   "pane:prev": "command+[",

--- a/app/keymaps/linux.json
+++ b/app/keymaps/linux.json
@@ -25,6 +25,7 @@
     "ctrl+alt+left",
     "ctrl+shift+tab"
   ],
+  "tab:close": "ctrl+w",
   "tab:jump:prefix": "ctrl",
   "pane:next": "ctrl+pageup",
   "pane:prev": "ctrl+pagedown",

--- a/app/keymaps/win32.json
+++ b/app/keymaps/win32.json
@@ -22,6 +22,7 @@
   "tab:prev": [
     "ctrl+shift+tab"
   ],
+  "tab:close": "ctrl+w",
   "tab:jump:prefix": "ctrl",
   "pane:next": "ctrl+pageup",
   "pane:prev": "ctrl+pagedown",

--- a/lib/index.tsx
+++ b/lib/index.tsx
@@ -10,6 +10,7 @@ import type {configOptions} from '../typings/config';
 import {loadConfig, reloadConfig} from './actions/config';
 import init from './actions/index';
 import {addNotificationMessage} from './actions/notifications';
+import * as headerActions from './actions/header';
 import * as sessionActions from './actions/sessions';
 import * as termGroupActions from './actions/term-groups';
 import * as uiActions from './actions/ui';
@@ -95,6 +96,10 @@ rpc.on('session exit', ({uid}) => {
 
 rpc.on('termgroup close req', () => {
   store_.dispatch(termGroupActions.exitActiveTermGroup());
+});
+
+rpc.on('tab close req', () => {
+  store_.dispatch(headerActions.closeTab(store_.getState().sessions.activeUid));
 });
 
 rpc.on('session clear req', () => {


### PR DESCRIPTION
## Description

Add keyboard shortcut to close tabs with Ctrl+W (Linux/Windows) and Cmd+W (Mac).

Fixes #3548

## Changes

- **app/commands.ts**: Add 'tab:close' command that emits 'tab close req' RPC event
- **app/keymaps/darwin.json**: Add 'tab:close': 'command+w' for Mac
- **app/keymaps/linux.json**: Add 'tab:close': 'ctrl+w' for Linux  
- **app/keymaps/win32.json**: Add 'tab:close': 'ctrl+w' for Windows
- **lib/index.tsx**: Add RPC handler for 'tab close req' to dispatch closeTab action

## Usage

Users can now close tabs using:
- **Mac**: Cmd+W
- **Linux/Windows**: Ctrl+W

This matches the behavior of most browsers and terminal emulators.

## Testing

- [x] Added keybinding to all three platform keymaps
- [x] Command handler emits correct RPC event
- [x] RPC handler dispatches closeTab action with active session UID

## Related Issues

Closes #3548